### PR TITLE
Updated valid-metadata-timestamp-1.2.json

### DIFF
--- a/tests/resources/valid-metadata-timestamp-1.2.json
+++ b/tests/resources/valid-metadata-timestamp-1.2.json
@@ -1,9 +1,9 @@
 {
-  "bomFormat": "CycloneDX",
-  "metadata": {
-    "timestamp": "2020-04-13T20:20:39+00:00"
-  },
-  "components": [],
-  "specVersion": "1.0",
-  "version": 1
+    "bomFormat": "CycloneDX",
+    "components": [],
+    "metadata": {
+      "timestamp": "2020-04-07T07:01:00Z"
+    },
+    "specVersion": "1.2",
+    "version": 1
 }


### PR DESCRIPTION
Included  4-spaces instead of 2-spaces, changed the "specVersion" to 1.2, corrected the value of timestamp and the ordering of metadata & components.