### PR TITLE
BREAKING CHANGE: remove deprecated `cyclonedx-bom` command #488

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -10,7 +10,6 @@ Once installed, you can call the tool via the following methods:
 
     $ python3 -m cyclonedx_py
     $ cyclonedx-py
-    $ cyclonedx-bom  # deprecated
 
 The full documentation can be issued by running with ``--help``:
 
@@ -83,7 +82,7 @@ Simply run:
 
 
 This will generate a CycloneDX including all packages installed in your current Python environment and output to STDOUT
-in XML using the default schema version ``1.3`` by default.
+in XML using the default schema version ``1.4`` by default.
 
 From your Python application manifest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ types-toml = "^0.10.0"
 types-setuptools = ">= 57.0.0"
 
 [tool.poetry.scripts]
-cyclonedx-bom = 'cyclonedx_py.client:main_deprecated'  # deprecated as of https://github.com/CycloneDX/cyclonedx-python/issues/488
 cyclonedx-py  = 'cyclonedx_py.client:main'
 
 [build-system]


### PR DESCRIPTION
Implementation for #488 