### PR TITLE
remove index=pypi attribute requirement for pipenv hash inclusion

### DIFF
--- a/cyclonedx_py/parser/pipenv.py
+++ b/cyclonedx_py/parser/pipenv.py
@@ -44,7 +44,7 @@ class PipEnvParser(BaseParser):
                     type='pypi', name=package_name, version=str(package_data.get('version') or 'unknown').lstrip('=')
                 )
             )
-            if package_data.get('index') == 'pypi' and isinstance(package_data.get('hashes'), list):
+            if isinstance(package_data.get('hashes'), list):
                 # Add download location with hashes stored in Pipfile.lock
                 for pip_hash in package_data['hashes']:
                     ext_ref = ExternalReference(

--- a/tests/test_parser_pipenv.py
+++ b/tests/test_parser_pipenv.py
@@ -50,7 +50,8 @@ class TestPipEnvParser(TestCase):
 
         self.assertEqual('anyio', c_anyio.name)
         self.assertEqual('3.3.3', c_anyio.version)
-        self.assertEqual(0, len(c_anyio.external_references), f'{c_anyio.external_references}')
+        self.assertEqual(2, len(c_anyio.external_references), f'{c_anyio.external_references}')
+        self.assertEqual(1, len(c_anyio.external_references.pop().hashes))
 
         self.assertEqual('toml', c_toml.name)
         self.assertEqual('0.10.2', c_toml.version)


### PR DESCRIPTION
Signed-off-by: sleightsec <69399725+sleightsec@users.noreply.github.com>

fixes #347 