### PR TITLE
fix: add a missing space in the help pages `pathto` -> `path to`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,16 @@ optional arguments:
                         Build a SBOM based on the packages installed in your
                         current Python environment (default)
   -p, --p, --poetry     Build a SBOM based on a Poetry poetry.lock's contents.
-                        Use with -i to specify absolute pathto a `poetry.lock`
+                        Use with -i to specify absolute path to a `poetry.lock`
                         you wish to use, else we'll look for one in the
                         current working directory.
   -pip, --pip           Build a SBOM based on a PipEnv Pipfile.lock's
-                        contents. Use with -i to specify absolute pathto a
+                        contents. Use with -i to specify absolute path to a
                         `Pipefile.lock` you wish to use, else we'll look for
                         one in the current working directory.
   -r, --r, --requirements
                         Build a SBOM based on a requirements.txt's contents.
-                        Use with -i to specify absolute pathto a
+                        Use with -i to specify absolute path to a
                         `requirements.txt` you wish to use, else we'll look
                         for one in the current working directory.
   -X                    Enable debug output

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -179,19 +179,19 @@ class CycloneDxCmd:
         )
         input_group.add_argument(
             '-p', '--p', '--poetry', action='store_true',
-            help='Build a SBOM based on a Poetry poetry.lock\'s contents. Use with -i to specify absolute path'
+            help='Build a SBOM based on a Poetry poetry.lock\'s contents. Use with -i to specify absolute path '
                  'to a `poetry.lock` you wish to use, else we\'ll look for one in the current working directory.',
             dest='input_from_poetry'
         )
         input_group.add_argument(
             '-pip', '--pip', action='store_true',
-            help='Build a SBOM based on a PipEnv Pipfile.lock\'s contents. Use with -i to specify absolute path'
+            help='Build a SBOM based on a PipEnv Pipfile.lock\'s contents. Use with -i to specify absolute path '
                  'to a `Pipefile.lock` you wish to use, else we\'ll look for one in the current working directory.',
             dest='input_from_pip'
         )
         input_group.add_argument(
             '-r', '--r', '--requirements', action='store_true',
-            help='Build a SBOM based on a requirements.txt\'s contents. Use with -i to specify absolute path'
+            help='Build a SBOM based on a requirements.txt\'s contents. Use with -i to specify absolute path '
                  'to a `requirements.txt` you wish to use, else we\'ll look for one in the current working directory.',
             dest='input_from_requirements'
         )

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -33,16 +33,16 @@ The full documentation can be issued by running with ``--help``:
                             Build a SBOM based on the packages installed in your
                             current Python environment (default)
       -p, --p, --poetry     Build a SBOM based on a Poetry poetry.lock's contents.
-                            Use with -i to specify absolute pathto a `poetry.lock`
+                            Use with -i to specify absolute path to a `poetry.lock`
                             you wish to use, else we'll look for one in the
                             current working directory.
       -pip, --pip           Build a SBOM based on a PipEnv Pipfile.lock's
-                            contents. Use with -i to specify absolute pathto a
+                            contents. Use with -i to specify absolute path to a
                             `Pipefile.lock` you wish to use, else we'll look for
                             one in the current working directory.
       -r, --r, --requirements
                             Build a SBOM based on a requirements.txt's contents.
-                            Use with -i to specify absolute pathto a
+                            Use with -i to specify absolute path to a
                             `requirements.txt` you wish to use, else we'll look
                             for one in the current working directory.
       -X                    Enable debug output


### PR DESCRIPTION
I was reading the README and noticed some missing spaces. Hope it's useful.