### PR TITLE
feat: option to choose license format

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ SBOM Output Configuration:
                         exists, it will be overwritten.
   -pb, --purl-bom-ref   Use a component's purl for the bom-ref value, instead
                         of a random UUID
+  --licence_output_format {expression,license} 
+                        The output format of the license of a component 
+                        (default: expression) 
 ```
 
 ### Advanced usage and details

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -32,6 +32,7 @@ from cyclonedx.parser import BaseParser
 
 from .parser.conda import CondaListExplicitParser, CondaListJsonParser
 from .parser.environment import EnvironmentParser
+from .parser.environment import LICENSE_OUTPUT_FORMAT
 from .parser.pipenv import PipEnvParser
 from .parser.poetry import PoetryParser
 from .parser.requirements import RequirementsParser
@@ -235,6 +236,12 @@ class CycloneDxCmd:
             '-pb', '--purl-bom-ref', action='store_true', dest='use_purl_bom_ref',
             help='Use a component''s purl for the bom-ref value, instead of a random UUID'
         )
+        output_group.add_argument(
+            '--license-format', action='store',
+            choices=[f.value for f in LICENSE_OUTPUT_FORMAT], default=LICENSE_OUTPUT_FORMAT.EXPRESSION.value,
+            help='The output format for licenses of components.',
+            dest='license_output_format'
+        )
 
         arg_parser.add_argument('-X', action='store_true', help='Enable debug output', dest='debug_enabled')
 
@@ -251,7 +258,7 @@ class CycloneDxCmd:
 
     def _get_input_parser(self) -> BaseParser:
         if self._arguments.input_from_environment:
-            return EnvironmentParser()
+            return EnvironmentParser(self._arguments.license_output_format)
 
         # All other Parsers will require some input - grab it now!
         if not self._arguments.input_source:

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -31,8 +31,7 @@ from cyclonedx.output import BaseOutput, OutputFormat, SchemaVersion, get_instan
 from cyclonedx.parser import BaseParser
 
 from .parser.conda import CondaListExplicitParser, CondaListJsonParser
-from .parser.environment import EnvironmentParser
-from .parser.environment import LICENSE_OUTPUT_FORMAT
+from .parser.environment import EnvironmentParser, LicenseOutputFormat
 from .parser.pipenv import PipEnvParser
 from .parser.poetry import PoetryParser
 from .parser.requirements import RequirementsParser
@@ -238,7 +237,7 @@ class CycloneDxCmd:
         )
         output_group.add_argument(
             '--license-format', action='store',
-            choices=[f.value for f in LICENSE_OUTPUT_FORMAT], default=LICENSE_OUTPUT_FORMAT.EXPRESSION.value,
+            choices=[f.value for f in LicenseOutputFormat], default=LicenseOutputFormat.EXPRESSION,
             help='The output format for licenses of components.',
             dest='license_output_format'
         )
@@ -258,7 +257,7 @@ class CycloneDxCmd:
 
     def _get_input_parser(self) -> BaseParser:
         if self._arguments.input_from_environment:
-            return EnvironmentParser(self._arguments.license_output_format)
+            return EnvironmentParser(licence_output_format=self._arguments.license_output_format)
 
         # All other Parsers will require some input - grab it now!
         if not self._arguments.input_source:

--- a/cyclonedx_py/parser/environment.py
+++ b/cyclonedx_py/parser/environment.py
@@ -28,8 +28,8 @@ The Environment Parsers support population of the following data about Component
 
 """
 
-import sys
 import enum
+import sys
 
 # See https://github.com/package-url/packageurl-python/issues/65
 from packageurl import PackageURL  # type: ignore
@@ -50,7 +50,7 @@ from cyclonedx.parser import BaseParser
 
 
 @enum.unique
-class LICENSE_OUTPUT_FORMAT(enum.Enum):
+class LicenseOutputFormat(enum.Enum):
     EXPRESSION = 'expression'
     LICENSE = 'license'
 
@@ -62,7 +62,8 @@ class EnvironmentParser(BaseParser):
     Best used when you have virtual Python environments per project.
     """
 
-    def __init__(self, use_purl_bom_ref: bool = False, licence_output_format: str = 'expression') -> None:
+    def __init__(self, use_purl_bom_ref: bool = False,
+                 licence_output_format: LicenseOutputFormat = LicenseOutputFormat.EXPRESSION) -> None:
         super().__init__()
 
         import pkg_resources
@@ -78,24 +79,23 @@ class EnvironmentParser(BaseParser):
                 c.author = i_metadata['Author']
 
             if 'License' in i_metadata and i_metadata['License'] != 'UNKNOWN':
-                if licence_output_format == 'expression':
+                if licence_output_format == LicenseOutputFormat.EXPRESSION:
                     c.licenses.add(LicenseChoice(license_expression=i_metadata['License']))
                 else:
                     c.licenses.add(LicenseChoice(license_=License(license_name=i_metadata['License'])))
 
             elif 'Classifier' in i_metadata:
-                for msg_header in i_metadata.items():
-                    if str(msg_header[0]) == 'Classifier' and \
-                            str(msg_header[1]).startswith('License :: OSI Approved :: '):
-                        class_license = str(msg_header[1]).replace('License :: OSI Approved :: ', "").strip()
-                        if licence_output_format == 'expression':
+                for cl_header in i_metadata.get_all(name='Classifier'):
+                    if str(cl_header).startswith('License :: OSI Approved :: '):
+                        cl_license = str(cl_header).replace('License :: OSI Approved :: ', "").strip()
+                        if licence_output_format == LicenseOutputFormat.EXPRESSION:
                             c.licenses.add(
                                 LicenseChoice(
-                                    license_expression=class_license
+                                    license_expression=cl_license
                                 )
                             )
                         else:
-                            c.licenses.add(LicenseChoice(license_=License(license_name=class_license)))
+                            c.licenses.add(LicenseChoice(license_=License(license_name=cl_license)))
 
             self._components.append(c)
 


### PR DESCRIPTION
**Updates**
- Added a new flag to choose the license format with default set to the original
- Updated the readme
- Fixed a bug when using the license from the classifier

**Important change**: the license classifier header will only be used if the license header is not available.
This codepath was not working before, it was looping over the different letters of the classifier values instead of looping over all the classifier headers.

**Note:** When choosing license as license output format, the SPDX expression is set as the license name property. The license format is not a  valid SPDX licenseID. So this PR will only add the ability to SEE the license. The matching will no actually work.
See comment from @madpah  in https://github.com/CycloneDX/cyclonedx-python/discussions/377

fixes #378