### PR TITLE
docs: improve CONTRIBUTION instructions - sign-off step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,9 @@ make html
 poetry run tox
 ```
 
-## Sign your commits
+## Sign off your commits
 
-Please sign your commits,
+Please sign off your commits,
 to show that you agree to publish your changes under the current terms and licenses of the project.
 
 ```shell


### PR DESCRIPTION
There's a difference between signing commits (-S) and signing off commits (-s).

cross-port of CycloneDX/cyclonedx-python-lib/pull/319
