### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.5-alpine
+
+RUN pip install tox

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+    "name": "devcontainer",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "extensions": [
+        "ms-python.python",
+        "redhat.vscode-yaml"
+    ],
+    "postCreateCommand": "pip3 install --user -r requirements.txt"
+}


### PR DESCRIPTION
This is mainly to make switching between implementations for maintainers easier. But can also be handy for new contributors.