### PR TITLE
fix: properly support reading from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Input Method:
   Flags to determine how `cyclonedx-bom` obtains it's input
 
   -i FILE_PATH, --in-file FILE_PATH
-                        File to read input from, or STDIN if not specified
+                        File to read input from. Use "-" to read from STDIN.
 
 SBOM Output Configuration:
   Choose the output format and schema version

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -166,8 +166,8 @@ class CycloneDxCmd:
         )
         input_method_group.add_argument(
             '-i', '--in-file', action='store', metavar='FILE_PATH',
-            type=argparse.FileType('r'), default=(None if sys.stdin.isatty() else sys.stdin),
-            help='File to read input from, or STDIN if not specified', dest='input_source', required=False
+            type=argparse.FileType('r'), default=None,
+            help='File to read input from. Use "-" to read from STDIN.', dest='input_source', required=False
         )
 
         output_group = arg_parser.add_argument_group(

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -166,7 +166,8 @@ class CycloneDxCmd:
         )
         input_method_group.add_argument(
             '-i', '--in-file', action='store', metavar='FILE_PATH',
-            type=argparse.FileType('r'), default=None,
+            type=argparse.FileType('r'),  # FileType does handle '-'
+            default=None,
             help='File to read input from. Use "-" to read from STDIN.', dest='input_source', required=False
         )
 


### PR DESCRIPTION
Bind reading from stdin on specifying `-i -`. This is part of
[`argparse.FileType`](https://docs.python.org/3/library/argparse.html?highlight=pseudo-argument#argparse.FileType).

Fixes #306

Local tests under the following conditions:

 * implicit reading `poetry.lock` using args `-p -o -`
 * explicit reading `poetry.lock` using args `-p -i poetry.lock -o -`
 * explicit reading `poetry.lock` file after renaming using
   `cat p.lock | python -m cyclonedx_py.client -p -i - -o -`

Signed-off-by: Theodor van Nahl <theo@van-nahl.org>