### PR TITLE
feat: parsers can outbut more debug messages

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Build own SBoM (XML)
         run: >
           docker run --rm "$DOCKER_TAG"
+          -X
           --environment
           --format=xml
           --output=-
@@ -76,6 +77,7 @@ jobs:
       - name: Build own SBoM (JSON)
         run: >
           docker run --rm "$DOCKER_TAG"
+          -X
           --environment
           --format=json
           --output=-

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -243,13 +243,13 @@ class CycloneDxCmd:
     def _debug_message(self, message: str, *args: Any, **kwargs: Any) -> None:
         if self._DEBUG_ENABLED:
             print(
-                f'[DEBUG] - {{__t}} - {message}'.format(*args, __t=datetime.now(), **kwargs),
+                f'[DEBUG] - {{__t}} - {message}'.format(*args, **kwargs, __t=datetime.now()),
                 file=sys.stderr)
 
     @staticmethod
     def _error_and_exit(message: str, *args: Any, exit_code: int = 1, **kwargs: Any) -> None:
         print(
-            f'[ERROR] - {{__t}} - {message}'.format(*args, __t=datetime.now(), **kwargs),
+            f'[ERROR] - {{__t}} - {message}'.format(*args, **kwargs, __t=datetime.now()),
             file=sys.stderr)
         exit(exit_code)
 
@@ -257,7 +257,7 @@ class CycloneDxCmd:
         if self._arguments.input_from_environment:
             return EnvironmentParser(
                 use_purl_bom_ref=self._arguments.use_purl_bom_ref,
-                debug_message=lambda m, *a, **k: self._debug_message(f'EnvironmentParser - {m}', *a, **k)
+                debug_message=lambda m, *a, **k: self._debug_message(f'EnvironmentParser {m}', *a, **k)
             )
 
         # All other Parsers will require some input - grab it now!
@@ -293,31 +293,31 @@ class CycloneDxCmd:
             return CondaListExplicitParser(
                 conda_data=input_data,
                 use_purl_bom_ref=self._arguments.use_purl_bom_ref,
-                debug_message=lambda m, *a, **k: self._debug_message(f'CondaListExplicitParser - {m}', *a, **k)
+                debug_message=lambda m, *a, **k: self._debug_message(f'CondaListExplicitParser {m}', *a, **k)
             )
         elif self._arguments.input_from_conda_json:
             return CondaListJsonParser(
                 conda_data=input_data,
                 use_purl_bom_ref=self._arguments.use_purl_bom_ref,
-                debug_message=lambda m, *a, **k: self._debug_message(f'CondaListJsonParser - {m}', *a, **k)
+                debug_message=lambda m, *a, **k: self._debug_message(f'CondaListJsonParser {m}', *a, **k)
             )
         elif self._arguments.input_from_pip:
             return PipEnvParser(
                 pipenv_contents=input_data,
                 use_purl_bom_ref=self._arguments.use_purl_bom_ref,
-                debug_message=lambda m, *a, **k: self._debug_message(f'PipEnvParser - {m}', *a, **k)
+                debug_message=lambda m, *a, **k: self._debug_message(f'PipEnvParser {m}', *a, **k)
             )
         elif self._arguments.input_from_poetry:
             return PoetryParser(
                 poetry_lock_contents=input_data,
                 use_purl_bom_ref=self._arguments.use_purl_bom_ref,
-                debug_message=lambda m, *a, **k: self._debug_message(f'PoetryParser - {m}', *a, **k)
+                debug_message=lambda m, *a, **k: self._debug_message(f'PoetryParser {m}', *a, **k)
             )
         elif self._arguments.input_from_requirements:
             return RequirementsParser(
                 requirements_content=input_data,
                 use_purl_bom_ref=self._arguments.use_purl_bom_ref,
-                debug_message=lambda m, *a, **k: self._debug_message(f'RequirementsParser - {m}', *a, **k)
+                debug_message=lambda m, *a, **k: self._debug_message(f'RequirementsParser {m}', *a, **k)
             )
         else:
             raise CycloneDxCmdException('Parser type could not be determined.')

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -266,11 +266,11 @@ class CycloneDxCmd:
             current_directory = os.getcwd()
             try:
                 if self._arguments.input_from_conda_explicit:
-                    raise CycloneDxCmdNoInputFileSupplied('When using input from Conda Explicit, you need to pipe input'
-                                                          'via STDIN')
+                    raise CycloneDxCmdNoInputFileSupplied(
+                        'When using input from Conda Explicit, you need to pipe input via STDIN')
                 elif self._arguments.input_from_conda_json:
-                    raise CycloneDxCmdNoInputFileSupplied('When using input from Conda JSON, you need to pipe input'
-                                                          'via STDIN')
+                    raise CycloneDxCmdNoInputFileSupplied(
+                        'When using input from Conda JSON, you need to pipe input via STDIN')
                 elif self._arguments.input_from_pip:
                     self._arguments.input_source = open(os.path.join(current_directory, 'Pipfile.lock'), 'r')
                 elif self._arguments.input_from_poetry:
@@ -281,7 +281,7 @@ class CycloneDxCmd:
                     raise CycloneDxCmdException('Parser type could not be determined.')
             except FileNotFoundError as error:
                 raise CycloneDxCmdNoInputFileSupplied(
-                    f'No input file was supplied and no input was provided on STDIN:\n{str(error)}',
+                    f'No input file was supplied and no input was provided on STDIN:\n{str(error)}'
                 ) from error
 
         input_data_fh = self._arguments.input_source

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -251,7 +251,8 @@ class CycloneDxCmd:
 
     def _get_input_parser(self) -> BaseParser:
         if self._arguments.input_from_environment:
-            return EnvironmentParser(use_purl_bom_ref=self._arguments.use_purl_bom_ref)
+            return EnvironmentParser(use_purl_bom_ref=self._arguments.use_purl_bom_ref,
+                                     debug_message=self._debug_message)
 
         # All other Parsers will require some input - grab it now!
         if not self._arguments.input_source:
@@ -284,19 +285,24 @@ class CycloneDxCmd:
 
         if self._arguments.input_from_conda_explicit:
             return CondaListExplicitParser(conda_data=input_data,
-                                           use_purl_bom_ref=self._arguments.use_purl_bom_ref)
+                                           use_purl_bom_ref=self._arguments.use_purl_bom_ref,
+                                           debug_message=self._debug_message)
         elif self._arguments.input_from_conda_json:
             return CondaListJsonParser(conda_data=input_data,
-                                       use_purl_bom_ref=self._arguments.use_purl_bom_ref)
+                                       use_purl_bom_ref=self._arguments.use_purl_bom_ref,
+                                       debug_message=self._debug_message)
         elif self._arguments.input_from_pip:
             return PipEnvParser(pipenv_contents=input_data,
-                                use_purl_bom_ref=self._arguments.use_purl_bom_ref)
+                                use_purl_bom_ref=self._arguments.use_purl_bom_ref,
+                                debug_message=self._debug_message)
         elif self._arguments.input_from_poetry:
             return PoetryParser(poetry_lock_contents=input_data,
-                                use_purl_bom_ref=self._arguments.use_purl_bom_ref)
+                                use_purl_bom_ref=self._arguments.use_purl_bom_ref,
+                                debug_message=self._debug_message)
         elif self._arguments.input_from_requirements:
             return RequirementsParser(requirements_content=input_data,
-                                      use_purl_bom_ref=self._arguments.use_purl_bom_ref)
+                                      use_purl_bom_ref=self._arguments.use_purl_bom_ref,
+                                      debug_message=self._debug_message)
         else:
             raise CycloneDxCmdException('Parser type could not be determined.')
 

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -242,15 +242,13 @@ class CycloneDxCmd:
 
     def _debug_message(self, message: str, *args: Any, **kwargs: Any) -> None:
         if self._DEBUG_ENABLED:
-            print(
-                f'[DEBUG] - {{__t}} - {message}'.format(*args, **kwargs, __t=datetime.now()),
-                file=sys.stderr)
+            print(f'[DEBUG] - {{__t}} - {message}'.format(*args, **kwargs, __t=datetime.now()),
+                  file=sys.stderr)
 
     @staticmethod
     def _error_and_exit(message: str, *args: Any, exit_code: int = 1, **kwargs: Any) -> None:
-        print(
-            f'[ERROR] - {{__t}} - {message}'.format(*args, **kwargs, __t=datetime.now()),
-            file=sys.stderr)
+        print(f'[ERROR] - {{__t}} - {message}'.format(*args, **kwargs, __t=datetime.now()),
+              file=sys.stderr)
         exit(exit_code)
 
     def _get_input_parser(self) -> BaseParser:

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -82,11 +82,11 @@ class CycloneDxCmd:
     def get_output(self) -> BaseOutput:
         try:
             parser = self._get_input_parser()
-        except CycloneDxCmdNoInputFileSupplied as e:
-            print(f'ERROR: {str(e)}', file=sys.stderr)
+        except CycloneDxCmdNoInputFileSupplied as error:
+            print(f'ERROR: {str(error)}', file=sys.stderr)
             exit(1)
-        except CycloneDxCmdException as e:
-            print(f'ERROR: {str(e)}', file=sys.stderr)
+        except CycloneDxCmdException as error:
+            print(f'ERROR: {str(error)}', file=sys.stderr)
             exit(1)
 
         if parser and parser.has_warnings():
@@ -255,8 +255,10 @@ class CycloneDxCmd:
 
     def _get_input_parser(self) -> BaseParser:
         if self._arguments.input_from_environment:
-            return EnvironmentParser(use_purl_bom_ref=self._arguments.use_purl_bom_ref,
-                                     debug_message=lambda m, *a, **k: self._debug_message(f'EnvironmentParser - {m}', *a, **k))
+            return EnvironmentParser(
+                use_purl_bom_ref=self._arguments.use_purl_bom_ref,
+                debug_message=lambda m, *a, **k: self._debug_message(f'EnvironmentParser - {m}', *a, **k)
+            )
 
         # All other Parsers will require some input - grab it now!
         if not self._arguments.input_source:
@@ -277,10 +279,10 @@ class CycloneDxCmd:
                     self._arguments.input_source = open(os.path.join(current_directory, 'requirements.txt'), 'r')
                 else:
                     raise CycloneDxCmdException('Parser type could not be determined.')
-            except FileNotFoundError as e:
+            except FileNotFoundError as error:
                 raise CycloneDxCmdNoInputFileSupplied(
-                    f'No input file was supplied and no input was provided on STDIN:\n{str(e)}'
-                )
+                    f'No input file was supplied and no input was provided on STDIN:\n{str(error)}',
+                ) from error
 
         input_data_fh = self._arguments.input_source
         with input_data_fh:
@@ -288,25 +290,35 @@ class CycloneDxCmd:
             input_data_fh.close()
 
         if self._arguments.input_from_conda_explicit:
-            return CondaListExplicitParser(conda_data=input_data,
-                                           use_purl_bom_ref=self._arguments.use_purl_bom_ref,
-                                           debug_message=lambda m, *a, **k: self._debug_message(f'CondaListExplicitParser - {m}', *a, **k))
+            return CondaListExplicitParser(
+                conda_data=input_data,
+                use_purl_bom_ref=self._arguments.use_purl_bom_ref,
+                debug_message=lambda m, *a, **k: self._debug_message(f'CondaListExplicitParser - {m}', *a, **k)
+            )
         elif self._arguments.input_from_conda_json:
-            return CondaListJsonParser(conda_data=input_data,
-                                       use_purl_bom_ref=self._arguments.use_purl_bom_ref,
-                                       debug_message=lambda m, *a, **k: self._debug_message(f'CondaListJsonParser - {m}', *a, **k))
+            return CondaListJsonParser(
+                conda_data=input_data,
+                use_purl_bom_ref=self._arguments.use_purl_bom_ref,
+                debug_message=lambda m, *a, **k: self._debug_message(f'CondaListJsonParser - {m}', *a, **k)
+            )
         elif self._arguments.input_from_pip:
-            return PipEnvParser(pipenv_contents=input_data,
-                                use_purl_bom_ref=self._arguments.use_purl_bom_ref,
-                                debug_message=lambda m, *a, **k: self._debug_message(f'PipEnvParser - {m}', *a, **k))
+            return PipEnvParser(
+                pipenv_contents=input_data,
+                use_purl_bom_ref=self._arguments.use_purl_bom_ref,
+                debug_message=lambda m, *a, **k: self._debug_message(f'PipEnvParser - {m}', *a, **k)
+            )
         elif self._arguments.input_from_poetry:
-            return PoetryParser(poetry_lock_contents=input_data,
-                                use_purl_bom_ref=self._arguments.use_purl_bom_ref,
-                                debug_message=lambda m, *a, **k: self._debug_message(f'PoetryParser - {m}', *a, **k))
+            return PoetryParser(
+                poetry_lock_contents=input_data,
+                use_purl_bom_ref=self._arguments.use_purl_bom_ref,
+                debug_message=lambda m, *a, **k: self._debug_message(f'PoetryParser - {m}', *a, **k)
+            )
         elif self._arguments.input_from_requirements:
-            return RequirementsParser(requirements_content=input_data,
-                                      use_purl_bom_ref=self._arguments.use_purl_bom_ref,
-                                      debug_message=lambda m, *a, **k: self._debug_message(f'RequirementsParser - {m}', *a, **k))
+            return RequirementsParser(
+                requirements_content=input_data,
+                use_purl_bom_ref=self._arguments.use_purl_bom_ref,
+                debug_message=lambda m, *a, **k: self._debug_message(f'RequirementsParser - {m}', *a, **k)
+            )
         else:
             raise CycloneDxCmdException('Parser type could not be determined.')
 

--- a/cyclonedx_py/parser/_debug.py
+++ b/cyclonedx_py/parser/_debug.py
@@ -22,11 +22,11 @@ from typing import TYPE_CHECKING, Any, Callable
 if TYPE_CHECKING:
     from mypy_extensions import Arg, KwArg, VarArg
 
-    DebugMessageCallback = Callable[[Arg(str, 'message'), VarArg(Any), KwArg(Any)], None]
+    DebugMessageCallback = Callable[[Arg(str, 'message'), VarArg(Any), KwArg(Any)], None]  # noqa: F821
     """Callback for debug messaging.
-    
-    :param message: the format string, 
-    :Other Parameters: the *args: to :func:`str.forma()`
+
+    :parameter message: the format string.
+    :Other Parameters: the *args: to :func:`str.forma()`.
     :Keyword Arguments: the **kwargs to :func:`str.format()`.
     """
 else:

--- a/cyclonedx_py/parser/_debug.py
+++ b/cyclonedx_py/parser/_debug.py
@@ -1,0 +1,25 @@
+# encoding: utf-8
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+
+
+from typing import Callable
+
+T_debug_message_cb = Callable[[str], None]
+
+
+def quiet(*_, **__) -> None:
+    pass

--- a/cyclonedx_py/parser/_debug.py
+++ b/cyclonedx_py/parser/_debug.py
@@ -15,11 +15,27 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
 
+"""The following structures are internal helpers."""
 
-from typing import Callable
+from typing import TYPE_CHECKING, Any, Callable
 
-T_debug_message_cb = Callable[[str], None]
+if TYPE_CHECKING:
+    from mypy_extensions import Arg, KwArg, VarArg
+
+    DebugMessageCallback = Callable[[Arg(str, 'message'), VarArg(Any), KwArg(Any)], None]
+    """Callback for debug messaging.
+    
+    :param message: the format string, 
+    :Other Parameters: the *args: to :func:`str.forma()`
+    :Keyword Arguments: the **kwargs to :func:`str.format()`.
+    """
+else:
+    DebugMessageCallback = Callable[..., None]
 
 
-def quiet(*_, **__) -> None:
+def quiet(message: str, *_: Any, **__: Any) -> None:
+    """Do not print anything.
+
+     Must be compatible to :py:data:`Callback_debug_message`.
+     """
     pass

--- a/cyclonedx_py/parser/_debug.py
+++ b/cyclonedx_py/parser/_debug.py
@@ -36,6 +36,6 @@ else:
 def quiet(message: str, *_: Any, **__: Any) -> None:
     """Do not print anything.
 
-     Must be compatible to :py:data:`Callback_debug_message`.
+     Must be compatible to :py:data:`DebugMessageCallback`.
      """
     pass

--- a/cyclonedx_py/parser/conda.py
+++ b/cyclonedx_py/parser/conda.py
@@ -31,17 +31,23 @@ from ..utils.conda import (
     parse_conda_json_to_conda_package,
     parse_conda_list_str_to_conda_package,
 )
+from ._debug import T_debug_message_cb, quiet
 
 
 class _BaseCondaParser(BaseParser, metaclass=ABCMeta):
     """Internal abstract parser - not for programmatic use.
     """
 
-    def __init__(self, conda_data: str, use_purl_bom_ref: bool = False) -> None:
+    def __init__(
+            self, conda_data: str, use_purl_bom_ref: bool = False,
+            *,
+            debug_message: T_debug_message_cb = quiet
+    ) -> None:
         super().__init__()
         self._conda_packages: List[CondaPackage] = []
         self._parse_to_conda_packages(data_str=conda_data)
         self._conda_packages_to_components(use_purl_bom_ref=use_purl_bom_ref)
+        self._debug_message = debug_message
 
     @abstractmethod
     def _parse_to_conda_packages(self, data_str: str) -> None:

--- a/cyclonedx_py/parser/conda.py
+++ b/cyclonedx_py/parser/conda.py
@@ -31,7 +31,7 @@ from ..utils.conda import (
     parse_conda_json_to_conda_package,
     parse_conda_list_str_to_conda_package,
 )
-from ._debug import T_debug_message_cb, quiet
+from ._debug import DebugMessageCallback, quiet
 
 
 class _BaseCondaParser(BaseParser, metaclass=ABCMeta):
@@ -41,13 +41,14 @@ class _BaseCondaParser(BaseParser, metaclass=ABCMeta):
     def __init__(
             self, conda_data: str, use_purl_bom_ref: bool = False,
             *,
-            debug_message: T_debug_message_cb = quiet
+            debug_message: DebugMessageCallback = quiet
     ) -> None:
         super().__init__()
+        debug_message('init')
+        self._debug_message = debug_message
         self._conda_packages: List[CondaPackage] = []
         self._parse_to_conda_packages(data_str=conda_data)
         self._conda_packages_to_components(use_purl_bom_ref=use_purl_bom_ref)
-        self._debug_message = debug_message
 
     @abstractmethod
     def _parse_to_conda_packages(self, data_str: str) -> None:
@@ -67,7 +68,9 @@ class _BaseCondaParser(BaseParser, metaclass=ABCMeta):
         Converts the parsed `CondaPackage` instances into `Component` instances.
 
         """
+        self._debug_message('processing conda_packages')
         for conda_package in self._conda_packages:
+            self._debug_message('processing conda_package: {!r}', conda_package)
             purl = conda_package_to_purl(conda_package)
             bom_ref = purl.to_string() if use_purl_bom_ref else None
             c = Component(
@@ -95,11 +98,14 @@ class CondaListJsonParser(_BaseCondaParser):
 
     def _parse_to_conda_packages(self, data_str: str) -> None:
         conda_list_content = json.loads(data_str)
-
+        self._debug_message('processing conda_list_content')
         for package in conda_list_content:
+            self._debug_message('processing package: {!r}', package)
             conda_package = parse_conda_json_to_conda_package(conda_json_str=json.dumps(package))
             if conda_package:
                 self._conda_packages.append(conda_package)
+            else:
+                self._debug_message('no conda_package -> skip')
 
 
 class CondaListExplicitParser(_BaseCondaParser):
@@ -109,8 +115,12 @@ class CondaListExplicitParser(_BaseCondaParser):
     """
 
     def _parse_to_conda_packages(self, data_str: str) -> None:
+        self._debug_message('processing data_str')
         for line in data_str.replace('\r\n', '\n').split('\n'):
             line = line.strip()
+            self._debug_message('processing line: {}', line)
             conda_package = parse_conda_list_str_to_conda_package(conda_list_str=line)
             if conda_package:
                 self._conda_packages.append(conda_package)
+            else:
+                self._debug_message('no conda_package -> skip')

--- a/cyclonedx_py/parser/conda.py
+++ b/cyclonedx_py/parser/conda.py
@@ -44,7 +44,7 @@ class _BaseCondaParser(BaseParser, metaclass=ABCMeta):
             debug_message: DebugMessageCallback = quiet
     ) -> None:
         super().__init__()
-        debug_message('init')
+        debug_message('init {}', self.__class__.__name__)
         self._debug_message = debug_message
         self._conda_packages: List[CondaPackage] = []
         self._parse_to_conda_packages(data_str=conda_data)

--- a/cyclonedx_py/parser/environment.py
+++ b/cyclonedx_py/parser/environment.py
@@ -90,6 +90,7 @@ class EnvironmentParser(BaseParser):
                 except CycloneDxModelException as error:
                     # @todo traceback and details to the output?
                     debug_message('Warning: suppressed {!r}', error)
+                    del error
 
             debug_message('processing classifiers')
             for classifier in i_metadata.get_all("Classifier", []):
@@ -109,6 +110,7 @@ class EnvironmentParser(BaseParser):
                     except CycloneDxModelException as error:
                         # @todo traceback and details to the output?
                         debug_message('Warning: suppressed {!r}', error)
+                        del error
 
             self._components.append(c)
 

--- a/cyclonedx_py/parser/environment.py
+++ b/cyclonedx_py/parser/environment.py
@@ -49,7 +49,7 @@ from cyclonedx.model import License, LicenseChoice
 from cyclonedx.model.component import Component
 from cyclonedx.parser import BaseParser
 
-from ._debug import T_debug_message_cb, quiet
+from ._debug import DebugMessageCallback, quiet
 
 
 class EnvironmentParser(BaseParser):
@@ -62,47 +62,53 @@ class EnvironmentParser(BaseParser):
     def __init__(
             self, use_purl_bom_ref: bool = False,
             *,
-            debug_message: T_debug_message_cb = quiet
+            debug_message: DebugMessageCallback = quiet
     ) -> None:
         super().__init__()
-        self._debug_message = debug_message
+        debug_message('init')
 
+        debug_message('late import pkg_resources')
         import pkg_resources
 
+        debug_message('processing pkg_resources.working_set')
         i: DistInfoDistribution
         for i in iter(pkg_resources.working_set):
+            debug_message('processing working_set item: {!r}', i)
             purl = PackageURL(type='pypi', name=i.project_name, version=i.version)
             bom_ref = purl.to_string() if use_purl_bom_ref else None
             c = Component(name=i.project_name, bom_ref=bom_ref, version=i.version, purl=purl)
 
             i_metadata = self._get_metadata_for_package(i.project_name)
+            debug_message('processing i_metadata')
             if 'Author' in i_metadata:
                 c.author = i_metadata['Author']
-
             if 'License' in i_metadata and i_metadata['License'] and i_metadata['License'] != 'UNKNOWN':
                 # Values might be ala `MIT` (SPDX id), `Apache-2.0 license` (arbitrary string), ...
                 # Therefore, just go with a named license.
                 try:
                     c.licenses.add(LicenseChoice(license_=License(license_name=i_metadata['License'])))
-                except CycloneDxModelException:
-                    # write a debug message?
-                    pass
+                except CycloneDxModelException as error:
+                    # @todo traceback and details to the output?
+                    debug_message('Warning: suppressed {!r}', error)
 
+            debug_message('processing classifiers')
             for classifier in i_metadata.get_all("Classifier", []):
+                debug_message('processing classifier: {!r}', classifier)
+                classifier = str(classifier)
                 # Trove classifiers - https://packaging.python.org/specifications/core-metadata/#metadata-classifier
                 # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
-                if str(classifier).startswith('License :: OSI Approved :: '):
-                    license_name = str(classifier).replace('License :: OSI Approved :: ', '').strip()
-                elif str(classifier).startswith('License :: '):
-                    license_name = str(classifier).replace('License :: ', '').strip()
+                if classifier.startswith('License :: OSI Approved :: '):
+                    license_name = classifier.replace('License :: OSI Approved :: ', '').strip()
+                elif classifier.startswith('License :: '):
+                    license_name = classifier.replace('License :: ', '').strip()
                 else:
                     license_name = ''
                 if license_name:
                     try:
                         c.licenses.add(LicenseChoice(license_=License(license_name=license_name)))
-                    except CycloneDxModelException:
-                        # write a debug message?
-                        pass
+                    except CycloneDxModelException as error:
+                        # @todo traceback and details to the output?
+                        debug_message('Warning: suppressed {!r}', error)
 
             self._components.append(c)
 

--- a/cyclonedx_py/parser/environment.py
+++ b/cyclonedx_py/parser/environment.py
@@ -65,7 +65,7 @@ class EnvironmentParser(BaseParser):
             debug_message: DebugMessageCallback = quiet
     ) -> None:
         super().__init__()
-        debug_message('init')
+        debug_message('init {}', self.__class__.__name__)
 
         debug_message('late import pkg_resources')
         import pkg_resources

--- a/cyclonedx_py/parser/environment.py
+++ b/cyclonedx_py/parser/environment.py
@@ -49,6 +49,8 @@ from cyclonedx.model import License, LicenseChoice
 from cyclonedx.model.component import Component
 from cyclonedx.parser import BaseParser
 
+from ._debug import T_debug_message_cb, quiet
+
 
 class EnvironmentParser(BaseParser):
     """
@@ -57,8 +59,13 @@ class EnvironmentParser(BaseParser):
     Best used when you have virtual Python environments per project.
     """
 
-    def __init__(self, use_purl_bom_ref: bool = False) -> None:
+    def __init__(
+            self, use_purl_bom_ref: bool = False,
+            *,
+            debug_message: T_debug_message_cb = quiet
+    ) -> None:
         super().__init__()
+        self._debug_message = debug_message
 
         import pkg_resources
 

--- a/cyclonedx_py/parser/pipenv.py
+++ b/cyclonedx_py/parser/pipenv.py
@@ -73,8 +73,8 @@ class PipEnvFileParser(PipEnvParser):
             debug_message: DebugMessageCallback = quiet
     ) -> None:
         debug_message('open file: {}', pipenv_lock_filename)
-        with open(pipenv_lock_filename) as r:
+        with open(pipenv_lock_filename) as plf:
             super(PipEnvFileParser, self).__init__(
-                pipenv_contents=r.read(), use_purl_bom_ref=use_purl_bom_ref,
+                pipenv_contents=plf.read(), use_purl_bom_ref=use_purl_bom_ref,
                 debug_message=debug_message
             )

--- a/cyclonedx_py/parser/pipenv.py
+++ b/cyclonedx_py/parser/pipenv.py
@@ -27,7 +27,7 @@ from cyclonedx.parser import BaseParser
 # See https://github.com/package-url/packageurl-python/issues/65
 from packageurl import PackageURL  # type: ignore
 
-from ._debug import T_debug_message_cb, quiet
+from ._debug import DebugMessageCallback, quiet
 
 
 class PipEnvParser(BaseParser):
@@ -35,15 +35,18 @@ class PipEnvParser(BaseParser):
     def __init__(
             self, pipenv_contents: str, use_purl_bom_ref: bool = False,
             *,
-            debug_message: T_debug_message_cb = quiet
+            debug_message: DebugMessageCallback = quiet
     ) -> None:
         super().__init__()
-        self._debug_message = debug_message
+        debug_message('init')
 
+        debug_message('loading pipenv_contents')
         pipfile_lock_contents = json.loads(pipenv_contents)
         pipfile_default: Dict[str, Dict[str, Any]] = pipfile_lock_contents.get('default') or {}
 
+        debug_message('processing pipfile_default')
         for (package_name, package_data) in pipfile_default.items():
+            debug_message('processing {!s}: {!r}', package_name, package_data)
             version = str(package_data.get('version') or 'unknown').lstrip('=')
             purl = PackageURL(type='pypi', name=package_name, version=version)
             bom_ref = purl.to_string() if use_purl_bom_ref else None
@@ -51,6 +54,7 @@ class PipEnvParser(BaseParser):
             if isinstance(package_data.get('hashes'), list):
                 # Add download location with hashes stored in Pipfile.lock
                 for pip_hash in package_data['hashes']:
+                    debug_message('processing pip_hash: {!r}', pip_hash)
                     ext_ref = ExternalReference(
                         reference_type=ExternalReferenceType.DISTRIBUTION,
                         url=XsUri(c.get_pypi_url()),
@@ -58,7 +62,6 @@ class PipEnvParser(BaseParser):
                     )
                     ext_ref.hashes.add(HashType.from_composite_str(pip_hash))
                     c.external_references.add(ext_ref)
-
             self._components.append(c)
 
 
@@ -67,8 +70,9 @@ class PipEnvFileParser(PipEnvParser):
     def __init__(
             self, pipenv_lock_filename: str, use_purl_bom_ref: bool = False,
             *,
-            debug_message: T_debug_message_cb = quiet
+            debug_message: DebugMessageCallback = quiet
     ) -> None:
+        debug_message('open file: {}', pipenv_lock_filename)
         with open(pipenv_lock_filename) as r:
             super(PipEnvFileParser, self).__init__(
                 pipenv_contents=r.read(), use_purl_bom_ref=use_purl_bom_ref,

--- a/cyclonedx_py/parser/pipenv.py
+++ b/cyclonedx_py/parser/pipenv.py
@@ -38,7 +38,7 @@ class PipEnvParser(BaseParser):
             debug_message: DebugMessageCallback = quiet
     ) -> None:
         super().__init__()
-        debug_message('init')
+        debug_message('init {}', self.__class__.__name__)
 
         debug_message('loading pipenv_contents')
         pipfile_lock_contents = json.loads(pipenv_contents)

--- a/cyclonedx_py/parser/pipenv.py
+++ b/cyclonedx_py/parser/pipenv.py
@@ -27,11 +27,18 @@ from cyclonedx.parser import BaseParser
 # See https://github.com/package-url/packageurl-python/issues/65
 from packageurl import PackageURL  # type: ignore
 
+from ._debug import T_debug_message_cb, quiet
+
 
 class PipEnvParser(BaseParser):
 
-    def __init__(self, pipenv_contents: str, use_purl_bom_ref: bool = False) -> None:
+    def __init__(
+            self, pipenv_contents: str, use_purl_bom_ref: bool = False,
+            *,
+            debug_message: T_debug_message_cb = quiet
+    ) -> None:
         super().__init__()
+        self._debug_message = debug_message
 
         pipfile_lock_contents = json.loads(pipenv_contents)
         pipfile_default: Dict[str, Dict[str, Any]] = pipfile_lock_contents.get('default') or {}
@@ -57,6 +64,13 @@ class PipEnvParser(BaseParser):
 
 class PipEnvFileParser(PipEnvParser):
 
-    def __init__(self, pipenv_lock_filename: str, use_purl_bom_ref: bool = False) -> None:
+    def __init__(
+            self, pipenv_lock_filename: str, use_purl_bom_ref: bool = False,
+            *,
+            debug_message: T_debug_message_cb = quiet
+    ) -> None:
         with open(pipenv_lock_filename) as r:
-            super(PipEnvFileParser, self).__init__(pipenv_contents=r.read(), use_purl_bom_ref=use_purl_bom_ref)
+            super(PipEnvFileParser, self).__init__(
+                pipenv_contents=r.read(), use_purl_bom_ref=use_purl_bom_ref,
+                debug_message=debug_message
+            )

--- a/cyclonedx_py/parser/pipenv.py
+++ b/cyclonedx_py/parser/pipenv.py
@@ -46,7 +46,7 @@ class PipEnvParser(BaseParser):
 
         debug_message('processing pipfile_default')
         for (package_name, package_data) in pipfile_default.items():
-            debug_message('processing {!s}: {!r}', package_name, package_data)
+            debug_message('processing package: {!r} {!r}', package_name, package_data)
             version = str(package_data.get('version') or 'unknown').lstrip('=')
             purl = PackageURL(type='pypi', name=package_name, version=version)
             bom_ref = purl.to_string() if use_purl_bom_ref else None

--- a/cyclonedx_py/parser/poetry.py
+++ b/cyclonedx_py/parser/poetry.py
@@ -26,11 +26,19 @@ from cyclonedx.parser import BaseParser
 from packageurl import PackageURL  # type: ignore
 from toml import loads as load_toml
 
+from ._debug import T_debug_message_cb, quiet
+
 
 class PoetryParser(BaseParser):
 
-    def __init__(self, poetry_lock_contents: str, use_purl_bom_ref: bool = False) -> None:
+    def __init__(
+            self, poetry_lock_contents: str, use_purl_bom_ref: bool = False,
+            *,
+            debug_message: T_debug_message_cb = quiet
+    ) -> None:
         super().__init__()
+        self.debug_message = debug_message
+
         poetry_lock = load_toml(poetry_lock_contents)
 
         for package in poetry_lock['package']:
@@ -58,6 +66,13 @@ class PoetryParser(BaseParser):
 
 class PoetryFileParser(PoetryParser):
 
-    def __init__(self, poetry_lock_filename: str, use_purl_bom_ref: bool = False) -> None:
+    def __init__(
+            self, poetry_lock_filename: str, use_purl_bom_ref: bool = False,
+            *,
+            debug_message: T_debug_message_cb = quiet
+    ) -> None:
         with open(poetry_lock_filename) as r:
-            super(PoetryFileParser, self).__init__(poetry_lock_contents=r.read(), use_purl_bom_ref=use_purl_bom_ref)
+            super(PoetryFileParser, self).__init__(
+                poetry_lock_contents=r.read(), use_purl_bom_ref=use_purl_bom_ref,
+                debug_message=debug_message
+            )

--- a/cyclonedx_py/parser/poetry.py
+++ b/cyclonedx_py/parser/poetry.py
@@ -75,8 +75,8 @@ class PoetryFileParser(PoetryParser):
             debug_message: DebugMessageCallback = quiet
     ) -> None:
         debug_message('open file: {}', poetry_lock_filename)
-        with open(poetry_lock_filename) as r:
+        with open(poetry_lock_filename) as plf:
             super(PoetryFileParser, self).__init__(
-                poetry_lock_contents=r.read(), use_purl_bom_ref=use_purl_bom_ref,
+                poetry_lock_contents=plf.read(), use_purl_bom_ref=use_purl_bom_ref,
                 debug_message=debug_message
             )

--- a/cyclonedx_py/parser/poetry.py
+++ b/cyclonedx_py/parser/poetry.py
@@ -37,7 +37,7 @@ class PoetryParser(BaseParser):
             debug_message: DebugMessageCallback = quiet
     ) -> None:
         super().__init__()
-        debug_message('init')
+        debug_message('init {}', self.__class__.__name__)
 
         debug_message('loading poetry_lock_contents')
         poetry_lock = load_toml(poetry_lock_contents)

--- a/cyclonedx_py/parser/poetry.py
+++ b/cyclonedx_py/parser/poetry.py
@@ -63,6 +63,7 @@ class PoetryParser(BaseParser):
                 except CycloneDxModelException as error:
                     # @todo traceback and details to the output?
                     debug_message('Warning: suppressed {!r}', error)
+                    del error
 
             self._components.append(component)
 

--- a/cyclonedx_py/parser/requirements.py
+++ b/cyclonedx_py/parser/requirements.py
@@ -40,7 +40,7 @@ class RequirementsParser(BaseParser):
             debug_message: DebugMessageCallback = quiet
     ) -> None:
         super().__init__()
-        debug_message('init')
+        debug_message('init {}', self.__class__.__name__)
 
         if os.path.exists(requirements_content):
             debug_message('create RequirementsFile from file: {}', requirements_content)

--- a/cyclonedx_py/parser/requirements.py
+++ b/cyclonedx_py/parser/requirements.py
@@ -30,11 +30,19 @@ from cyclonedx.parser import BaseParser, ParserWarning
 from packageurl import PackageURL  # type: ignore
 from pip_requirements_parser import RequirementsFile  # type: ignore
 
+from ._debug import T_debug_message_cb, quiet
+
 
 class RequirementsParser(BaseParser):
 
-    def __init__(self, requirements_content: str, use_purl_bom_ref: bool = False) -> None:
+    def __init__(
+            self, requirements_content: str, use_purl_bom_ref: bool = False,
+            *,
+            debug_message: T_debug_message_cb = quiet
+    ) -> None:
         super().__init__()
+        self.debug_message = debug_message
+
         parsed_rf: Optional[RequirementsFile] = None
         requirements_file: Optional[_TemporaryFileWrapper[Any]] = None
 
@@ -79,5 +87,12 @@ class RequirementsParser(BaseParser):
 
 class RequirementsFileParser(RequirementsParser):
 
-    def __init__(self, requirements_file: str, use_purl_bom_ref: bool = False) -> None:
-        super().__init__(requirements_content=requirements_file, use_purl_bom_ref=use_purl_bom_ref)
+    def __init__(
+            self, requirements_file: str, use_purl_bom_ref: bool = False,
+            *,
+            debug_message: T_debug_message_cb = quiet
+    ) -> None:
+        super().__init__(
+            requirements_content=requirements_file, use_purl_bom_ref=use_purl_bom_ref,
+            debug_message=debug_message
+        )

--- a/cyclonedx_py/parser/requirements.py
+++ b/cyclonedx_py/parser/requirements.py
@@ -19,8 +19,7 @@
 
 import os
 import os.path
-from tempfile import NamedTemporaryFile, _TemporaryFileWrapper  # Weak error
-from typing import Any, Optional
+from tempfile import NamedTemporaryFile  # Weak error
 
 from cyclonedx.model import HashType
 from cyclonedx.model.component import Component

--- a/poetry.lock
+++ b/poetry.lock
@@ -451,7 +451,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "659ed36c6acf03fff3a84d0030b52ee1597d8b1ab51e65eaeec36fb3662d7b1c"
+content-hash = "8a8e2bb08219bd7ca43a369b055bbd2a4e3cf6641aac201293783b14df200a00"
 
 [metadata.files]
 attrs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ coverage = [
    { python = ">=3.7",      version = "^6.5", extras = ["toml"] },
 ]
 mypy = "^0.971"
+mypy-extensions = "^0.4.3"
 flake8 = "^4.0.1"
 flake8-annotations = {version = "^2.7.0", python = ">= 3.6.2"}
 flake8-bugbear = "^22.9.23"


### PR DESCRIPTION
currently the parsers do not output any debug information.
this PR will make all parser verbose on demand. 

call `cyclonedx-bom -X` for testing.

fixes #461

- [x] hand over central debug handler(CallBack) to parsers
- [x] utilize debug handler/CB
- [ ] unit test usage of handler/CB - check if expected messages were sent -- can be part of an additional PR