### PR TITLE
Added support for dependencies in poetry and environment parser.

### DIFF
--- a/cyclonedx_py/parser/environment.py
+++ b/cyclonedx_py/parser/environment.py
@@ -31,7 +31,6 @@ The Environment Parsers support population of the following data about Component
 import sys
 
 # See https://github.com/package-url/packageurl-python/issues/65
-from cyclonedx.model.dependency import Dependency
 from packageurl import PackageURL  # type: ignore
 from pkg_resources import DistInfoDistribution  # type: ignore
 
@@ -43,6 +42,7 @@ else:
 
 from cyclonedx.model import LicenseChoice
 from cyclonedx.model.component import Component
+from cyclonedx.model.dependency import Dependency
 from cyclonedx.parser import BaseParser, ParserWarning
 
 

--- a/cyclonedx_py/parser/environment.py
+++ b/cyclonedx_py/parser/environment.py
@@ -31,6 +31,7 @@ The Environment Parsers support population of the following data about Component
 import sys
 
 # See https://github.com/package-url/packageurl-python/issues/65
+from cyclonedx.model.dependency import Dependency
 from packageurl import PackageURL  # type: ignore
 from pkg_resources import DistInfoDistribution  # type: ignore
 
@@ -42,7 +43,7 @@ else:
 
 from cyclonedx.model import LicenseChoice
 from cyclonedx.model.component import Component
-from cyclonedx.parser import BaseParser
+from cyclonedx.parser import BaseParser, ParserWarning
 
 
 class EnvironmentParser(BaseParser):
@@ -80,7 +81,25 @@ class EnvironmentParser(BaseParser):
                                 license_expression=str(classifier).replace('License :: OSI Approved :: ', '').strip()
                             )
                         )
-
+            for requirement in i.requires():
+                try:
+                    requirement_distribution = pkg_resources.get_distribution(requirement.project_name)
+                except pkg_resources.DistributionNotFound:
+                    self._warnings.append(
+                        ParserWarning(
+                            item=requirement.project_name,
+                            warning='Dependency \'{}\' does not have a version installed in local environment and '
+                                    'cannot be included in your CycloneDX SBOM.'.format(requirement.project_name)
+                        )
+                    )
+                else:
+                    version = requirement_distribution.version
+                    d = Dependency(
+                        purl=PackageURL(
+                            type='pypi', name=requirement.project_name, version=version
+                        )
+                    )
+                    c.add_dependency(d)
             self._components.append(c)
 
     @staticmethod

--- a/tests/fixtures/poetry-lock-simple.txt
+++ b/tests/fixtures/poetry-lock-simple.txt
@@ -1,10 +1,21 @@
 [[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
-category = "main"
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
+[[package]]
+name = "importlib-metadata"
+version = "4.8.1"
+description = "Read metadata from Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.6"
 
 [metadata]
 lock-version = "1.1"
@@ -12,7 +23,11 @@ python-versions = "^3.9"
 content-hash = "3dc7af43729f7ff1e7cf84103a3e2c1945f233884eaa149c7e8d92cccb593984"
 
 [metadata.files]
-toml = [
-    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
-    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-4.8.1-py3-none-any.whl", hash = "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15"},
+    {file = "importlib_metadata-4.8.1.tar.gz", hash = "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"},
 ]

--- a/tests/test_parser_environment.py
+++ b/tests/test_parser_environment.py
@@ -20,6 +20,7 @@
 from unittest import TestCase
 
 from cyclonedx.model.component import Component
+from packageurl import PackageURL
 
 from cyclonedx_py.parser.environment import EnvironmentParser
 
@@ -40,3 +41,8 @@ class TestEnvironmentParser(TestCase):
         c_tox: Component = [x for x in parser.get_components() if x.name == 'tox'][0]
         self.assertIsNotNone(c_tox.licenses)
         self.assertEqual('MIT', c_tox.licenses[0].expression)
+
+        # Since we have tox, we have its dependencies:
+        self.assertEqual(len(c_tox.get_dependencies()), 9)
+        colorama_dependency = [x for x in c_tox.get_dependencies() if x.purl.name == "colorama"][0]
+        self.assertEqual(PackageURL(type="pypi", name="colorama", version="0.4.4"), colorama_dependency.purl)

--- a/tests/test_parser_poetry.py
+++ b/tests/test_parser_poetry.py
@@ -20,6 +20,8 @@
 import os
 from unittest import TestCase
 
+from packageurl import PackageURL
+
 from cyclonedx_py.parser.poetry import PoetryFileParser
 
 
@@ -29,8 +31,13 @@ class TestPoetryParser(TestCase):
         tests_poetry_lock_file = os.path.join(os.path.dirname(__file__), 'fixtures/poetry-lock-simple.txt')
 
         parser = PoetryFileParser(poetry_lock_filename=tests_poetry_lock_file)
-        self.assertEqual(1, parser.component_count())
+        self.assertEqual(2, parser.component_count())
         components = parser.get_components()
-        self.assertEqual('toml', components[0].name)
-        self.assertEqual('0.10.2', components[0].version)
+        self.assertEqual('pluggy', components[0].name)
+        self.assertEqual('1.0.0', components[0].version)
+        self.assertEqual('importlib-metadata', components[1].name)
+        self.assertEqual('4.8.1', components[1].version)
         self.assertEqual(len(components[0].external_references), 2)
+        dependencies = components[0].get_dependencies()
+        self.assertEqual(1, len(dependencies))
+        self.assertEqual(PackageURL(type="pypi", name="importlib-metadata", version="4.8.1"), dependencies[0].purl)


### PR DESCRIPTION
Hello everyone,
I'd like to help with adding support for dependencies. 
I created a PR adding Dependency model to the `cyclonedx-python` repo https://github.com/CycloneDX/cyclonedx-python-lib/pull/137, and this one as an initial sketch for supporting dependencies in parsers.
I'd appreciate if you could take a look at this code and say what's wrong here.