### PR TITLE
static code analysis & general fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,9 +91,14 @@ jobs:
       REPORTS_ARTIFACT: tests-reports
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version:
+          - "3.9" # highest supported
+          - "3.8"
+          - "3.7"
+          - "3.6" # lowest supported
     steps:
       - name: Checkout
         # see https://github.com/actions/checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Ensure build successful
         run: poetry build
       - name: Run tox
-        run: poetry run tox -e py${{ matrix.python-version }}
+        run: poetry run tox -e py -s false
       - name: Generate coverage reports
         run: >
           poetry run coverage report &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,33 @@ jobs:
       - name: Run tox
         run: poetry run tox -e flake8
 
+  static-code-analysis:
+    name: Static Coding Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        # see https://github.com/actions/checkout
+        uses: actions/checkout@v2
+      - name: Setup Python Environment
+        # see https://github.com/actions/setup-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+          architecture: 'x64'
+      - name: Install poetry
+        # see https://github.com/marketplace/actions/setup-poetry
+        uses: Gr1N/setup-poetry@v7
+        with:
+          poetry-version: 1.1.8
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
+      - name: Install dependencies
+        run: poetry install
+      - name: Run tox
+        run: poetry run tox -e mypy
+
   build-and-test:
     name: Tests for Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ dist/
 test-reports
 
 # Exclude Python Virtual Environment
-venv/*
+venv/
+.venv/
 
 # Exlude IDE related files
 .idea/*

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,34 @@
+[mypy]
+
+files = cyclonedx_py/
+
+show_error_codes = True
+pretty = True
+
+warn_unreachable = True
+allow_redefinition = False
+
+# ignore_missing_imports = False
+# follow_imports = normal
+# follow_imports_for_stubs = True
+
+### Strict mode ###
+warn_unused_configs         = True
+disallow_subclassing_any    = True
+disallow_any_generics       = True
+disallow_untyped_calls      = True
+disallow_untyped_defs       = True
+disallow_incomplete_defs    = True
+check_untyped_defs          = True
+disallow_untyped_decorators = True
+no_implicit_optional        = True
+warn_redundant_casts        = True
+warn_unused_ignores         = True
+warn_return_any             = True
+no_implicit_reexport        = True
+
+[mypy-pytest.*]
+ignore_missing_imports = True
+
+[mypy-tests.*]
+disallow_untyped_decorators = False

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -84,11 +84,11 @@ class CycloneDxCmd:
 
         # Add cyclonedx_bom as a Tool to record it being part of the CycloneDX SBOM generation process
         if sys.version_info >= (3, 8, 0):
-            from importlib.metadata import version
+            from importlib.metadata import version as md_version
         else:
-            from importlib_metadata import version
+            from importlib_metadata import version as md_version  # type: ignore
         bom.get_metadata().add_tool(tool=Tool(
-            vendor='CycloneDX', name='cyclonedx-bom', version=version('cyclonedx-bom')
+            vendor='CycloneDX', name='cyclonedx-bom', version=md_version('cyclonedx-bom')
         ))
 
         return get_instance(

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -48,7 +48,7 @@ class CycloneDxCmd:
     # Parsed Arguments
     _arguments: argparse.Namespace
 
-    def __init__(self, args: argparse.Namespace):
+    def __init__(self, args: argparse.Namespace) -> None:
         self._arguments = args
 
         if self._arguments.debug_enabled:
@@ -99,7 +99,7 @@ class CycloneDxCmd:
             )]
         )
 
-    def execute(self):
+    def execute(self) -> None:
         output = self.get_output()
         if self._arguments.output_file == '-' or not self._arguments.output_file:
             self._debug_message('Returning SBOM to STDOUT')
@@ -187,12 +187,12 @@ class CycloneDxCmd:
 
         return arg_parser
 
-    def _debug_message(self, message: str):
+    def _debug_message(self, message: str) -> None:
         if self._DEBUG_ENABLED:
             print('[DEBUG] - {} - {}'.format(datetime.now(), message))
 
     @staticmethod
-    def _error_and_exit(message: str, exit_code: int = 1):
+    def _error_and_exit(message: str, exit_code: int = 1) -> None:
         print('[ERROR] - {} - {}'.format(datetime.now(), message))
         exit(exit_code)
 
@@ -243,7 +243,7 @@ class CycloneDxCmd:
             raise CycloneDxCmdException('Parser type could not be determined.')
 
 
-def main():
+def main() -> None:
     parser = CycloneDxCmd.get_arg_parser()
     args = parser.parse_args()
     CycloneDxCmd(args).execute()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,18 @@
 [[package]]
+name = "attrs"
+version = "21.2.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
+
+[[package]]
 name = "backports.entry-points-selectable"
 version = "1.1.0"
 description = "Compatibility shim providing selectable entry points for older implementations"
@@ -34,7 +48,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "cyclonedx-python-lib"
-version = "0.10.2"
+version = "0.11.1"
 description = "A library for producing CycloneDX SBOM (Software Bill of Materials) files."
 category = "main"
 optional = false
@@ -45,6 +59,8 @@ importlib-metadata = {version = ">=4.8.1,<5.0.0", markers = "python_version >= \
 packageurl-python = ">=0.9.4,<0.10.0"
 requirements_parser = ">=0.2.0,<0.3.0"
 toml = ">=0.10.2,<0.11.0"
+types-setuptools = ">=57.4.2,<58.0.0"
+types-toml = ">=0.10.1,<0.11.0"
 typing-extensions = {version = ">=3.10.0,<4.0.0", markers = "python_version >= \"3.6\" and python_version < \"3.8\""}
 
 [[package]]
@@ -82,6 +98,33 @@ pycodestyle = ">=2.7.0,<2.8.0"
 pyflakes = ">=2.3.0,<2.4.0"
 
 [[package]]
+name = "flake8-annotations"
+version = "2.0.1"
+description = "Flake8 Type Annotation Checks"
+category = "dev"
+optional = false
+python-versions = ">=3.6,<4.0"
+
+[package.dependencies]
+flake8 = ">=3.7.9,<4.0.0"
+typed-ast = {version = ">=1.4,<2.0", markers = "python_version < \"3.8\""}
+
+[[package]]
+name = "flake8-bugbear"
+version = "21.9.2"
+description = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+attrs = ">=19.2.0"
+flake8 = ">=3.0.0"
+
+[package.extras]
+dev = ["coverage", "black", "hypothesis", "hypothesmith"]
+
+[[package]]
 name = "importlib-metadata"
 version = "4.8.1"
 description = "Read metadata from Python packages"
@@ -117,6 +160,32 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 name = "mccabe"
 version = "0.6.1"
 description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "mypy"
+version = "0.910"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3,<0.5.0"
+toml = "*"
+typed-ast = {version = ">=1.4.0,<1.5.0", markers = "python_version < \"3.8\""}
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<1.5.0)"]
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
 category = "dev"
 optional = false
 python-versions = "*"
@@ -250,6 +319,30 @@ docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-a
 testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "psutil (>=5.6.1)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "pytest-xdist (>=1.22.2)", "pathlib2 (>=2.3.3)"]
 
 [[package]]
+name = "typed-ast"
+version = "1.4.3"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "types-setuptools"
+version = "57.4.2"
+description = "Typing stubs for setuptools"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "types-toml"
+version = "0.10.1"
+description = "Typing stubs for toml"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "3.10.0.2"
 description = "Backported and Experimental Type Hints for Python 3.5+"
@@ -293,9 +386,13 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "3983ecb758d42dee8940f0e965a2a3fba02e725848cfaca613ae04c416c4a15b"
+content-hash = "0dfa38dd83c813c7ceda9611a24ae25b03b9365e52b4c67c7574d00245e6baa1"
 
 [metadata.files]
+attrs = [
+    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
+    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
+]
 "backports.entry-points-selectable" = [
     {file = "backports.entry_points_selectable-1.1.0-py2.py3-none-any.whl", hash = "sha256:a6d9a871cde5e15b4c4a53e3d43ba890cc6861ec1332c9c2428c92f977192acc"},
     {file = "backports.entry_points_selectable-1.1.0.tar.gz", hash = "sha256:988468260ec1c196dab6ae1149260e2f5472c9110334e5d51adcb77867361f6a"},
@@ -354,8 +451,8 @@ coverage = [
     {file = "coverage-6.1.2.tar.gz", hash = "sha256:d9a635114b88c0ab462e0355472d00a180a5fbfd8511e7f18e4ac32652e7d972"},
 ]
 cyclonedx-python-lib = [
-    {file = "cyclonedx-python-lib-0.10.2.tar.gz", hash = "sha256:6f79742ca1728b9016ea272bbe58a60441848e6b4f9742918b8eb67ca987df3b"},
-    {file = "cyclonedx_python_lib-0.10.2-py3-none-any.whl", hash = "sha256:e0b2cd3e91c3d55746ce7175a05c23ea2f618158a407b7c9d166eef083a4ee04"},
+    {file = "cyclonedx-python-lib-0.11.1.tar.gz", hash = "sha256:cb0f1730ebe23c37820a9a2d4b42fc1d19fb3e8e6e92dfd3489673c76152e43c"},
+    {file = "cyclonedx_python_lib-0.11.1-py3-none-any.whl", hash = "sha256:ed6cf44f29b1f31835f818ca3b18deaee28be32a3179eadf9ad6c853217c93f9"},
 ]
 distlib = [
     {file = "distlib-0.3.3-py2.py3-none-any.whl", hash = "sha256:c8b54e8454e5bf6237cc84c20e8264c3e991e824ef27e8f1e81049867d861e31"},
@@ -369,6 +466,14 @@ flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
     {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
 ]
+flake8-annotations = [
+    {file = "flake8-annotations-2.0.1.tar.gz", hash = "sha256:a38b44d01abd480586a92a02a2b0a36231ec42dcc5e114de78fa5db016d8d3f9"},
+    {file = "flake8_annotations-2.0.1-py3-none-any.whl", hash = "sha256:d5b0e8704e4e7728b352fa1464e23539ff2341ba11cc153b536fa2cf921ee659"},
+]
+flake8-bugbear = [
+    {file = "flake8-bugbear-21.9.2.tar.gz", hash = "sha256:db9a09893a6c649a197f5350755100bb1dd84f110e60cf532fdfa07e41808ab2"},
+    {file = "flake8_bugbear-21.9.2-py36.py37.py38-none-any.whl", hash = "sha256:4f7eaa6f05b7d7ea4cbbde93f7bcdc5438e79320fa1ec420d860c181af38b769"},
+]
 importlib-metadata = [
     {file = "importlib_metadata-4.8.1-py3-none-any.whl", hash = "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15"},
     {file = "importlib_metadata-4.8.1.tar.gz", hash = "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"},
@@ -380,6 +485,35 @@ importlib-resources = [
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+mypy = [
+    {file = "mypy-0.910-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9"},
+    {file = "mypy-0.910-cp35-cp35m-win_amd64.whl", hash = "sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e"},
+    {file = "mypy-0.910-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212"},
+    {file = "mypy-0.910-cp36-cp36m-win_amd64.whl", hash = "sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885"},
+    {file = "mypy-0.910-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703"},
+    {file = "mypy-0.910-cp37-cp37m-win_amd64.whl", hash = "sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a"},
+    {file = "mypy-0.910-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504"},
+    {file = "mypy-0.910-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9"},
+    {file = "mypy-0.910-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072"},
+    {file = "mypy-0.910-cp38-cp38-win_amd64.whl", hash = "sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811"},
+    {file = "mypy-0.910-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e"},
+    {file = "mypy-0.910-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b"},
+    {file = "mypy-0.910-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2"},
+    {file = "mypy-0.910-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97"},
+    {file = "mypy-0.910-cp39-cp39-win_amd64.whl", hash = "sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8"},
+    {file = "mypy-0.910-py3-none-any.whl", hash = "sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d"},
+    {file = "mypy-0.910.tar.gz", hash = "sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 packageurl-python = [
     {file = "packageurl-python-0.9.6.tar.gz", hash = "sha256:c01fbaf62ad2eb791e97158d1f30349e830bee2dd3e9503a87f6c3ffae8d1cf0"},
@@ -428,6 +562,46 @@ toml = [
 tox = [
     {file = "tox-3.24.4-py2.py3-none-any.whl", hash = "sha256:5e274227a53dc9ef856767c21867377ba395992549f02ce55eb549f9fb9a8d10"},
     {file = "tox-3.24.4.tar.gz", hash = "sha256:c30b57fa2477f1fb7c36aa1d83292d5c2336cd0018119e1b1c17340e2c2708ca"},
+]
+typed-ast = [
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-win32.whl", hash = "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-win_amd64.whl", hash = "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-win32.whl", hash = "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-win_amd64.whl", hash = "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-win32.whl", hash = "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805"},
+    {file = "typed_ast-1.4.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39"},
+    {file = "typed_ast-1.4.3-cp38-cp38-win32.whl", hash = "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927"},
+    {file = "typed_ast-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40"},
+    {file = "typed_ast-1.4.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3"},
+    {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
+    {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
+    {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
+]
+types-setuptools = [
+    {file = "types-setuptools-57.4.2.tar.gz", hash = "sha256:5499a0f429281d1a3aa9494c79b6599ab356dfe6d393825426bc749e48ea1bf8"},
+    {file = "types_setuptools-57.4.2-py3-none-any.whl", hash = "sha256:9c96aab47fdcf066fef83160b2b9ddbfab3d2c8fdc89053579d0b306837bf22a"},
+]
+types-toml = [
+    {file = "types-toml-0.10.1.tar.gz", hash = "sha256:5c1f8f8d57692397c8f902bf6b4d913a0952235db7db17d2908cc110e70610cb"},
+    {file = "types_toml-0.10.1-py3-none-any.whl", hash = "sha256:8cdfd2b7c89bed703158b042dd5cf04255dae77096db66f4a12ca0a93ccb07a5"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,15 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-cyclonedx-python-lib = "^0.10.2"
+cyclonedx-python-lib = "^0.11"
 
 [tool.poetry.dev-dependencies]
 tox = "^3.24.3"
 coverage = "^6.1"
 flake8 = "^3.9.2"
+mypy = "^0.910"
+flake8-annotations = "^2.0"
+flake8-bugbear = "^21.9.2"
 
 [tool.poetry.scripts]
 cyclonedx-bom = 'cyclonedx_py.client:main'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+from os import path
+
+FIXTURES_DIRECTORY = path.join(path.dirname(__file__), 'fixtures')

--- a/tests/base.py
+++ b/tests/base.py
@@ -24,6 +24,7 @@ from datetime import datetime, timezone
 from unittest import TestCase
 from uuid import uuid4
 from xml.dom import minidom
+from typing import Any
 
 if sys.version_info >= (3, 8, 0):
     from importlib.metadata import version
@@ -39,13 +40,13 @@ single_uuid: str = 'urn:uuid:{}'.format(uuid4())
 
 class BaseJsonTestCase(TestCase):
 
-    def assertEqualJson(self, a: str, b: str):
+    def assertEqualJson(self, a: str, b: str) -> None:
         self.assertEqual(
             json.dumps(json.loads(a), sort_keys=True),
             json.dumps(json.loads(b), sort_keys=True)
         )
 
-    def assertEqualJsonBom(self, a: str, b: str):
+    def assertEqualJsonBom(self, a: str, b: str) -> None:
         """
         Remove UUID before comparison as this will be unique to each generation
         """
@@ -80,12 +81,12 @@ class BaseJsonTestCase(TestCase):
 
 class BaseXmlTestCase(TestCase):
 
-    def assertEqualXml(self, a: str, b: str):
+    def assertEqualXml(self, a: str, b: str) -> None:
         da, db = minidom.parseString(a), minidom.parseString(b)
         self.assertTrue(self._is_equal_xml_element(da.documentElement, db.documentElement),
                         'XML Documents are not equal: \n{}\n{}'.format(da.toxml(), db.toxml()))
 
-    def assertEqualXmlBom(self, a: str, b: str, namespace: str):
+    def assertEqualXmlBom(self, a: str, b: str, namespace: str) -> None:
         """
         Sanitise some fields such as timestamps which cannot have their values directly compared for equality.
         """
@@ -124,7 +125,7 @@ class BaseXmlTestCase(TestCase):
             xml.etree.ElementTree.tostring(bb, 'unicode')
         )
 
-    def _is_equal_xml_element(self, a, b):
+    def _is_equal_xml_element(self, a: Any, b: Any) -> bool:
         if a.tagName != b.tagName:
             return False
         if sorted(a.attributes.items()) != sorted(b.attributes.items()):

--- a/tests/test_cyclonedx.py
+++ b/tests/test_cyclonedx.py
@@ -36,7 +36,7 @@ class TestCycloneDxXml(BaseXmlTestCase):
                 'cyclonedx-py',
                 '-e',
                 '-o', os.path.join(dirname, 'sbom.xml'),
-            ])
+            ], shell=False)
 
     def text_conda_list_explicit(self) -> None:
         with tempfile.TemporaryDirectory() as dirname:
@@ -46,7 +46,7 @@ class TestCycloneDxXml(BaseXmlTestCase):
                 '-c',
                 '-i', os.path.join(FIXTURES_DIRECTORY, 'conda-list-explicit-simple.txt'),
                 '-o', os.path.join(dirname, 'sbom.xml'),
-            ])
+            ], shell=False)
 
             with open(os.path.join(dirname, 'sbom.xml'), 'r') as f, \
                     open(os.path.join(FIXTURES_DIRECTORY, 'bom_v1.3_setuptools.xml')) as expected:
@@ -63,7 +63,7 @@ class TestCycloneDxXml(BaseXmlTestCase):
                 '-r',
                 '-i', os.path.join(FIXTURES_DIRECTORY, 'requirements-simple.txt'),
                 '-o', os.path.join(dirname, 'sbom.xml'),
-            ])
+            ], shell=False)
 
             with open(os.path.join(dirname, 'sbom.xml'), 'r') as f, \
                     open(os.path.join(FIXTURES_DIRECTORY, 'bom_v1.3_setuptools.xml')) as expected:
@@ -90,7 +90,7 @@ class TestCycloneDxXml(BaseXmlTestCase):
                 '-i', os.path.join(FIXTURES_DIRECTORY, 'requirements-simple.txt'),
                 '--schema-version', schema_version,
                 '-o', os.path.join(dirname, 'sbom.xml'),
-            ])
+            ], shell=False)
 
             with open(os.path.join(dirname, 'sbom.xml'), 'r') as f, \
                     open(os.path.join(FIXTURES_DIRECTORY, 'bom_v{}_setuptools.xml'.format(schema_version))) as expected:

--- a/tests/test_cyclonedx.py
+++ b/tests/test_cyclonedx.py
@@ -17,15 +17,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
 
-import os.path
+from os import path
 import subprocess
 import tempfile
 
-from base import BaseXmlTestCase
-
-script_path = os.path.dirname(__file__)
-
-FIXTURES_DIRECTORY = os.path.join(os.path.dirname(__file__), 'fixtures')
+from . import FIXTURES_DIRECTORY
+from .base import BaseXmlTestCase
 
 
 class TestCycloneDxXml(BaseXmlTestCase):
@@ -35,7 +32,7 @@ class TestCycloneDxXml(BaseXmlTestCase):
             subprocess.check_output([
                 'cyclonedx-py',
                 '-e',
-                '-o', os.path.join(dirname, 'sbom.xml'),
+                '-o', path.join(dirname, 'sbom.xml'),
             ], shell=False)
 
     def text_conda_list_explicit(self) -> None:
@@ -44,12 +41,12 @@ class TestCycloneDxXml(BaseXmlTestCase):
             subprocess.check_output([
                 'cyclonedx-bom',
                 '-c',
-                '-i', os.path.join(FIXTURES_DIRECTORY, 'conda-list-explicit-simple.txt'),
-                '-o', os.path.join(dirname, 'sbom.xml'),
+                '-i', path.join(FIXTURES_DIRECTORY, 'conda-list-explicit-simple.txt'),
+                '-o', path.join(dirname, 'sbom.xml'),
             ], shell=False)
 
-            with open(os.path.join(dirname, 'sbom.xml'), 'r') as f, \
-                    open(os.path.join(FIXTURES_DIRECTORY, 'bom_v1.3_setuptools.xml')) as expected:
+            with open(path.join(dirname, 'sbom.xml'), 'r') as f, \
+                    open(path.join(FIXTURES_DIRECTORY, 'bom_v1.3_setuptools.xml')) as expected:
                 self.assertEqualXmlBom(f.read(), expected.read(),
                                        namespace='http://cyclonedx.org/schema/bom/1.3')
                 f.close()
@@ -61,12 +58,12 @@ class TestCycloneDxXml(BaseXmlTestCase):
             subprocess.check_output([
                 'cyclonedx-py',
                 '-r',
-                '-i', os.path.join(FIXTURES_DIRECTORY, 'requirements-simple.txt'),
-                '-o', os.path.join(dirname, 'sbom.xml'),
+                '-i', path.join(FIXTURES_DIRECTORY, 'requirements-simple.txt'),
+                '-o', path.join(dirname, 'sbom.xml'),
             ], shell=False)
 
-            with open(os.path.join(dirname, 'sbom.xml'), 'r') as f, \
-                    open(os.path.join(FIXTURES_DIRECTORY, 'bom_v1.3_setuptools.xml')) as expected:
+            with open(path.join(dirname, 'sbom.xml'), 'r') as f, \
+                    open(path.join(FIXTURES_DIRECTORY, 'bom_v1.3_setuptools.xml')) as expected:
                 self.assertEqualXmlBom(f.read(), expected.read(),
                                        namespace='http://cyclonedx.org/schema/bom/1.3')
                 f.close()
@@ -87,13 +84,13 @@ class TestCycloneDxXml(BaseXmlTestCase):
             subprocess.check_output([
                 'cyclonedx-py',
                 '-r',
-                '-i', os.path.join(FIXTURES_DIRECTORY, 'requirements-simple.txt'),
+                '-i', path.join(FIXTURES_DIRECTORY, 'requirements-simple.txt'),
                 '--schema-version', schema_version,
-                '-o', os.path.join(dirname, 'sbom.xml'),
+                '-o', path.join(dirname, 'sbom.xml'),
             ], shell=False)
 
-            with open(os.path.join(dirname, 'sbom.xml'), 'r') as f, \
-                    open(os.path.join(FIXTURES_DIRECTORY, 'bom_v{}_setuptools.xml'.format(schema_version))) as expected:
+            with open(path.join(dirname, 'sbom.xml'), 'r') as f, \
+                    open(path.join(FIXTURES_DIRECTORY, 'bom_v{}_setuptools.xml'.format(schema_version))) as expected:
                 self.assertEqualXmlBom(f.read(), expected.read(),
                                        namespace='http://cyclonedx.org/schema/bom/{}'.format(schema_version))
                 f.close()

--- a/tests/test_cyclonedx.py
+++ b/tests/test_cyclonedx.py
@@ -30,7 +30,7 @@ FIXTURES_DIRECTORY = os.path.join(os.path.dirname(__file__), 'fixtures')
 
 class TestCycloneDxXml(BaseXmlTestCase):
 
-    def test_environment(self):
+    def test_environment(self) -> None:
         with tempfile.TemporaryDirectory() as dirname:
             subprocess.check_output([
                 'cyclonedx-py',
@@ -38,7 +38,7 @@ class TestCycloneDxXml(BaseXmlTestCase):
                 '-o', os.path.join(dirname, 'sbom.xml'),
             ])
 
-    def text_conda_list_explicit(self):
+    def text_conda_list_explicit(self) -> None:
         with tempfile.TemporaryDirectory() as dirname:
             # Run command to generate latest 1.3 XML SBOM from Requirements File
             subprocess.check_output([
@@ -55,7 +55,7 @@ class TestCycloneDxXml(BaseXmlTestCase):
                 f.close()
                 expected.close()
 
-    def test_requirements_txt_file(self):
+    def test_requirements_txt_file(self) -> None:
         with tempfile.TemporaryDirectory() as dirname:
             # Run command to generate latest 1.3 XML SBOM from Requirements File
             subprocess.check_output([
@@ -72,16 +72,16 @@ class TestCycloneDxXml(BaseXmlTestCase):
                 f.close()
                 expected.close()
 
-    def test_requirements_txt_file_v1_2(self):
+    def test_requirements_txt_file_v1_2(self) -> None:
         self._do_test_requirements_txt_file_for_version(schema_version='1.2')
 
-    def test_requirements_txt_file_v1_1(self):
+    def test_requirements_txt_file_v1_1(self) -> None:
         self._do_test_requirements_txt_file_for_version(schema_version='1.1')
 
-    def test_requirements_txt_file_v1_0(self):
+    def test_requirements_txt_file_v1_0(self) -> None:
         self._do_test_requirements_txt_file_for_version(schema_version='1.0')
 
-    def _do_test_requirements_txt_file_for_version(self, schema_version: str):
+    def _do_test_requirements_txt_file_for_version(self, schema_version: str) -> None:
         with tempfile.TemporaryDirectory() as dirname:
             # Run command to generate XML SBOM from Requirements File
             subprocess.check_output([

--- a/tox.ini
+++ b/tox.ini
@@ -16,21 +16,23 @@ download = False
 
 [testenv]
 # settings in this category apply to all other testenv, if not overwritten
-skip_install = True
+skip_install = False
 whitelist_externals = poetry
 deps = poetry
 commands_pre =
     {envpython} --version
-    poetry install -v
+    poetry install --no-root -v
 commands =
     poetry run coverage run --source=cyclonedx_py -m unittest discover -s tests -v
 
 [testenv:mypy]
+skip_install = True
 commands =
     poetry run mypy
     # mypy config is on own file: `.mypy.ini`
 
 [testenv:flake8]
+skip_install = True
 commands =
     poetry run flake8 cyclonedx_py/ tests/
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands_pre =
     {envpython} --version
     poetry install --no-root -v
 commands =
-    poetry run coverage run --source=cyclonedx_py -m unittest discover -s tests -v
+    poetry run coverage run --source=cyclonedx_py -m unittest -v
 
 [testenv:mypy]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@
 minversion = 3.10
 envlist =
     flake8
+    mypy
     py{310,39,38,37,36}
 isolated_build = True
 skip_missing_interpreters = True
@@ -24,11 +25,22 @@ commands_pre =
 commands =
     poetry run coverage run --source=cyclonedx_py -m unittest discover -s tests
 
+[testenv:mypy]
+commands =
+    poetry run mypy
+    # mypy config is on own file: `.mypy.ini`
+
 [testenv:flake8]
 commands =
     poetry run flake8 cyclonedx_py/ tests/
 
 [flake8]
-ignore = E305
-exclude = .git,__pycache__
+exclude =
+    build,dist,__pycache__,.eggs,*_cache
+    .git,.tox,.venv,venv
+    _OLD,_TEST,
+    docs
 max-line-length = 120
+ignore = E305
+    # ignore `self`, `cls` markers of flake8-annotations>=2.0
+    ANN101,ANN102

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,31 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
 [tox]
-minversion=3.6.0
-envlist = flake8,py3.9,py3.8,py3.7,py3.6
+minversion = 3.10
+envlist =
+    flake8
+    py{310,39,38,37,36}
 isolated_build = True
+skip_missing_interpreters = True
+usedevelop = False
+download = False
 
 [testenv]
+# settings in this category apply to all other testenv, if not overwritten
+skip_install = True
 whitelist_externals = poetry
-commands =
-    pip install poetry
+deps = poetry
+commands_pre =
+    {envpython} --version
     poetry install -v
+commands =
     poetry run coverage run --source=cyclonedx_py -m unittest discover -s tests
 
 [testenv:flake8]
-skip_install = True
 commands =
-    pip install poetry
-    poetry install -v
     poetry run flake8 cyclonedx_py/ tests/
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands_pre =
     {envpython} --version
     poetry install -v
 commands =
-    poetry run coverage run --source=cyclonedx_py -m unittest discover -s tests
+    poetry run coverage run --source=cyclonedx_py -m unittest discover -s tests -v
 
 [testenv:mypy]
 commands =


### PR DESCRIPTION


* bumped dependency `cyclonedx-python-lib` to ^0.11 - closes #254
* added static code analysis via `mypy` - closes #253
* added additional QA tools: `flake8-annotations`, & `flake8-bugbear`
* fixed tox to run with correct python versions
* added missing typehints
* made the unittests an own module