### PR TITLE
docs: add and fix hint to rtfd

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ poetry run autopep8 --in-place -r .
 
 ## Documentation
 
-This project uses [Sphinx] to generate documentation which is automatically published to [readthedocs.io].
+This project uses [Sphinx] to generate documentation which is automatically published to [RTFD][link_rtfd].
 
 Source for documentation is stored in the `docs` folder in [RST] format.
 
@@ -58,5 +58,5 @@ git commit --signed-off ...
 [poetry]: https://python-poetry.org
 [PEP8]: https://www.python.org/dev/peps/pep-0008/
 [Sphinx]: https://www.sphinx-doc.org/
-[readthedocs.io]: https://cyclonedx-python-library.readthedocs.io/
+[link_rtfd]: https://cyclonedx-bom-tool.readthedocs.io/
 [RST]: https://en.wikipedia.org/wiki/ReStructuredText

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # CycloneDX Python SBOM Generation Tool
 
 [![shield_gh-workflow-test]][link_gh-workflow-test]
+[![shield_rtfd]][link_rtfd]
 [![shield_pypi-version]][link_pypi]
 [![shield_docker-version]][link_docker]
 [![shield_license]][license_file]  
@@ -93,8 +94,6 @@ SBOM Output Configuration:
                         exists, it will be overwritten.
 ```
 
-
-
 ## Python Support
 
 We endeavour to support all functionality for all [current actively supported Python versions](https://www.python.org/downloads/).
@@ -115,6 +114,7 @@ See the [LICENSE][license_file] file for the full license.
 [contributing_file]: https://github.com/CycloneDX/cyclonedx-python/blob/master/CONTRIBUTING.md
 
 [shield_gh-workflow-test]: https://img.shields.io/github/workflow/status/CycloneDX/cyclonedx-python/Python%20CI/master?logo=GitHub&logoColor=white "build"
+[shield_rtfd]: https://img.shields.io/readthedocs/cyclonedx-bom-tool?logo=readthedocs&logoColor=white
 [shield_pypi-version]: https://img.shields.io/pypi/v/cyclonedx-bom?logo=Python&logoColor=white&label=PyPI "PyPI"
 [shield_docker-version]: https://img.shields.io/docker/v/cyclonedx/cyclonedx-python?logo=docker&logoColor=white&label=docker "docker"
 [shield_license]: https://img.shields.io/github/license/CycloneDX/cyclonedx-python "license"
@@ -122,6 +122,7 @@ See the [LICENSE][license_file] file for the full license.
 [shield_slack]: https://img.shields.io/badge/slack-join-blue?logo=Slack&logoColor=white "slack join"
 [shield_groups]: https://img.shields.io/badge/discussion-groups.io-blue.svg "groups discussion"
 [shield_twitter-follow]: https://img.shields.io/badge/Twitter-follow-blue?logo=Twitter&logoColor=white "twitter follow"
+[link_rtfd]: https://cyclonedx-bom-tool.readthedocs.io/
 [link_gh-workflow-test]: https://github.com/CycloneDX/cyclonedx-python/actions/workflows/python.yml?query=branch%3Amaster
 [link_pypi]: https://pypi.org/project/cyclonedx-bom/
 [link_docker]: https://hub.docker.com/r/cyclonedx/cyclonedx-python

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The BOM will contain an aggregate of all your current project's dependencies, or
 
 CycloneDX is a lightweight BOM specification that is easily created, human-readable, and simple to parse.
 
+Read the full [documentation][link_rtfd] for more details.
+
 ## Installation
 
 Install this from [PyPi.org][link_pypi] using your preferred Python package manager.
@@ -40,7 +42,7 @@ poetry add cyclonedx-bom
 
 ## Usage
 
-Once installed, you can access the full documentation by running `--help`:
+## Basic usage
 
 ```text
 $ cyclonedx-bom --help
@@ -94,6 +96,10 @@ SBOM Output Configuration:
                         exists, it will be overwritten.
 ```
 
+### Advanced usage and details
+
+See the full [documentation][link_rtfd] for advanced usage and details on input formats, switches and options.
+
 ## Python Support
 
 We endeavour to support all functionality for all [current actively supported Python versions](https://www.python.org/downloads/).
@@ -112,6 +118,7 @@ See the [LICENSE][license_file] file for the full license.
 
 [license_file]: https://github.com/CycloneDX/cyclonedx-python/blob/master/LICENSE
 [contributing_file]: https://github.com/CycloneDX/cyclonedx-python/blob/master/CONTRIBUTING.md
+[link_rtfd]: https://cyclonedx-bom-tool.readthedocs.io/
 
 [shield_gh-workflow-test]: https://img.shields.io/github/workflow/status/CycloneDX/cyclonedx-python/Python%20CI/master?logo=GitHub&logoColor=white "build"
 [shield_rtfd]: https://img.shields.io/readthedocs/cyclonedx-bom-tool?logo=readthedocs&logoColor=white
@@ -122,7 +129,6 @@ See the [LICENSE][license_file] file for the full license.
 [shield_slack]: https://img.shields.io/badge/slack-join-blue?logo=Slack&logoColor=white "slack join"
 [shield_groups]: https://img.shields.io/badge/discussion-groups.io-blue.svg "groups discussion"
 [shield_twitter-follow]: https://img.shields.io/badge/Twitter-follow-blue?logo=Twitter&logoColor=white "twitter follow"
-[link_rtfd]: https://cyclonedx-bom-tool.readthedocs.io/
 [link_gh-workflow-test]: https://github.com/CycloneDX/cyclonedx-python/actions/workflows/python.yml?query=branch%3Amaster
 [link_pypi]: https://pypi.org/project/cyclonedx-bom/
 [link_docker]: https://hub.docker.com/r/cyclonedx/cyclonedx-python

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project provides a runnable Python-based application for generating Cyclone
 
 The BOM will contain an aggregate of all your current project's dependencies, or those defined by the manifest you supply.
 
-CycloneDX is a lightweight BOM specification that is easily created, human-readable, and simple to parse.
+[CycloneDX](https://cyclonedx.org/) is a lightweight BOM specification that is easily created, human-readable, and simple to parse.
 
 Read the full [documentation][link_rtfd] for more details.
 


### PR DESCRIPTION
added/fixed some links to the docs in RTFD
reminder: the short form for `readthedocs` is `RTFD` - like in https://rtfd.io
