### PR TITLE
feat: Allow filtering for EnvironmentParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ python3 -m cyclonedx_py
 
 ```text
 $ cyclonedx-py --help
-usage: cyclonedx-py [-h] (-c | -cj | -e | -p | -pip | -r) [-i FILE_PATH]
+usage: cyclonedx-py [-h] (-c | -cj | -e | -p | -pip | -r) [-i FILE_PATH] [--location-filter]
                  [--format {json,xml}] [--schema-version {1.4,1.3,1.2,1.1,1.0}]
                  [-o FILE_PATH] [-F] [-X]
 
@@ -67,7 +67,13 @@ optional arguments:
                         --json`
   -e, --e, --environment
                         Build a SBOM based on the packages installed in your
-                        current Python environment (default)
+                        current Python environment (default).
+
+                        Use with `-i` to specify absolute path to a `requirements.txt`
+                        you wish to use for filtering packages.
+
+                        User with `--location-filter` to filter packages based on
+                        their installation location.
   -p, --p, --poetry     Build a SBOM based on a Poetry poetry.lock's contents.
                         Use with -i to specify absolute path to a `poetry.lock`
                         you wish to use, else we'll look for one in the
@@ -88,6 +94,10 @@ Input Method:
 
   -i FILE_PATH, --in-file FILE_PATH
                         File to read input from. Use "-" to read from STDIN.
+
+  --location-filter     When building a SBOM from your current Python environment
+                        (Option -e) only those packages which are located in one
+                        of the specified paths will be considered.
 
 SBOM Output Configuration:
   Choose the output format and schema version

--- a/cyclonedx_py/parser/environment.py
+++ b/cyclonedx_py/parser/environment.py
@@ -84,6 +84,11 @@ class EnvironmentParser(BaseParser):
 
             rf_names = set([req.name for req in parsed_rf.requirements])
 
+        if os.name == 'nt' and location_filter:
+            # make all paths lower case to match location properties
+            # from pkg_resources.working_set on Windows
+            location_filter = list(map(str.lower, location_filter))
+
         import pkg_resources
 
         i: DistInfoDistribution

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -17,7 +17,7 @@ The full documentation can be issued by running with ``--help``:
 .. code-block:: bash
 
     $ cyclonedx-py --help
-    usage: cyclonedx-py [-h] (-c | -cj | -e | -p | -pip | -r) [-i FILE_PATH]
+    usage: cyclonedx-py [-h] (-c | -cj | -e | -p | -pip | -r) [-i FILE_PATH] [--location-filter]
                      [--format {json,xml}] [--schema-version {1.4,1.3,1.2,1.1,1.0}]
                      [-o FILE_PATH] [-F] [-X]
 
@@ -33,17 +33,17 @@ The full documentation can be issued by running with ``--help``:
                             Build a SBOM based on the packages installed in your
                             current Python environment (default).
 
-                            Use with -i to specify absolute path to a `requirements.txt`
+                            Use with `-i` to specify absolute path to a `requirements.txt`
                             you wish to use for filtering packages.
 
-                            User with --location-filter to filter packages based on
+                            User with `--location-filter` to filter packages based on
                             their installation location.
       -p, --p, --poetry     Build a SBOM based on a Poetry poetry.lock''s contents.
-                            Use with -i to specify absolute path to a `poetry.lock`
+                            Use with `-i` to specify absolute path to a `poetry.lock`
                             you wish to use, else we''ll look for one in the
                             current working directory.
       -pip, --pip           Build a SBOM based on a PipEnv Pipfile.lock''s
-                            contents. Use with -i to specify absolute path to a
+                            contents. Use with `-i` to specify absolute path to a
                             `Pipefile.lock` you wish to use, else we''ll look for
                             one in the current working directory.
       -r, --r, --requirements

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -31,27 +31,37 @@ The full documentation can be issued by running with ``--help``:
                             --json`
       -e, --e, --environment
                             Build a SBOM based on the packages installed in your
-                            current Python environment (default)
-      -p, --p, --poetry     Build a SBOM based on a Poetry poetry.lock's contents.
+                            current Python environment (default).
+
+                            Use with -i to specify absolute path to a `requirements.txt`
+                            you wish to use for filtering packages.
+
+                            User with --location-filter to filter packages based on
+                            their installation location.
+      -p, --p, --poetry     Build a SBOM based on a Poetry poetry.lock''s contents.
                             Use with -i to specify absolute path to a `poetry.lock`
-                            you wish to use, else we'll look for one in the
+                            you wish to use, else we''ll look for one in the
                             current working directory.
-      -pip, --pip           Build a SBOM based on a PipEnv Pipfile.lock's
+      -pip, --pip           Build a SBOM based on a PipEnv Pipfile.lock''s
                             contents. Use with -i to specify absolute path to a
-                            `Pipefile.lock` you wish to use, else we'll look for
+                            `Pipefile.lock` you wish to use, else we''ll look for
                             one in the current working directory.
       -r, --r, --requirements
-                            Build a SBOM based on a requirements.txt's contents.
+                            Build a SBOM based on a requirements.txt''s contents.
                             Use with -i to specify absolute path to a
-                            `requirements.txt` you wish to use, else we'll look
+                            `requirements.txt` you wish to use, else we''ll look
                             for one in the current working directory.
       -X                    Enable debug output
 
     Input Method:
-      Flags to determine how this tool obtains it's input
+      Flags to determine how this tool obtains it''s input
 
       -i FILE_PATH, --in-file FILE_PATH
                             File to read input from, or STDIN if not specified
+
+      --location-filter     When building a SBOM from your current Python environment
+                            (Option -e) only those packages which are located in one
+                            of the specified paths will be considered.
 
     SBOM Output Configuration:
       Choose the output format and schema version

--- a/tests/test_parser_environment.py
+++ b/tests/test_parser_environment.py
@@ -16,7 +16,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
-
+import os
+import sys
 from unittest import TestCase
 
 from cyclonedx.model import License, LicenseChoice
@@ -63,3 +64,37 @@ class TestEnvironmentParser(TestCase):
         self.assertEqual(len(c_tox.licenses), 2)
         self.assertEqual({LicenseChoice(license_=License(license_name="MIT License")),
                           LicenseChoice(license_=License(license_name="MIT"))}, c_tox.licenses)
+
+    def test_simple_use_location_filter(self) -> None:
+        # Ensure that it makes no difference if we pass the complete sys.path
+        # as location filter or no filter at all
+        parser_sys_path = EnvironmentParser(location_filter=sys.path)
+        self.assertGreater(parser_sys_path.component_count(), 1)
+
+        parser_no_filter = EnvironmentParser()
+        self.assertGreater(parser_no_filter.component_count(), 1)
+        self.assertEqual(parser_no_filter.component_count(), parser_sys_path.component_count())
+
+        # ensure that no components are found if we set the location filter
+        # to a non existing path
+        parser_invalid_filter = EnvironmentParser(location_filter=["/tmp/fa12b66cac07e4bb480e98eba9627737"])
+        self.assertEqual(parser_invalid_filter.component_count(), 0)
+
+    def test_simple_use_requiremets(self) -> None:
+        with open(os.path.join(os.path.dirname(__file__),
+                               'fixtures/requirements-simple.txt')) as r:
+            parser = EnvironmentParser(requirements_content=r.read())
+        components = parser.get_components()
+        self.assertEqual(1, len(components))
+
+        parser = EnvironmentParser(requirements_content=os.path.join(os.path.dirname(__file__),
+                                                                     'fixtures/requirements-simple.txt'))
+        components = parser.get_components()
+        self.assertGreaterEqual(1, len(components), f"{components}")
+
+        parser = EnvironmentParser(
+            location_filter=["/tmp/fa12b66cac07e4bb480e98eba9627737"],
+            requirements_content=os.path.join(os.path.dirname(__file__),
+                                              'fixtures/requirements-simple.txt'))
+        components = parser.get_components()
+        self.assertGreaterEqual(0, len(components))


### PR DESCRIPTION
This PR contains changes to the `EnvironmentParser` to allow the filtering of packages read from `pkg_resources.working_set`.

The  PR overlaps with #444 

As requested from `CONTRIBUTING.md`:

* commits are signed
* documentation added
* formatted with `isort` and `autopep8`
* added new tests for implemented functionality
* run tests locally successful with `poetry run tox` 
