### PR TITLE
fix: handle `requirements.txt` which contain dependencies without a v…

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,26 @@ cyclonedx-py -r -rf PATH/TO/requirements.txt -o -
 
 This will generate a CycloneDX and output to STDOUT in XML using the latest schema version `1.3` by default.
 
+#### Unpinned dependencies in `requirements.txt`
+
+If you failed to freeze your dependencies before passing the `requirements.txt` data to `cyclonedx-py`, you'll be 
+warned about this and the dependencies that do not have pinned versions WILL NOT be included in the resulting CycloneDX
+output.
+
+```
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!! Some of your dependencies do not have pinned version !!
+!! numbers in your requirements.txt                     !!
+!!                                                      !!
+!! -> idna                                              !!
+!! -> requests                                          !!
+!! -> urllib3                                           !!
+!!                                                      !!
+!! The above will NOT be included in the generated      !!
+!! CycloneDX as version is a mandatory field.           !!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+```
+
 ## Python Support
 
 We endeavour to support all functionality for all [current actively supported Python versions](https://www.python.org/downloads/).

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -45,8 +45,24 @@ class CycloneDxCmd:
             self._debug_message('Parsed Arguments: {}'.format(self._arguments))
 
     def get_output(self) -> BaseOutput:
+        parser = self._get_input_parser()
+
+        if parser.has_warnings():
+            print('')
+            print('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
+            print('!! Some of your dependencies do not have pinned version !!')
+            print('!! numbers in your requirements.txt                     !!')
+            print('!!                                                      !!')
+            for warning in parser.get_warnings():
+                print('!! -> {} !!'.format(warning.get_item().ljust(49)))
+            print('!!                                                      !!')
+            print('!! The above will NOT be included in the generated      !!')
+            print('!! CycloneDX as version is a mandatory field.           !!')
+            print('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
+            print('')
+
         return get_instance(
-            bom=Bom.from_parser(self._get_input_parser()),
+            bom=Bom.from_parser(parser=parser),
             output_format=OutputFormat[str(self._arguments.output_format).upper()],
             schema_version=SchemaVersion['V{}'.format(
                 str(self._arguments.output_schema_version).replace('.', '_')

--- a/poetry.lock
+++ b/poetry.lock
@@ -34,7 +34,7 @@ toml = ["toml"]
 
 [[package]]
 name = "cyclonedx-python-lib"
-version = "0.4.0"
+version = "0.4.1"
 description = "A library for producing CycloneDX SBOM (Software Bill of Materials) files."
 category = "main"
 optional = false
@@ -285,7 +285,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "e1bdb6f793ad8d0709570c609e14d481ea85cb554709d67c78fa38a9f1baedfb"
+content-hash = "21cea0e086dd50cf3864bc6ecd88816aefaa4b12d1fdcef0eed79d66fe47be05"
 
 [metadata.files]
 "backports.entry-points-selectable" = [
@@ -351,8 +351,8 @@ coverage = [
     {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
 cyclonedx-python-lib = [
-    {file = "cyclonedx-python-lib-0.4.0.tar.gz", hash = "sha256:3402f5077c1768ded58a340727ed679d6f764654395414661b794a153d86791e"},
-    {file = "cyclonedx_python_lib-0.4.0-py3-none-any.whl", hash = "sha256:c2c5830adbad18865dfa91cc2611a2d596df047e58d9c26434cc69e70c025666"},
+    {file = "cyclonedx-python-lib-0.4.1.tar.gz", hash = "sha256:11ceb9ad1b23b26b8c22697c306b7c4d809ec6521069066b31e2f230483b1f8b"},
+    {file = "cyclonedx_python_lib-0.4.1-py3-none-any.whl", hash = "sha256:506d3fccd573982d934a91574083361cc3c450f62161c16c4c7ca53d93149983"},
 ]
 distlib = [
     {file = "distlib-0.3.2-py2.py3-none-any.whl", hash = "sha256:23e223426b28491b1ced97dc3bbe183027419dfc7982b4fa2f05d5f3ff10711c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-cyclonedx-python-lib = "^0.4.0"
+cyclonedx-python-lib = "0.4.1"
 
 [tool.poetry.dev-dependencies]
 tox = "^3.24.3"


### PR DESCRIPTION
In response to reported issue #235.

This PR bumps the `cyclonedx-python-lib` version to include better support for parsing `requirements.txt` content that does NOT include a version statement. Such dependency definitions cannot result in entries in a CycloneDX BOM as `version` is a required attribute according to the CycloneDX schema.

Further, `cyclonedx-py` will now issue a warning to STDOUT if you are using either running with the `-r` flag and the supplied `requirements.txt` contains dependencies without versions.

Example:
```
> cat requirements.txt
certifi==2021.5.30 # via requests
chardet>=4.0.0 # via requests
idna
requests
urllib3

> cyclonedx-py -r -o sbom.xml

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!! Some of your dependencies do not have pinned version !!
!! numbers in your requirements.txt                     !!
!!                                                      !!
!! -> idna                                              !!
!! -> requests                                          !!
!! -> urllib3                                           !!
!!                                                      !!
!! The above will NOT be included in the generated      !!
!! CycloneDX as version is a mandatory field.           !!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

Signed-off-by: Paul Horton <phorton@sonatype.com>