### PR TITLE
feat: `metadata.component` for poetry 

### DIFF
--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -249,7 +249,8 @@ class CycloneDxCmd:
         )
 
         arg_parser.add_argument('-X', action='store_true', help='Enable debug output', dest='debug_enabled')
-        arg_parser.add_argument('--add-metadata', action='store', help='File to read metadata from', dest='input_metadata')
+        arg_parser.add_argument('--add-metadata', action='store', help='File to read metadata from',
+                                dest='input_metadata')
 
         return arg_parser
 

--- a/cyclonedx_py/parser/poetry.py
+++ b/cyclonedx_py/parser/poetry.py
@@ -21,9 +21,9 @@ from enum import Enum, unique
 
 from cyclonedx.exception.model import CycloneDxModelException
 from cyclonedx.model import ExternalReference, ExternalReferenceType, HashType, Property, XsUri
+from cyclonedx.model.bom import BomMetaData
 from cyclonedx.model.component import Component
 from cyclonedx.parser import BaseParser
-from cyclonedx.model.bom import BomMetaData
 
 # See https://github.com/package-url/packageurl-python/issues/65
 from packageurl import PackageURL  # type: ignore
@@ -98,10 +98,10 @@ class PoetryParser(BaseParser):
                     debug_message('Warning: suppressed {!r}', error)
                     del error
             self._components.append(component)
-        
+
         if pyproject_toml_contents:
             poetry_toml = load_toml(pyproject_toml_contents)
-            poetry_toml_metadata = poetry_toml.get('tool','').get('poetry','')
+            poetry_toml_metadata = poetry_toml.get('tool', '').get('poetry', '')
             metadata_component = Component(
                 name=poetry_toml_metadata['name'], version=poetry_toml_metadata['version']
             )

--- a/tests/fixtures/poetry-pytoml.txt
+++ b/tests/fixtures/poetry-pytoml.txt
@@ -1,0 +1,68 @@
+[tool.poetry]
+name = "cyclonedx-bom"
+version = "3.11.0"
+description = "CycloneDX Software Bill of Materials (SBOM) generation utility"
+authors = [
+  "Steven Springett <steve.springett@owasp.org>",
+  "Paul Horton <phorton@sonatype.com>",
+]
+maintainers = [
+  "Paul Horton <phorton@sonatype.com>",
+  "Jan Kowalleck <jan.kowalleck@gmail.com>",
+]
+license = "Apache-2.0"
+readme = "README.md"
+homepage = "https://github.com/CycloneDX/cyclonedx-python/#readme"
+repository = "https://github.com/CycloneDX/cyclonedx-python"
+documentation = "https://cyclonedx-bom-tool.readthedocs.io/"
+packages = [
+    { include = "cyclonedx_py" }
+]
+include = [
+    "LICENSE", "NOTICE"
+]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+# ATTENTION: keep `deps.lowest.r` file in sync
+cyclonedx-python-lib = ">= 4.0.0, < 5.0.0"
+packageurl-python = ">= 0.9"
+importlib-metadata = { version = ">= 3.4", python = "< 3.8" }
+pip-requirements-parser = "^32.0.0"
+setuptools = ">= 47.0.0"
+toml = "^0.10.0"
+
+[tool.poetry.dev-dependencies]
+coverage = "^7.2.1"
+ddt = "^1.6.0"
+flake8 = "^5.0.4" # last version supporting Python 3.7
+flake8-annotations = "^2.9.1" # last version supporting Python 3.7
+flake8-bugbear = "^22.7.1"
+flake8-isort = "^4.1.2"
+isort = "^5.11.5" # last version supporting Python 3.7
+mypy = "^1.1.1"
+mypy-extensions = "^1.0.0"
+tox = "^3.25.1"
+# `types-toml` need to stay in sync with version of `toml`
+types-toml = "^0.10.0"
+# `types-setuptools` need to stay in sync with version of `setuptools` - but 47 was not typed...
+types-setuptools = ">= 57.0.0"
+
+[tool.poetry.scripts]
+cyclonedx-py  = 'cyclonedx_py.client:main'
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.semantic_release]
+# https://python-semantic-release.readthedocs.io/en/latest/configuration.html
+version_variable = [
+    "pyproject.toml:version"
+]
+branch = "main"
+upload_to_pypi = true
+upload_to_repository = true
+upload_to_release = true
+build_command = "pip install poetry && poetry build"
+remove_dist = false  # dist results required for some CI automation

--- a/tests/test_parser_poetry.py
+++ b/tests/test_parser_poetry.py
@@ -84,3 +84,12 @@ class TestPoetryParser(TestCase):
         c_property = next(filter(lambda p: p.name == 'cdx:poetry:package:group', component.properties), None)
         self.assertIsNotNone(c_property)
         self.assertEqual('dev', c_property.value)
+
+    @data('poetry-pytoml.txt')
+    def test_metadata(self, toml_file_name: str) -> None:
+        poetry_lock_filename = os.path.join(os.path.dirname(__file__), 'fixtures', 'poetry-lock11-simple.txt')
+        poetry_toml_filename = os.path.join(os.path.dirname(__file__), 'fixtures', toml_file_name)
+        parser = PoetryFileParser(poetry_lock_filename=poetry_lock_filename,
+                                  use_purl_bom_ref=True,
+                                  poetry_toml_filename=poetry_toml_filename)
+        self.assertEqual('cyclonedx-bom', parser._metadata.component.name)


### PR DESCRIPTION
This PR tries to address #391 

Currently I only check for a pyproject.toml. As this will be used in combination with poetry I only added this feature there.
