### PR TITLE
fix: fix typo in help page

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ optional arguments:
   -X                    Enable debug output
 
 Input Method:
-  Flags to determine how this tool obtains it's input
+  Flags to determine how this tool obtains its input
 
   -i FILE_PATH, --in-file FILE_PATH
                         File to read input from. Use "-" to read from STDIN.

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -198,7 +198,7 @@ class CycloneDxCmd:
 
         input_method_group = arg_parser.add_argument_group(
             title='Input Method',
-            description='Flags to determine how this tool obtains it\'s input'
+            description='Flags to determine how this tool obtains its input'
         )
         input_method_group.add_argument(
             '-i', '--in-file', action='store', metavar='FILE_PATH',

--- a/cyclonedx_py/utils/conda.py
+++ b/cyclonedx_py/utils/conda.py
@@ -174,7 +174,7 @@ def split_package_build_string(build_string: str) -> Tuple[str, Optional[int]]:
 
     _pos = build_string.rindex('_') if '_' in build_string else -1
     if _pos >= 1:
-        # Build number will be the last part - check if it's an integer
+        # Build number will be the last part - check if it is an integer
         # Updated logic given https://github.com/CycloneDX/cyclonedx-python-lib/issues/65
         build_number = build_string[_pos + 1:]
         if build_number.isdigit():

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -48,7 +48,7 @@ The full documentation can be issued by running with ``--help``:
       -X                    Enable debug output
 
     Input Method:
-      Flags to determine how this tool obtains it's input
+      Flags to determine how this tool obtains its input
 
       -i FILE_PATH, --in-file FILE_PATH
                             File to read input from, or STDIN if not specified


### PR DESCRIPTION
`it's` -> `its`

fixes #551