### PR TITLE
Make component type generic

### DIFF
--- a/cyclonedx/bom/generator.py
+++ b/cyclonedx/bom/generator.py
@@ -65,15 +65,16 @@ def build_xml_bom(components):
             component.hashes,
             component.licenses,
             component.purl,
-            component.modified
+            component.modified,
+            component.component_type
         )
         xml_components.append(component_xml)
     xml_pretty_print(bom)
     return declaration + ElementTree.tostring(bom, "unicode")
 
 
-def build_xml_component_element(publisher, name, version, description, hashes, licenses, purl, modified):
-    component = ElementTree.Element("component", {"type": "library"})
+def build_xml_component_element(publisher, name, version, description, hashes, licenses, purl, modified, component_type):
+    component = ElementTree.Element("component", {"type": component_type})
 
     if publisher and publisher != "UNKNOWN":
         ElementTree.SubElement(component, "publisher").text = publisher

--- a/cyclonedx/bom/reader.py
+++ b/cyclonedx/bom/reader.py
@@ -53,6 +53,7 @@ def get_component(req, package_info_url=DEFAULT_PACKAGE_INFO_URL):
         name=req.name,
         version=req.specs[0][1],
         purl=generate_purl(req.name, req.specs[0][1]),
+        component_type='library'
     )
 
     if req.specs[0][0] != "==":

--- a/cyclonedx/models/component.py
+++ b/cyclonedx/models/component.py
@@ -24,7 +24,7 @@ class Component:
         licenses=None,
         purl=None,
         modified=False,
-        component_type='library'
+        component_type=None
     ):
         self.name = name
         self.version = version


### PR DESCRIPTION
This will help to make reusing of code easier. For example, someone can import this library in their Python script and use these functions to generate an SBoM where components could be of different types in their use case.