### PR TITLE
feat: Update CLI to use File parsers

### DIFF
--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -30,11 +30,11 @@ from cyclonedx.model.bom import Bom
 from cyclonedx.output import BaseOutput, OutputFormat, SchemaVersion, get_instance as get_output_instance
 from cyclonedx.parser import BaseParser
 
-from .parser.conda import CondaListExplicitParser, CondaListJsonParser
+from .parser.conda import CondaListExplicitFileParser, CondaListJsonFileParser
 from .parser.environment import EnvironmentParser
-from .parser.pipenv import PipEnvParser
-from .parser.poetry import PoetryParser
-from .parser.requirements import RequirementsParser
+from .parser.pipenv import PipEnvFileParser
+from .parser.poetry import PoetryFileParser
+from .parser.requirements import RequirementsFileParser
 
 
 class CycloneDxCmdException(Exception):
@@ -277,26 +277,26 @@ class CycloneDxCmd:
                     f'No input file was supplied and no input was provided on STDIN:\n{str(e)}'
                 )
 
-        input_data_fh = self._arguments.input_source
-        with input_data_fh:
-            input_data = input_data_fh.read()
-            input_data_fh.close()
-
         if self._arguments.input_from_conda_explicit:
-            return CondaListExplicitParser(conda_data=input_data,
-                                           use_purl_bom_ref=self._arguments.use_purl_bom_ref)
+            return CondaListExplicitFileParser(
+                conda_filename=self._arguments.input_source,
+                use_purl_bom_ref=self._arguments.use_purl_bom_ref)
         elif self._arguments.input_from_conda_json:
-            return CondaListJsonParser(conda_data=input_data,
-                                       use_purl_bom_ref=self._arguments.use_purl_bom_ref)
+            return CondaListJsonFileParser(
+                conda_filename=self._arguments.input_source,
+                use_purl_bom_ref=self._arguments.use_purl_bom_ref)
         elif self._arguments.input_from_pip:
-            return PipEnvParser(pipenv_contents=input_data,
-                                use_purl_bom_ref=self._arguments.use_purl_bom_ref)
+            return PipEnvFileParser(
+                pipenv_filename=self._arguments.input_source,
+                use_purl_bom_ref=self._arguments.use_purl_bom_ref)
         elif self._arguments.input_from_poetry:
-            return PoetryParser(poetry_lock_contents=input_data,
-                                use_purl_bom_ref=self._arguments.use_purl_bom_ref)
+            return PoetryFileParser(
+                poetry_lock_filename=self._arguments.input_source,
+                use_purl_bom_ref=self._arguments.use_purl_bom_ref)
         elif self._arguments.input_from_requirements:
-            return RequirementsParser(requirements_content=input_data,
-                                      use_purl_bom_ref=self._arguments.use_purl_bom_ref)
+            return RequirementsFileParser(
+                requirements_filename=self._arguments.input_source,
+                use_purl_bom_ref=self._arguments.use_purl_bom_ref)
         else:
             raise CycloneDxCmdException('Parser type could not be determined.')
 

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -287,7 +287,7 @@ class CycloneDxCmd:
                 use_purl_bom_ref=self._arguments.use_purl_bom_ref)
         elif self._arguments.input_from_pip:
             return PipEnvFileParser(
-                pipenv_filename=self._arguments.input_source,
+                pipenv_lock_filename=self._arguments.input_source,
                 use_purl_bom_ref=self._arguments.use_purl_bom_ref)
         elif self._arguments.input_from_poetry:
             return PoetryFileParser(

--- a/cyclonedx_py/parser/conda.py
+++ b/cyclonedx_py/parser/conda.py
@@ -96,6 +96,13 @@ class CondaListJsonParser(_BaseCondaParser):
                 self._conda_packages.append(conda_package)
 
 
+class CondaListJsonFileParser(CondaListJsonParser):
+
+    def __init__(self, conda_filename: str, use_purl_bom_ref: bool = False) -> None:
+        with open(conda_filename) as r:
+            super(CondaListJsonFileParser, self).__init__(conda_data=r.read(), use_purl_bom_ref=use_purl_bom_ref)
+
+
 class CondaListExplicitParser(_BaseCondaParser):
     """
     This parser is intended to receive the output from the command `conda list --explicit` or
@@ -108,3 +115,10 @@ class CondaListExplicitParser(_BaseCondaParser):
             conda_package = parse_conda_list_str_to_conda_package(conda_list_str=line)
             if conda_package:
                 self._conda_packages.append(conda_package)
+
+
+class CondaListExplicitFileParser(CondaListExplicitParser):
+
+    def __init__(self, conda_filename: str, use_purl_bom_ref: bool = False) -> None:
+        with open(conda_filename) as r:
+            super(CondaListExplicitFileParser, self).__init__(conda_data=r.read(), use_purl_bom_ref=use_purl_bom_ref)

--- a/tests/test_parser_pipenv.py
+++ b/tests/test_parser_pipenv.py
@@ -20,10 +20,24 @@
 import os
 from unittest import TestCase
 
-from cyclonedx_py.parser.pipenv import PipEnvFileParser
+from cyclonedx_py.parser.pipenv import PipEnvFileParser, PipEnvParser
 
 
 class TestPipEnvParser(TestCase):
+
+    def test_simple_parser(self) -> None:
+        tests_pipfile_lock = os.path.join(os.path.dirname(__file__), 'fixtures/pipfile-lock-simple.txt')
+        with (open(tests_pipfile_lock, 'r')) as tests_pipfile_lock_fh:
+            parser = PipEnvParser(pipenv_contents=tests_pipfile_lock_fh.read())
+
+        self.assertEqual(1, parser.component_count())
+        c_toml = next(filter(lambda c: c.name == 'toml', parser.get_components()), None)
+        self.assertIsNotNone(c_toml)
+        self.assertEqual('toml', c_toml.name)
+        self.assertNotEqual(c_toml.purl.to_string(), c_toml.bom_ref.value)
+        self.assertEqual('0.10.2', c_toml.version)
+        self.assertEqual(2, len(c_toml.external_references), f'{c_toml.external_references}')
+        self.assertEqual(1, len(c_toml.external_references.pop().hashes))
 
     def test_simple(self) -> None:
         tests_pipfile_lock = os.path.join(os.path.dirname(__file__), 'fixtures/pipfile-lock-simple.txt')

--- a/tests/test_parser_poetry.py
+++ b/tests/test_parser_poetry.py
@@ -20,10 +20,23 @@
 import os
 from unittest import TestCase
 
-from cyclonedx_py.parser.poetry import PoetryFileParser
+from cyclonedx_py.parser.poetry import PoetryFileParser, PoetryParser
 
 
 class TestPoetryParser(TestCase):
+
+    def test_simple_parser(self) -> None:
+        tests_poetry_lock_file = os.path.join(os.path.dirname(__file__), 'fixtures/poetry-lock-simple.txt')
+        with (open(tests_poetry_lock_file, 'r')) as tests_poetry_lock_file_fh:
+            parser = PoetryParser(poetry_lock_contents=tests_poetry_lock_file_fh.read())
+
+        self.assertEqual(1, parser.component_count())
+        component = next(filter(lambda c: c.name == 'toml', parser.get_components()), None)
+        self.assertIsNotNone(component)
+        self.assertEqual('toml', component.name)
+        self.assertNotEqual(component.purl.to_string(), component.bom_ref.value)
+        self.assertEqual('0.10.2', component.version)
+        self.assertEqual(2, len(component.external_references), f'{component.external_references}')
 
     def test_simple(self) -> None:
         tests_poetry_lock_file = os.path.join(os.path.dirname(__file__), 'fixtures/poetry-lock-simple.txt')

--- a/tests/test_parser_requirements.py
+++ b/tests/test_parser_requirements.py
@@ -117,8 +117,8 @@ class TestRequirementsParser(TestCase):
         # RequirementsFileParser can parse nested requirements files,
         # but RequirementsParser cannot.
         parser = RequirementsFileParser(
-            requirements_file=os.path.join(os.path.dirname(__file__),
-                                           'fixtures/requirements-local-and-remote-packages.txt')
+            requirements_filename=os.path.join(os.path.dirname(__file__),
+                                               'fixtures/requirements-local-and-remote-packages.txt')
         )
         components = parser.get_components()
 


### PR DESCRIPTION
This moves the file reading into the parser, allowing for the CLI to to read nested files (using `RequirementsFileReader`).

This introduces changes which may be considered breaking changes:
* Default CLI behaviour will be to read nested requirements.txt files.
* rename `requirements_filename` parameter for RequirementsFileParser to be consistent with other parsers

