### PR TITLE
Fix classifier parsing in python 3.8 / python 3.9

### DIFF
--- a/cyclonedx_py/parser/environment.py
+++ b/cyclonedx_py/parser/environment.py
@@ -75,18 +75,17 @@ class EnvironmentParser(BaseParser):
                 # Therefore, just go with a named license.
                 c.licenses.add(LicenseChoice(license_=License(license_name=i_metadata['License'])))
 
-            if 'Classifier' in i_metadata:
-                for classifier in i_metadata['Classifier']:
-                    # Trove classifiers - https://packaging.python.org/specifications/core-metadata/#metadata-classifier
-                    # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
-                    if str(classifier).startswith('License :: OSI Approved :: '):
-                        c.licenses.add(LicenseChoice(license_=License(
-                            license_name=str(classifier).replace('License :: OSI Approved :: ', '').strip()
-                        )))
-                    elif str(classifier).startswith('License :: '):
-                        c.licenses.add(LicenseChoice(license_=License(
-                            license_name=str(classifier).replace('License :: ', '').strip()
-                        )))
+            for classifier in i_metadata.get_all("Classifier"):
+                # Trove classifiers - https://packaging.python.org/specifications/core-metadata/#metadata-classifier
+                # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
+                if str(classifier).startswith('License :: OSI Approved :: '):
+                    c.licenses.add(LicenseChoice(license_=License(
+                        license_name=str(classifier).replace('License :: OSI Approved :: ', '').strip()
+                    )))
+                elif str(classifier).startswith('License :: '):
+                    c.licenses.add(LicenseChoice(license_=License(
+                        license_name=str(classifier).replace('License :: ', '').strip()
+                    )))
 
             self._components.append(c)
 

--- a/tests/test_parser_environment.py
+++ b/tests/test_parser_environment.py
@@ -19,6 +19,8 @@
 
 from unittest import TestCase
 
+from cyclonedx.model import License, LicenseChoice
+
 from cyclonedx_py.parser.environment import EnvironmentParser
 
 
@@ -39,7 +41,9 @@ class TestEnvironmentParser(TestCase):
         self.assertIsNotNone(c_tox)
         self.assertNotEqual(c_tox.purl.to_string(), c_tox.bom_ref.value)
         self.assertIsNotNone(c_tox.licenses)
-        self.assertEqual('MIT', c_tox.licenses.pop().license.name)
+        self.assertEqual(len(c_tox.licenses), 2)
+        self.assertEqual({LicenseChoice(license_=License(license_name="MIT License")),
+                          LicenseChoice(license_=License(license_name="MIT"))}, c_tox.licenses)
 
     def test_simple_use_purl_bom_ref(self) -> None:
         """
@@ -56,4 +60,6 @@ class TestEnvironmentParser(TestCase):
         self.assertIsNotNone(c_tox)
         self.assertEqual(c_tox.purl.to_string(), c_tox.bom_ref.value)
         self.assertIsNotNone(c_tox.licenses)
-        self.assertEqual('MIT', c_tox.licenses.pop().license.name)
+        self.assertEqual(len(c_tox.licenses), 2)
+        self.assertEqual({LicenseChoice(license_=License(license_name="MIT License")),
+                          LicenseChoice(license_=License(license_name="MIT"))}, c_tox.licenses)


### PR DESCRIPTION
The classifier parser did not work as expected on my machine.

In python3.8 and python3.9 the type `email.message import Message` is used as metadata type and the metadata are stored in `i_metadata._headers` as a list of tuples. To iterate over the classifiers in this list of tuples 
```
for classifier in i_metadata['Classifier']:
```
was used. Though this loop iterates only over the first classifiers characters and not over all classifiers, so the classifiers were never parsed.

I propose in this commit to generate a list of classifiers for python3.8/python3.9 and python3.10 separately and loop over the list of classifiers.


Please note:
I created this PR on github web, I guess the commit message needs to be adjusted before merging!