### PR TITLE
fix: error message when `requirements.txt` file is non-existent updated

### DIFF
--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -137,7 +137,7 @@ class CycloneDxCmd:
                 # A requirements.txt path was provided
                 return RequirementsFileParser(requirements_file=requirements_file)
             else:
-                self._error_and_exit('The requirements.txt file path provided does not exist ({})'.format(
+                self._error_and_exit('The provided file \'{}\' does not exist'.format(
                     requirements_file
                 ))
         else:


### PR DESCRIPTION
Minor update to error message when supplied path to a `requirements.txt` file does not exist.

See #232.

Signed-off-by: Paul Horton <phorton@sonatype.com>