### PR TITLE
Continue with other requirements

### DIFF
--- a/cyclonedx/cli/generateBom.py
+++ b/cyclonedx/cli/generateBom.py
@@ -61,7 +61,7 @@ def read_bom(fd):
         name = req.name
         if not req.specs:
             print("WARNING: " + name + " does not have a version specified. Skipping.")
-            break
+            continue
 
         if len(req.specs[0]) >= 2:
             version = req.specs[0][1]
@@ -145,4 +145,3 @@ def main():
         print("Complete")
     else:
         print("The generated BOM is not valid")
-


### PR DESCRIPTION
Currently the BOM generation breaks when a single requirement does not refer to a specific version. It would be better to continue with the other requirements.