### PR TITLE
Enforced UTF-8 encoding while writing bom.xml

### DIFF
--- a/cyclonedx/cli/generateBom.py
+++ b/cyclonedx/cli/generateBom.py
@@ -136,8 +136,8 @@ def main():
 
     # Generate the CycloneDX BOM and return it as an XML string
     bom_xml = BomGenerator.build_bom(component_elements)
-    with open(args.output_file, "w") as text_file:
-        text_file.write(bom_xml)
+    with open(args.output_file, "wb") as text_file:
+        text_file.write(bom_xml.encode("utf-8")
 
     print("Validating BOM")
     is_valid = BomValidator.is_valid(args.output_file)


### PR DESCRIPTION
This should prevent exceptions such as this one:
```

Traceback (most recent call last):
  File "c:\python\python_3.7.4_64bit\Lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\python\python_3.7.4_64bit\Lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Data\.virtualenvs\cycloneDX-fCyJ5Voc\Scripts\cyclonedx-py.exe\__main__.py", line 9, in <module>
  File "c:\Data\.virtualenvs\cyclonedx-fcyj5voc\lib\site-packages\cyclonedx\cli\generateBom.py", line 140, in main
    text_file.write(bom_xml)
  File "c:\Data\.virtualenvs\cyclonedx-fcyj5voc\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\u0103' in position 57206: character maps to <undefined>
```