### PR TITLE
Issue# 205. Use HTTPS_PROXY if env is set

### DIFF
--- a/cyclonedx/bom/reader.py
+++ b/cyclonedx/bom/reader.py
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) Steve Springett. All Rights Reserved.
 
+import os
 import requests
 import requirements
 from collections import OrderedDict
@@ -27,6 +28,8 @@ from cyclonedx.models import *
 
 
 DEFAULT_PACKAGE_INFO_URL = "https://pypi.org/pypi/{package_name}/{package_version}/json"
+
+PROXY = os.environ.get('HTTPS_PROXY')
 
 def read_bom(fd, package_info_url=DEFAULT_PACKAGE_INFO_URL, json=False):
     """Read BOM data from file handle."""
@@ -103,7 +106,7 @@ def get_package_info(
     url = url.format(package_name=package_name, package_version=package_version)
 
     try:
-        request_data = requests.get(url)
+        request_data = requests.get(url, proxies={'https':PROXY} if PROXY else None)
         request_data.raise_for_status()
         package_info = request_data.json()
     except requests.RequestException:


### PR DESCRIPTION
Hi,

requests.get call is used by the reader module to connect to pypi.org so metadata can be collected. In environments where HTTP proxies are used, above call fails to connect to pypi.org. 

In this PR, requests.get call is modified to use `proxies` argument if `HTTPS_PROXY` environment variable is set.

`proxies={'https':<HTTPS_PROXY>}`

This PR addresses #205