### PR TITLE
fix: properly declare licenses from environment

### DIFF
--- a/tests/test_parser_environment.py
+++ b/tests/test_parser_environment.py
@@ -39,7 +39,7 @@ class TestEnvironmentParser(TestCase):
         self.assertIsNotNone(c_tox)
         self.assertNotEqual(c_tox.purl.to_string(), c_tox.bom_ref.value)
         self.assertIsNotNone(c_tox.licenses)
-        self.assertEqual('MIT', c_tox.licenses.pop().expression)
+        self.assertEqual('MIT', c_tox.licenses.pop().license.name)
 
     def test_simple_use_purl_bom_ref(self) -> None:
         """
@@ -56,4 +56,4 @@ class TestEnvironmentParser(TestCase):
         self.assertIsNotNone(c_tox)
         self.assertEqual(c_tox.purl.to_string(), c_tox.bom_ref.value)
         self.assertIsNotNone(c_tox.licenses)
-        self.assertEqual('MIT', c_tox.licenses.pop().expression)
+        self.assertEqual('MIT', c_tox.licenses.pop().license.name)


### PR DESCRIPTION
current implementation uses SPDX license expressions for everything, instead of using license with name or wth spdx ids
this caused broken results.

better: use license with name for everything, as this cannot cause any malformed result.
Here is the fix.

closes #410