### PR TITLE
ci: finish transition to main branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ name: Docker CI
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -25,7 +25,7 @@ on:
     branches-ignore: ['dependabot/**']
   push:
     tags: [ 'v*.*.*' ]  # run again on release tags to have tools mark them
-    branches: [ 'master' ]
+    branches: [ 'main' ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,7 @@ name: Release
 
 on:
   push:
-    branches:
-      - master
+    branches: ["main"]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
somebody renamed the `master` branch to `main`.
but forgot to transition the CI triggers.

fixed this 