### PR TITLE
feat: set Component `bom_ref` to match `purl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ SBOM Output Configuration:
                         to STDOUT)
   -F, --force           If outputting to a file and the stated file already
                         exists, it will be overwritten.
+  -pb, --purl-bom-ref   Use a component's purl for the bom-ref value, instead
+                        of a random UUID
 ```
 
 ### Advanced usage and details

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -231,6 +231,10 @@ class CycloneDxCmd:
             '-F', '--force', action='store_true', dest='output_file_overwrite',
             help='If outputting to a file and the stated file already exists, it will be overwritten.'
         )
+        output_group.add_argument(
+            '-pb', '--purl-bom-ref', action='store_true', dest='use_purl_bom_ref',
+            help='Use a component''s purl for the bom-ref value, instead of a random UUID'
+        )
 
         arg_parser.add_argument('-X', action='store_true', help='Enable debug output', dest='debug_enabled')
 
@@ -279,15 +283,20 @@ class CycloneDxCmd:
             input_data_fh.close()
 
         if self._arguments.input_from_conda_explicit:
-            return CondaListExplicitParser(conda_data=input_data)
+            return CondaListExplicitParser(conda_data=input_data,
+                                           use_purl_bom_ref=self._arguments.use_purl_bom_ref)
         elif self._arguments.input_from_conda_json:
-            return CondaListJsonParser(conda_data=input_data)
+            return CondaListJsonParser(conda_data=input_data,
+                                       use_purl_bom_ref=self._arguments.use_purl_bom_ref)
         elif self._arguments.input_from_pip:
-            return PipEnvParser(pipenv_contents=input_data)
+            return PipEnvParser(pipenv_contents=input_data,
+                                use_purl_bom_ref=self._arguments.use_purl_bom_ref)
         elif self._arguments.input_from_poetry:
-            return PoetryParser(poetry_lock_contents=input_data)
+            return PoetryParser(poetry_lock_contents=input_data,
+                                use_purl_bom_ref=self._arguments.use_purl_bom_ref)
         elif self._arguments.input_from_requirements:
-            return RequirementsParser(requirements_content=input_data)
+            return RequirementsParser(requirements_content=input_data,
+                                      use_purl_bom_ref=self._arguments.use_purl_bom_ref)
         else:
             raise CycloneDxCmdException('Parser type could not be determined.')
 

--- a/cyclonedx_py/parser/conda.py
+++ b/cyclonedx_py/parser/conda.py
@@ -37,11 +37,11 @@ class _BaseCondaParser(BaseParser, metaclass=ABCMeta):
     """Internal abstract parser - not for programmatic use.
     """
 
-    def __init__(self, conda_data: str) -> None:
+    def __init__(self, conda_data: str, use_purl_bom_ref: bool = False) -> None:
         super().__init__()
         self._conda_packages: List[CondaPackage] = []
         self._parse_to_conda_packages(data_str=conda_data)
-        self._conda_packages_to_components()
+        self._conda_packages_to_components(use_purl_bom_ref=use_purl_bom_ref)
 
     @abstractmethod
     def _parse_to_conda_packages(self, data_str: str) -> None:
@@ -56,15 +56,16 @@ class _BaseCondaParser(BaseParser, metaclass=ABCMeta):
         """
         pass
 
-    def _conda_packages_to_components(self) -> None:
+    def _conda_packages_to_components(self, use_purl_bom_ref: bool) -> None:
         """
         Converts the parsed `CondaPackage` instances into `Component` instances.
 
         """
         for conda_package in self._conda_packages:
             purl = conda_package_to_purl(conda_package)
+            bom_ref = purl.to_string() if use_purl_bom_ref else None
             c = Component(
-                name=conda_package['name'], bom_ref=purl.to_string(), version=conda_package['version'],
+                name=conda_package['name'], bom_ref=bom_ref, version=conda_package['version'],
                 purl=purl
             )
             c.external_references.add(ExternalReference(

--- a/cyclonedx_py/parser/conda.py
+++ b/cyclonedx_py/parser/conda.py
@@ -60,11 +60,10 @@ class _BaseCondaParser(BaseParser, metaclass=ABCMeta):
 
         """
         for conda_package in self._conda_packages:
+            purl = PackageURL(type='pypi', name=conda_package['name'], version=str(conda_package['version']))
             c = Component(
-                name=conda_package['name'], version=str(conda_package['version']),
-                purl=PackageURL(
-                    type='pypi', name=conda_package['name'], version=str(conda_package['version'])
-                )
+                name=conda_package['name'], bom_ref=purl.to_string(), version=str(conda_package['version']),
+                purl=purl
             )
             c.external_references.add(ExternalReference(
                 reference_type=ExternalReferenceType.DISTRIBUTION,

--- a/cyclonedx_py/parser/conda.py
+++ b/cyclonedx_py/parser/conda.py
@@ -64,7 +64,7 @@ class _BaseCondaParser(BaseParser, metaclass=ABCMeta):
         for conda_package in self._conda_packages:
             purl = conda_package_to_purl(conda_package)
             c = Component(
-                name=conda_package['name'], bom_ref=purl.to_string(), version=str(conda_package['version']),
+                name=conda_package['name'], bom_ref=purl.to_string(), version=conda_package['version'],
                 purl=purl
             )
             c.external_references.add(ExternalReference(

--- a/cyclonedx_py/parser/environment.py
+++ b/cyclonedx_py/parser/environment.py
@@ -59,9 +59,8 @@ class EnvironmentParser(BaseParser):
 
         i: DistInfoDistribution
         for i in iter(pkg_resources.working_set):
-            c = Component(name=i.project_name, version=i.version, purl=PackageURL(
-                type='pypi', name=i.project_name, version=i.version
-            ))
+            purl = PackageURL(type='pypi', name=i.project_name, version=i.version)
+            c = Component(name=i.project_name, bom_ref=purl.to_string(), version=i.version, purl=purl)
 
             i_metadata = self._get_metadata_for_package(i.project_name)
             if 'Author' in i_metadata:

--- a/cyclonedx_py/parser/environment.py
+++ b/cyclonedx_py/parser/environment.py
@@ -55,7 +55,7 @@ class EnvironmentParser(BaseParser):
     Best used when you have virtual Python environments per project.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, use_purl_bom_ref: bool = False) -> None:
         super().__init__()
 
         import pkg_resources
@@ -63,7 +63,8 @@ class EnvironmentParser(BaseParser):
         i: DistInfoDistribution
         for i in iter(pkg_resources.working_set):
             purl = PackageURL(type='pypi', name=i.project_name, version=i.version)
-            c = Component(name=i.project_name, bom_ref=purl.to_string(), version=i.version, purl=purl)
+            bom_ref = purl.to_string() if use_purl_bom_ref else None
+            c = Component(name=i.project_name, bom_ref=bom_ref, version=i.version, purl=purl)
 
             i_metadata = self._get_metadata_for_package(i.project_name)
             if 'Author' in i_metadata:

--- a/cyclonedx_py/parser/pipenv.py
+++ b/cyclonedx_py/parser/pipenv.py
@@ -30,7 +30,7 @@ from packageurl import PackageURL  # type: ignore
 
 class PipEnvParser(BaseParser):
 
-    def __init__(self, pipenv_contents: str) -> None:
+    def __init__(self, pipenv_contents: str, use_purl_bom_ref: bool = False) -> None:
         super().__init__()
 
         pipfile_lock_contents = json.loads(pipenv_contents)
@@ -39,7 +39,8 @@ class PipEnvParser(BaseParser):
         for (package_name, package_data) in pipfile_default.items():
             version = str(package_data.get('version') or 'unknown').lstrip('=')
             purl = PackageURL(type='pypi', name=package_name, version=version)
-            c = Component(name=package_name, bom_ref=purl.to_string(), version=version, purl=purl)
+            bom_ref = purl.to_string() if use_purl_bom_ref else None
+            c = Component(name=package_name, bom_ref=bom_ref, version=version, purl=purl)
             if isinstance(package_data.get('hashes'), list):
                 # Add download location with hashes stored in Pipfile.lock
                 for pip_hash in package_data['hashes']:
@@ -56,6 +57,6 @@ class PipEnvParser(BaseParser):
 
 class PipEnvFileParser(PipEnvParser):
 
-    def __init__(self, pipenv_lock_filename: str) -> None:
+    def __init__(self, pipenv_lock_filename: str, use_purl_bom_ref: bool = False) -> None:
         with open(pipenv_lock_filename) as r:
-            super(PipEnvFileParser, self).__init__(pipenv_contents=r.read())
+            super(PipEnvFileParser, self).__init__(pipenv_contents=r.read(), use_purl_bom_ref=use_purl_bom_ref)

--- a/cyclonedx_py/parser/pipenv.py
+++ b/cyclonedx_py/parser/pipenv.py
@@ -37,13 +37,9 @@ class PipEnvParser(BaseParser):
         pipfile_default: Dict[str, Dict[str, Any]] = pipfile_lock_contents.get('default') or {}
 
         for (package_name, package_data) in pipfile_default.items():
-            c = Component(
-                name=package_name,
-                version=str(package_data.get('version') or 'unknown').lstrip('='),
-                purl=PackageURL(
-                    type='pypi', name=package_name, version=str(package_data.get('version') or 'unknown').lstrip('=')
-                )
-            )
+            version = str(package_data.get('version') or 'unknown').lstrip('=')
+            purl = PackageURL(type='pypi', name=package_name, version=version)
+            c = Component(name=package_name, bom_ref=purl.to_string(), version=version, purl=purl)
             if isinstance(package_data.get('hashes'), list):
                 # Add download location with hashes stored in Pipfile.lock
                 for pip_hash in package_data['hashes']:

--- a/cyclonedx_py/parser/poetry.py
+++ b/cyclonedx_py/parser/poetry.py
@@ -29,14 +29,15 @@ from toml import loads as load_toml
 
 class PoetryParser(BaseParser):
 
-    def __init__(self, poetry_lock_contents: str) -> None:
+    def __init__(self, poetry_lock_contents: str, use_purl_bom_ref: bool = False) -> None:
         super().__init__()
         poetry_lock = load_toml(poetry_lock_contents)
 
         for package in poetry_lock['package']:
             purl = PackageURL(type='pypi', name=package['name'], version=package['version'])
+            bom_ref = purl.to_string() if use_purl_bom_ref else None
             component = Component(
-                name=package['name'], bom_ref=purl.to_string(), version=package['version'],
+                name=package['name'], bom_ref=bom_ref, version=package['version'],
                 purl=purl
             )
 
@@ -57,6 +58,6 @@ class PoetryParser(BaseParser):
 
 class PoetryFileParser(PoetryParser):
 
-    def __init__(self, poetry_lock_filename: str) -> None:
+    def __init__(self, poetry_lock_filename: str, use_purl_bom_ref: bool = False) -> None:
         with open(poetry_lock_filename) as r:
-            super(PoetryFileParser, self).__init__(poetry_lock_contents=r.read())
+            super(PoetryFileParser, self).__init__(poetry_lock_contents=r.read(), use_purl_bom_ref=use_purl_bom_ref)

--- a/cyclonedx_py/parser/poetry.py
+++ b/cyclonedx_py/parser/poetry.py
@@ -34,10 +34,10 @@ class PoetryParser(BaseParser):
         poetry_lock = load_toml(poetry_lock_contents)
 
         for package in poetry_lock['package']:
+            purl = PackageURL(type='pypi', name=package['name'], version=package['version'])
             component = Component(
-                name=package['name'], version=package['version'], purl=PackageURL(
-                    type='pypi', name=package['name'], version=package['version']
-                )
+                name=package['name'], bom_ref=purl.to_string(), version=package['version'],
+                purl=purl
             )
 
             for file_metadata in poetry_lock['metadata']['files'][package['name']]:

--- a/cyclonedx_py/parser/requirements.py
+++ b/cyclonedx_py/parser/requirements.py
@@ -63,11 +63,13 @@ class RequirementsParser(BaseParser):
                     )
                 )
             else:
+                purl = PackageURL(type='pypi', name=name, version=version)
                 self._components.append(Component(
                     name=name,
+                    bom_ref=purl.to_string(),
                     version=version,
                     hashes=hashes,
-                    purl=PackageURL(type='pypi', name=name, version=version)
+                    purl=purl
                 ))
 
         if requirements_file:

--- a/cyclonedx_py/parser/requirements.py
+++ b/cyclonedx_py/parser/requirements.py
@@ -33,7 +33,7 @@ from pip_requirements_parser import RequirementsFile  # type: ignore
 
 class RequirementsParser(BaseParser):
 
-    def __init__(self, requirements_content: str) -> None:
+    def __init__(self, requirements_content: str, use_purl_bom_ref: bool = False) -> None:
         super().__init__()
         parsed_rf: Optional[RequirementsFile] = None
         requirements_file: Optional[_TemporaryFileWrapper[Any]] = None
@@ -64,9 +64,10 @@ class RequirementsParser(BaseParser):
                 )
             else:
                 purl = PackageURL(type='pypi', name=name, version=version)
+                bom_ref = purl.to_string() if use_purl_bom_ref else None
                 self._components.append(Component(
                     name=name,
-                    bom_ref=purl.to_string(),
+                    bom_ref=bom_ref,
                     version=version,
                     hashes=hashes,
                     purl=purl
@@ -78,5 +79,5 @@ class RequirementsParser(BaseParser):
 
 class RequirementsFileParser(RequirementsParser):
 
-    def __init__(self, requirements_file: str) -> None:
-        super().__init__(requirements_content=requirements_file)
+    def __init__(self, requirements_file: str, use_purl_bom_ref: bool = False) -> None:
+        super().__init__(requirements_content=requirements_file, use_purl_bom_ref=use_purl_bom_ref)

--- a/tests/test_parser_conda.py
+++ b/tests/test_parser_conda.py
@@ -39,6 +39,7 @@ class TestCondaParser(TestCase):
         c_idna = next(filter(lambda c: c.name == 'idna', components), None)
         self.assertIsNotNone(c_idna)
         self.assertEqual('idna', c_idna.name)
+        self.assertEqual(c_idna.purl.to_string(), c_idna.bom_ref.value)
         self.assertEqual('2.10', c_idna.version)
         self.assertEqual(1, len(c_idna.external_references), f'{c_idna.external_references}')
         self.assertEqual(0, len(c_idna.external_references.pop().hashes))

--- a/tests/test_parser_conda.py
+++ b/tests/test_parser_conda.py
@@ -41,6 +41,28 @@ class TestCondaParser(TestCase):
         c_idna = next(filter(lambda c: c.name == 'idna', components), None)
         self.assertIsNotNone(c_idna)
         self.assertEqual('idna', c_idna.name)
+        self.assertNotEqual(c_idna.purl.to_string(), c_idna.bom_ref.value)
+        self.assertEqual('2.10', c_idna.version)
+        self.assertEqual('pkg:conda/idna@2.10?build=pyhd3eb1b0_0&channel=pkgs/main&subdir=noarch',
+                         c_idna.purl.to_string())
+        self.assertEqual(1, len(c_idna.external_references), f'{c_idna.external_references}')
+        self.assertEqual(0, len(c_idna.external_references.pop().hashes))
+        self.assertEqual(0, len(c_idna.hashes), f'{c_idna.hashes}')
+
+    def test_conda_list_json_use_purl_bom_ref(self) -> None:
+        conda_list_output_file = os.path.join(os.path.dirname(__file__),
+                                              'fixtures/conda-list-output.json')
+
+        with (open(conda_list_output_file, 'r')) as conda_list_output_fh:
+            parser = CondaListJsonParser(conda_data=conda_list_output_fh.read(),
+                                         use_purl_bom_ref=True)
+
+        self.assertEqual(34, parser.component_count())
+        components = parser.get_components()
+
+        c_idna = next(filter(lambda c: c.name == 'idna', components), None)
+        self.assertIsNotNone(c_idna)
+        self.assertEqual('idna', c_idna.name)
         self.assertEqual(c_idna.purl.to_string(), c_idna.bom_ref.value)
         self.assertEqual('2.10', c_idna.version)
         self.assertEqual('pkg:conda/idna@2.10?build=pyhd3eb1b0_0&channel=pkgs/main&subdir=noarch',

--- a/tests/test_parser_environment.py
+++ b/tests/test_parser_environment.py
@@ -37,6 +37,23 @@ class TestEnvironmentParser(TestCase):
         # We can only be sure that tox is in the environment, for example as we use tox to run tests
         c_tox = next(filter(lambda c: c.name == 'tox', parser.get_components()), None)
         self.assertIsNotNone(c_tox)
+        self.assertNotEqual(c_tox.purl.to_string(), c_tox.bom_ref.value)
+        self.assertIsNotNone(c_tox.licenses)
+        self.assertEqual('MIT', c_tox.licenses.pop().expression)
+
+    def test_simple_use_purl_bom_ref(self) -> None:
+        """
+        @todo This test is a vague as it will detect the unique environment where tests are being executed -
+                so is this valid?
+
+        :return:
+        """
+        parser = EnvironmentParser(use_purl_bom_ref=True)
+        self.assertGreater(parser.component_count(), 1)
+
+        # We can only be sure that tox is in the environment, for example as we use tox to run tests
+        c_tox = next(filter(lambda c: c.name == 'tox', parser.get_components()), None)
+        self.assertIsNotNone(c_tox)
         self.assertEqual(c_tox.purl.to_string(), c_tox.bom_ref.value)
         self.assertIsNotNone(c_tox.licenses)
         self.assertEqual('MIT', c_tox.licenses.pop().expression)

--- a/tests/test_parser_environment.py
+++ b/tests/test_parser_environment.py
@@ -37,5 +37,6 @@ class TestEnvironmentParser(TestCase):
         # We can only be sure that tox is in the environment, for example as we use tox to run tests
         c_tox = next(filter(lambda c: c.name == 'tox', parser.get_components()), None)
         self.assertIsNotNone(c_tox)
+        self.assertEqual(c_tox.purl.to_string(), c_tox.bom_ref.value)
         self.assertIsNotNone(c_tox.licenses)
         self.assertEqual('MIT', c_tox.licenses.pop().expression)

--- a/tests/test_parser_pipenv.py
+++ b/tests/test_parser_pipenv.py
@@ -33,6 +33,7 @@ class TestPipEnvParser(TestCase):
         c_toml = next(filter(lambda c: c.name == 'toml', parser.get_components()), None)
         self.assertIsNotNone(c_toml)
         self.assertEqual('toml', c_toml.name)
+        self.assertEqual(c_toml.purl.to_string(), c_toml.bom_ref.value)
         self.assertEqual('0.10.2', c_toml.version)
         self.assertEqual(2, len(c_toml.external_references), f'{c_toml.external_references}')
         self.assertEqual(1, len(c_toml.external_references.pop().hashes))

--- a/tests/test_parser_pipenv.py
+++ b/tests/test_parser_pipenv.py
@@ -33,6 +33,19 @@ class TestPipEnvParser(TestCase):
         c_toml = next(filter(lambda c: c.name == 'toml', parser.get_components()), None)
         self.assertIsNotNone(c_toml)
         self.assertEqual('toml', c_toml.name)
+        self.assertNotEqual(c_toml.purl.to_string(), c_toml.bom_ref.value)
+        self.assertEqual('0.10.2', c_toml.version)
+        self.assertEqual(2, len(c_toml.external_references), f'{c_toml.external_references}')
+        self.assertEqual(1, len(c_toml.external_references.pop().hashes))
+
+    def test_simple_use_purl_bom_ref(self) -> None:
+        tests_pipfile_lock = os.path.join(os.path.dirname(__file__), 'fixtures/pipfile-lock-simple.txt')
+
+        parser = PipEnvFileParser(pipenv_lock_filename=tests_pipfile_lock, use_purl_bom_ref=True)
+        self.assertEqual(1, parser.component_count())
+        c_toml = next(filter(lambda c: c.name == 'toml', parser.get_components()), None)
+        self.assertIsNotNone(c_toml)
+        self.assertEqual('toml', c_toml.name)
         self.assertEqual(c_toml.purl.to_string(), c_toml.bom_ref.value)
         self.assertEqual('0.10.2', c_toml.version)
         self.assertEqual(2, len(c_toml.external_references), f'{c_toml.external_references}')

--- a/tests/test_parser_poetry.py
+++ b/tests/test_parser_poetry.py
@@ -33,5 +33,6 @@ class TestPoetryParser(TestCase):
         component = next(filter(lambda c: c.name == 'toml', parser.get_components()), None)
         self.assertIsNotNone(component)
         self.assertEqual('toml', component.name)
+        self.assertEqual(component.purl.to_string(), component.bom_ref.value)
         self.assertEqual('0.10.2', component.version)
         self.assertEqual(2, len(component.external_references), f'{component.external_references}')

--- a/tests/test_parser_poetry.py
+++ b/tests/test_parser_poetry.py
@@ -33,6 +33,18 @@ class TestPoetryParser(TestCase):
         component = next(filter(lambda c: c.name == 'toml', parser.get_components()), None)
         self.assertIsNotNone(component)
         self.assertEqual('toml', component.name)
+        self.assertNotEqual(component.purl.to_string(), component.bom_ref.value)
+        self.assertEqual('0.10.2', component.version)
+        self.assertEqual(2, len(component.external_references), f'{component.external_references}')
+
+    def test_simple_purl_bom_ref(self) -> None:
+        tests_poetry_lock_file = os.path.join(os.path.dirname(__file__), 'fixtures/poetry-lock-simple.txt')
+
+        parser = PoetryFileParser(poetry_lock_filename=tests_poetry_lock_file, use_purl_bom_ref=True)
+        self.assertEqual(1, parser.component_count())
+        component = next(filter(lambda c: c.name == 'toml', parser.get_components()), None)
+        self.assertIsNotNone(component)
+        self.assertEqual('toml', component.name)
         self.assertEqual(component.purl.to_string(), component.bom_ref.value)
         self.assertEqual('0.10.2', component.version)
         self.assertEqual(2, len(component.external_references), f'{component.external_references}')

--- a/tests/test_parser_requirements.py
+++ b/tests/test_parser_requirements.py
@@ -35,6 +35,8 @@ class TestRequirementsParser(TestCase):
 
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(1, len(components), f'{components}')
+        for component in components:
+            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
 
     def test_example_1(self) -> None:
         with open(os.path.join(os.path.dirname(__file__),
@@ -46,6 +48,8 @@ class TestRequirementsParser(TestCase):
 
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(3, len(components), f'{components}')
+        for component in components:
+            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
 
     def test_example_with_comments(self) -> None:
         with open(os.path.join(os.path.dirname(__file__),
@@ -57,6 +61,8 @@ class TestRequirementsParser(TestCase):
 
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(5, len(components), f'{components}')
+        for component in components:
+            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
 
     def test_example_multilines_with_comments(self) -> None:
         with open(os.path.join(os.path.dirname(__file__),
@@ -68,6 +74,8 @@ class TestRequirementsParser(TestCase):
 
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(1, len(components), f'{components}')
+        for component in components:
+            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
 
     def test_example_local_packages(self) -> None:
         with open(os.path.join(os.path.dirname(__file__),
@@ -79,6 +87,8 @@ class TestRequirementsParser(TestCase):
 
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(6, len(components), f'{components}')
+        for component in components:
+            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
 
     def test_example_local_and_nested_packages(self) -> None:
         # RequirementsFileParser can parse nested requirements files,
@@ -91,6 +101,8 @@ class TestRequirementsParser(TestCase):
 
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(7, len(components), f'{components}')
+        for component in components:
+            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
 
     def test_example_private_packages(self) -> None:
         with open(os.path.join(os.path.dirname(__file__),
@@ -102,6 +114,8 @@ class TestRequirementsParser(TestCase):
 
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(1, len(components), f'{components}')
+        for component in components:
+            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
 
     def test_example_with_urls(self) -> None:
         with open(os.path.join(os.path.dirname(__file__),
@@ -113,6 +127,8 @@ class TestRequirementsParser(TestCase):
 
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(4, len(components), f'{components}')
+        for component in components:
+            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
 
     def test_example_with_hashes(self) -> None:
         with open(os.path.join(os.path.dirname(__file__),
@@ -124,6 +140,8 @@ class TestRequirementsParser(TestCase):
 
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(5, len(components), f'{components}')
+        for component in components:
+            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
 
     def test_example_without_pinned_versions_warns(self) -> None:
         with open(os.path.join(os.path.dirname(__file__),
@@ -135,3 +153,5 @@ class TestRequirementsParser(TestCase):
 
         self.assertEqual(2, len(components), f'{components}')
         self.assertTrue(parser.has_warnings(), f'{parser.get_warnings()}')
+        for component in components:
+            self.assertEqual(component.purl.to_string(), component.bom_ref.value)

--- a/tests/test_parser_requirements.py
+++ b/tests/test_parser_requirements.py
@@ -39,6 +39,20 @@ class TestRequirementsParser(TestCase):
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(1, len(components), f'{components}')
         for component in components:
+            self.assertNotEqual(component.purl.to_string(), component.bom_ref.value)
+
+    def test_simple_use_purl_bom_ref(self) -> None:
+        with open(os.path.join(os.path.dirname(__file__),
+                               'fixtures/requirements-simple.txt')) as r:
+            parser = RequirementsParser(
+                requirements_content=r.read(),
+                use_purl_bom_ref=True
+            )
+        components = parser.get_components()
+
+        self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
+        self.assertEqual(1, len(components), f'{components}')
+        for component in components:
             self.assertEqual(component.purl.to_string(), component.bom_ref.value)
 
     def test_example_1(self) -> None:
@@ -52,7 +66,7 @@ class TestRequirementsParser(TestCase):
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(3, len(components), f'{components}')
         for component in components:
-            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
+            self.assertNotEqual(component.purl.to_string(), component.bom_ref.value)
 
     def test_example_with_comments(self) -> None:
         with open(os.path.join(os.path.dirname(__file__),
@@ -65,7 +79,7 @@ class TestRequirementsParser(TestCase):
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(5, len(components), f'{components}')
         for component in components:
-            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
+            self.assertNotEqual(component.purl.to_string(), component.bom_ref.value)
 
     def test_example_multilines_with_comments(self) -> None:
         with open(os.path.join(os.path.dirname(__file__),
@@ -78,7 +92,7 @@ class TestRequirementsParser(TestCase):
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(1, len(components), f'{components}')
         for component in components:
-            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
+            self.assertNotEqual(component.purl.to_string(), component.bom_ref.value)
 
         c0: Component = components[0]
         self.assertEqual(1, len(c0.hashes))
@@ -97,7 +111,7 @@ class TestRequirementsParser(TestCase):
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(6, len(components), f'{components}')
         for component in components:
-            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
+            self.assertNotEqual(component.purl.to_string(), component.bom_ref.value)
 
     def test_example_local_and_nested_packages(self) -> None:
         # RequirementsFileParser can parse nested requirements files,
@@ -111,7 +125,7 @@ class TestRequirementsParser(TestCase):
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(7, len(components), f'{components}')
         for component in components:
-            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
+            self.assertNotEqual(component.purl.to_string(), component.bom_ref.value)
 
     def test_example_private_packages(self) -> None:
         with open(os.path.join(os.path.dirname(__file__),
@@ -124,7 +138,7 @@ class TestRequirementsParser(TestCase):
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(1, len(components), f'{components}')
         for component in components:
-            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
+            self.assertNotEqual(component.purl.to_string(), component.bom_ref.value)
 
     def test_example_with_urls(self) -> None:
         with open(os.path.join(os.path.dirname(__file__),
@@ -137,7 +151,7 @@ class TestRequirementsParser(TestCase):
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(4, len(components), f'{components}')
         for component in components:
-            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
+            self.assertNotEqual(component.purl.to_string(), component.bom_ref.value)
 
     def test_example_with_hashes(self) -> None:
         with open(os.path.join(os.path.dirname(__file__),
@@ -150,7 +164,7 @@ class TestRequirementsParser(TestCase):
         self.assertFalse(parser.has_warnings(), f'{parser.get_warnings()}')
         self.assertEqual(5, len(components), f'{components}')
         for component in components:
-            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
+            self.assertNotEqual(component.purl.to_string(), component.bom_ref.value)
 
         c_idna = next(filter(lambda c: c.name == 'idna', components), None)
         self.assertIsNotNone(c_idna)
@@ -171,4 +185,4 @@ class TestRequirementsParser(TestCase):
         self.assertEqual(2, len(components), f'{components}')
         self.assertTrue(parser.has_warnings(), f'{parser.get_warnings()}')
         for component in components:
-            self.assertEqual(component.purl.to_string(), component.bom_ref.value)
+            self.assertNotEqual(component.purl.to_string(), component.bom_ref.value)


### PR DESCRIPTION
Partially addresses https://github.com/CycloneDX/cyclonedx-python/issues/355.

Add CLI argument to use purl.to_string() as bom_ref for Components. This should improve reproducibility.