### PR TITLE
Support requirements.txt with local files

### DIFF
--- a/cyclonedx/cli/generateBom.py
+++ b/cyclonedx/cli/generateBom.py
@@ -60,6 +60,10 @@ def read_bom(fd):
     component_elements = []
     for req in requirements.parse(fd):
         name = req.name
+        if req.local_file:
+            print("WARNING: Local file " + req.path + " does not have versions. Skipping.")
+            continue
+            
         if not req.specs:
             print("WARNING: " + name + " does not have a version specified. Skipping.")
             break


### PR DESCRIPTION
It's possible for the requirements.txt file to have local file listings.  These do not have 'name' values, and so cause a runtime error when trying to concatenate a NoneType with a string.  Test for 'local_file' requirements and skip them when generating bom.
See https://requirements-parser.readthedocs.io/en/latest/usage.html#parsing-requirement-specifiers