### PR TITLE
docs: Minor updates to poetry usage details & contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Please sign your commits,
 to show that you agree to publish your changes under the current terms and licenses of the project.
 
 ```shell
-git commit --signed-off ...
+git commit --signoff ...
 ```
 
 [poetry]: https://python-poetry.org

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -108,7 +108,7 @@ As example:
 
 **Poetry**
 
-We support parsing your ``poetry.lock`` file which should be committed along with your ``pyrpoject.toml`` and details
+We support parsing your ``poetry.lock`` file which should be committed along with your ``pyproject.toml`` and details
 exact pinned versions.
 
 You can then run ``cyclonedx-bom`` as follows:


### PR DESCRIPTION
Hello,

This is just a small PR for a couple of documentation updates:

- I ran across a doc typo in the poetry usage instructions, for the [pyproject.toml](https://python-poetry.org/docs/pyproject/) file. 
- And in the contribution guidelines, I updated the [flag](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) for signing off on commits.

Thanks!