### PR TITLE
Configure dependabot through config-files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: daily
+- package-ecosystem: python
+  directory: "/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
Move to v2 config which uses a config-file.

Signed-off-by: David Karlsen <david@davidkarlsen.com>