### PR TITLE
Revert "chore(deps): Bump pip-requirements-parser from 32.0.0 to 32.0.1"

### DIFF
--- a/requirements.lowest.txt
+++ b/requirements.lowest.txt
@@ -4,7 +4,7 @@
 cyclonedx-python-lib == 2.0.0
 packageurl-python == 0.10.3
 importlib-metadata == 3.4.0 # ; python_version < '3.8'
-pip-requirements-parser == 32.0.1
+pip-requirements-parser == 32.0.0
 setuptools == 47.0.0
 types-setuptools == 57.0.0
 toml == 0.10.0


### PR DESCRIPTION
Reverts CycloneDX/cyclonedx-python#493

was merged by acccident