### PR TITLE
chore: improve docker, release, docs 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 
 env:
+  REPORTS_DIR: CI_reports
   PYTHON_VERISON: "3.10"
   POETRY_VERSION: "1.1.11"
 
@@ -19,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
+      REPORTS_ARTIFACT: 'docker-image-bom'
       DOCKER_TAG: 'cdx-python-testing:${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}'
     steps:
       - name: Checkout code
@@ -26,12 +28,15 @@ jobs:
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      - name: setup reports-dir
+        run: mkdir "$REPORTS_DIR"
+
       - name: Setup python ${{ env.PYTHON_VERISON }}
         # see https://github.com/actions/setup-python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERISON }}
-      - name: Install poetry
+      - name: Setup poetry ${{ env.POETRY_VERSION }}
         # see https://github.com/marketplace/actions/setup-poetry
         uses: Gr1N/setup-poetry@v7
         with:
@@ -39,15 +44,55 @@ jobs:
 
       - name: Poetry build
         run: poetry build
-      - name: get version
-        run: poetry version -s
+      - name: Artifact python dist
+        if: |
+          !failure() && !cancelled() &&
+          steps.after-release.outputs.released
+        # see https://github.com/actions/upload-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.RUN_ARTIFACT_PYTHON_DIST }}
+          path: ${{ env.DIST_SOURCE_DIR }}/
+          if-no-files-found: warn
+
+      - name: post-hook
+        id: after-build
+        run: |
+          VERSION="$(poetry version --short --no-interaction --no-ansi)"
+          echo "::set-output name=version::$VERSION"
 
       - name: Build Docker image
-        run: |
-          VERSION=`poetry version -s`
-          docker build -f Dockerfile --build-arg "VERSION=$VERSION" -t "$DOCKER_TAG" .
-      - name: Test Docker image
-        run: docker run --rm "$DOCKER_TAG" -h
+        env:
+          VERSION: ${{ steps.after-build.outputs.version }}
+        run: >
+          docker build -f Dockerfile
+          --build-arg "VERSION=$VERSION"
+          -t "$DOCKER_TAG"
+          .
+
+      - name: Build own SBoM (XML)
+        run: >
+          docker run --rm "$DOCKER_TAG"
+          --environment
+          --format=xml
+          --output=-
+          > "$REPORTS_DIR/docker-image.bom.xml"
+      - name: Build own SBoM (JSON)
+        run: >
+          docker run --rm "$DOCKER_TAG"
+          --environment
+          --format=json
+          --output=-
+          > "$REPORTS_DIR/docker-image.bom.json"
+      - name: Artifact reports
+        if: ${{ ! cancelled() }}
+        # see https://github.com/actions/upload-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.REPORTS_ARTIFACT }}
+          path: ${{ env.REPORTS_DIR }}
+          if-no-files-found: error
+
       - name: Destroy Docker image
         # run regardless of outcome
         if: ${{ always() }}

--- a/.github/workflows/manual-release-candidate.yml
+++ b/.github/workflows/manual-release-candidate.yml
@@ -8,6 +8,13 @@ on:
         required: true
         type: string
 
+env:
+  REPORTS_DIR: CI_reports
+  DIST_DIR: dist
+  DIST_ARTIFACT: python-dist
+  PYTHON_VERISON: "3.10"
+  POETRY_VERSION: "1.1.11"
+
 jobs:
   release_candidate:
     runs-on: ubuntu-latest
@@ -19,10 +26,10 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: ${{ env.PYTHON_VERISON }}
       - name: Install dependencies
         run: |
-          python -m pip install poetry --upgrade pip
+          python -m pip install poetry=="$POETRY_VERSION" --upgrade pip
           poetry config virtualenvs.create false
           poetry install
           python -m pip install python-semantic-release
@@ -32,7 +39,15 @@ jobs:
           echo "RC Version will be: ${RC_VERSION}"
           poetry version ${RC_VERSION}
           poetry build
+      - name: Artifact python dist
+        # see https://github.com/actions/upload-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.DIST_ARTIFACT }}
+          path: ${{ env.DIST_DIR }}/
+          if-no-files-found: error
       - name: Publish Pre Release 📦 to PyPI
+        # see https://github.com/pypa/gh-action-pypi-publish
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,7 +24,7 @@ on:
   pull_request:
   push:
     tags: [ 'v*.*.*' ]  # run again on release tags to have tools mark them
-    branches: [ 'master']
+    branches: [ 'master' ]
 
 env:
   REPORTS_DIR: CI_reports

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,56 +26,155 @@ on:
   workflow_dispatch:
 
 env:
+  REPORTS_DIR: CI_reports
+  DIST_DIR: dist
+  DIST_ARTIFACT: python-dist
   PYTHON_VERISON: "3.10"
   POETRY_VERSION: "1.1.11"
 
 jobs:
-  release:
+  release-PyPI:
+    name: "Release: GitHub, PyPI"
     # https://github.community/t/how-do-i-specify-job-dependency-running-in-another-workflow/16482
     # limit this to being run on regular commits, not the commits that semantic-release will create
-    if: github.ref == 'refs/heads/master' && !contains(github.event.head_commit.message, 'chore(release):')
+    if: |
+      github.ref == 'refs/heads/master' &&
+      !contains(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
-    concurrency: release
+    concurrency: release-PyPI  # one release at a time, prevent hickups
+    outputs:
+      version-before: ${{ steps.before-release.outputs.version }}  # version may be empty
+      released:       ${{ steps.after-release.outputs.released }}  # optional bool-ish string
+      version-after:  ${{ steps.after-release.outputs.version  }}  # version may still be empty
     steps:
       - name: Checkout code
         # see https://github.com/actions/checkout
         uses: actions/checkout@v2.4.0
         with:
-          fetch-depth: 0
+          fetch-depth: 0  # action `relekang/python-semantic-release` requires all git history
       - name: Setup python ${{ env.PYTHON_VERISON }}
         # see https://github.com/actions/setup-python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERISON }}
-      - name: Install poetry
+      - name: Setup poetry ${{ env.POETRY_VERSION }}
         # see https://github.com/marketplace/actions/setup-poetry
         uses: Gr1N/setup-poetry@v7
         with:
           poetry-version: ${{ env.POETRY_VERSION }}
-
+      - name: pre-hook
+        id: before-release
+        run: |
+          VERSION="$(poetry version --short --no-interaction --no-ansi)"
+          # version may be empty at first
+          echo "::set-output name=version::$VERSION"
       - name: Python Semantic Release
+        id: semantic-release
+        # see https://python-semantic-release.readthedocs.io/en/latest/automatic-releases/github-actions.html
         uses: relekang/python-semantic-release@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pypi_token: ${{ secrets.PYPI_TOKEN }}
-
-      - name: Poetry build
-        run: poetry build
-      - name: get version
-        run: poetry version -s
-
-      - name: Build Docker Image
-        env:
-          REPO: cyclonedx/cyclonedx-python
+      - name: post-hook
+        id: after-release
         run: |
-          VERSION=`poetry version -s`
-          docker build -f Dockerfile --build-arg "VERSION=$VERSION" -t "$REPO:$VERSION" -t "$REPO:latest" .
+          VERSION="$(poetry version --short --no-interaction --no-ansi)"
+          # version may still be empty
+          echo "::set-output name=version::$VERSION"
+          if [ "$VERSION" != "$VERSION_PRE" ]
+          then
+            echo "::set-output name=released::true"
+          fi
+        env: 
+          VERSION_PRE: ${{ steps.before-release.outputs.version }}
+      - name: Artifact python dist
+        if: |
+          !failure() && !cancelled() &&
+          steps.after-release.outputs.released
+        # see https://github.com/actions/upload-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.DIST_ARTIFACT }}
+          path: ${{ env.DIST_DIR }}/
+          if-no-files-found: error
+          # Dist results are required for further processing.
+          # Therefore, make sure that python-semantic-release is configuret to keep dist.
+          # see https://python-semantic-release.readthedocs.io/en/latest/configuration.html?highlight=remove_dist#remove-dist 
 
+  release-DockerHub:
+    name: "Release: DockerHub"
+    needs:
+      - release-PyPI
+    if: |
+      !failure() && !cancelled() &&
+      needs.release-PyPI.result == 'success' &&
+      needs.release-PyPI.outputs.released &&
+      needs.release-PyPI.outputs.version-after
+    runs-on: ubuntu-latest
+    concurrency: release-DockerHub  # because of the 'latest' tag
+    env:
+      VERSION: ${{ needs.release-PyPI.outputs.version-after }}
+      ARTIFACT_DOCKER_SBOM: 'docker-image-bom'
+      DOCKER_REPO: cyclonedx/cyclonedx-python
+    steps:
+      - name: Checkout code (tags/v${{ env.VERSION }})
+        # see https://github.com/actions/checkout
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: tags/v${{ env.VERSION }}
+      - name: setup dirs
+        run: |
+          mkdir "$REPORTS_DIR"
+          mkdir "$DIST_DIR"
+      - name: Fetch python dist artifact
+        # see https://github.com/actions/download-artifact
+        uses: actions/download-artifact@v2
+        with: 
+          name: ${{ env.DIST_ARTIFACT }}
+          path: ${{ env.DIST_DIR }}/
+      - name: Build Docker Image (${{ env.VERSION }})
+        run: >
+          docker build -f Dockerfile
+          --build-arg "VERSION=$VERSION"
+          -t "$DOCKER_REPO:$VERSION"
+          -t "$DOCKER_REPO:latest"
+          .
+      - name: Build own SBoM (XML)
+        run: >
+          docker run --rm "$DOCKER_REPO:$VERSION"
+          --environment
+          --format=xml
+          --output=-
+          > "$REPORTS_DIR/$ARTIFACT_DOCKER_SBOM.bom.xml"
+      - name: Build own SBoM (JSON)
+        run: >
+          docker run --rm "$DOCKER_REPO:$VERSION"
+          --environment
+          --format=json
+          --output=-
+          > "$REPORTS_DIR/$ARTIFACT_DOCKER_SBOM.bom.json"
+      - name: Artifact reports
+        if: ${{ ! cancelled() }}
+        # see https://github.com/actions/upload-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.ARTIFACT_DOCKER_SBOM }}
+          path: ${{ env.REPORTS_DIR }}/*.bom.*
+          if-no-files-found: error
+      # publish AFTER the boms were build, as the bom-generation is kind of a test if the image works
       - name: Publish Docker Image(s)
-        env:
-          REPO: 'cyclonedx/cyclonedx-python'
         run: |
-          VERSION=`poetry version -s`
-          docker login --username '${{ secrets.DOCKERHUB_USERNAME }}' --password '${{ secrets.DOCKERHUB_TOKEN }}'
-          docker push "$REPO:latest"
-          docker push "$REPO:$VERSION"
+          docker login --username "$DOCKERHUB_USERNAME" --password "$DOCKERHUB_TOKEN"
+          docker push "$DOCKER_REPO:$VERSION"
+          docker push "$DOCKER_REPO:latest"
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      # TODO: publish all files in $REPORTS_DIR as release assets - see https://github.com/actions/upload-release-asset
+      - name: Destroy Docker image
+        # run regardless of outcome
+        if: ${{ always() }}
+        run: >
+          docker rmi -f
+          "$DOCKER_REPO:$VERSION"
+          "$DOCKER_REPO:latest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,10 +45,13 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.semantic_release]
+# https://python-semantic-release.readthedocs.io/en/latest/configuration.html
 version_variable = [
     "pyproject.toml:version"
 ]
 branch = "master"
 upload_to_pypi = true
+upload_to_repository = true
 upload_to_release = true
 build_command = "pip install poetry && poetry build"
+remove_dist = false  # dist results required for some CI automation


### PR DESCRIPTION
currently working on several topics in parallel 

goals:
* fix a **BUG**:  on each push to master a new docker image is build and pushed to dockerhub, regardless if a semantic-release was issued or not. - see #292
* ~~encapsulate docker foo in a venv~~ - reverted due to https://github.com/CycloneDX/cyclonedx-python/pull/290#issuecomment-1013679750
* have docker image generate own SBOM - prep for #289
* split release: PyPI release separate from docker release -- compare to https://github.com/CycloneDX/cyclonedx-node-module/blob/master/.github/workflows/release.yml
  * this looks impossible at first, as the `python semantic release` action does not have proper outputs, yet. 
    requested via https://github.com/relekang/python-semantic-release/issues/401
  * actually it is not impossible to detect if a release happened, as @madpah stated:  
    call `poetry version` before and after the release and it they are unequal, a release happened.  
    with this trick, the `release`-job can have an output to decide if a release was triggered. other jobs/steps can rely on this output ...  
    quick idea: have two outputs: `version-before`, `version-after` - so we are free to code with it. 
    this way was implemented already
* docker release uses exact same build results that were published before
* use tagged version for docker release
----

TODO
- [x] split PyPI and DockerHub release 
- [x] improve docker build process in CI
- [x] generate docker SBOM  
- [x] use build assets for docker build
- [x] test the release process / pass  (in an own repo, probably)
- [x] finalize - write proper commit messages and such