### PR TITLE
chore: finish transition to main branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ build-backend = "poetry.core.masonry.api"
 version_variable = [
     "pyproject.toml:version"
 ]
-branch = "master"
+branch = "main"
 upload_to_pypi = true
 upload_to_repository = true
 upload_to_release = true


### PR DESCRIPTION
somebody renamed the `master` branch to `main`.
but forgot to transition the CI triggers.

fixed this