### PR TITLE
Use release built package when building Docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         VERSION=`cat VERSION`
         echo "##[set-output name=version;]$VERSION"
         python setup.py sdist bdist_wheel
-        docker build -f Dockerfile -t $REPO:$VERSION -t $REPO:latest .
+        docker build -f Dockerfile --build-arg VERSION=$VERSION -t $REPO:$VERSION -t $REPO:latest .
     
     - name: Publish package
       env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
 FROM python:3.8.1-slim-buster
-RUN pip install cyclonedx-bom
+
+ARG VERSION
+
+COPY ./dist /tmp/dist
+RUN pip install cyclonedx-bom==${VERSION} --find-links file:///tmp/dist
 ENTRYPOINT ["cyclonedx-py"]


### PR DESCRIPTION
There was a race condition with how the Docker image was being built. It was installing it from PyPI without specifying a version. So if the package had been built and published, but hadn't been indexed yet the Docker image would have the previous version.

Changing the Dockerfile to copy in the locally built package instead.