### PR TITLE
BC: drop support for python <= 3.7

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ concurrency:
 env:
   REPORTS_DIR: CI_reports
   PYTHON_VERSION: "3.11"
-  POETRY_VERSION: "1.4.0"
+  POETRY_VERSION: "1.4.1"
 
 jobs:
   test:

--- a/.github/workflows/manual-release-candidate.yml
+++ b/.github/workflows/manual-release-candidate.yml
@@ -7,16 +7,12 @@ concurrency:
   group: release
   cancel-in-progress: false
 
-concurrency:
-  group: release
-  cancel-in-progress: false
-
 env:
   REPORTS_DIR: CI_reports
   DIST_DIR: dist
   DIST_ARTIFACT: python-dist
   PYTHON_VERSION: "3.11"
-  POETRY_VERSION: "1.4.0"
+  POETRY_VERSION: "1.4.1"
 
 jobs:
   release_candidate:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -34,7 +34,7 @@ concurrency:
 env:
   REPORTS_DIR: CI_reports
   PYTHON_VERSION_DEFAULT: "3.11"
-  POETRY_VERSION: "1.4.0"
+  POETRY_VERSION: "1.4.1"
 
 jobs:
   coding-standards:
@@ -74,7 +74,7 @@ jobs:
             toxenv-factor: 'locked'
             os: ubuntu-latest
           - # test with the lowest dependencies
-            python-version: '3.7'
+            python-version: '3.8'
             toxenv-factor: 'lowest'
             os: ubuntu-20.04
     steps:
@@ -114,23 +114,18 @@ jobs:
           - "3.11" # highest supported
           - "3.10"
           - "3.9"
-          - "3.8"
-          - "3.7"  # lowest supported -- handled in include
+          - "3.8"  # lowest supported -- handled in include
         toxenv-factor: ['locked']
         include:
-          - # test with py37 ubuntu20
-            os: ubuntu-20.04
-            python-version: '3.7'
-            toxenv-factor: 'locked'
-          - # test with the lowest dependencies
-            os: ubuntu-20.04
-            python-version: '3.7'
+          # test with the lowest dependencies
+          - os: ubuntu-latest
+            python-version: '3.8'
             toxenv-factor: 'lowest'
           - os: macos-latest
-            python-version: '3.7'
+            python-version: '3.8'
             toxenv-factor: 'lowest'
           - os: windows-latest
-            python-version: '3.7'
+            python-version: '3.8'
             toxenv-factor: 'lowest'
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ env:
   DIST_DIR: dist
   DIST_ARTIFACT: python-dist
   PYTHON_VERSION: "3.11"
-  POETRY_VERSION: "1.4.0"
+  POETRY_VERSION: "1.4.1"
 
 jobs:
   release-PyPI:

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -114,15 +114,7 @@ class CycloneDxCmd:
         bom = Bom(components=filter(self._component_filter, parser.get_components()))
 
         # region Add cyclonedx_bom as a Tool to record it being part of the CycloneDX SBOM generation process
-        if sys.version_info < (3, 8):
-            from typing import Callable
-
-            from importlib_metadata import version as __md_version
-
-            # this stupid kind of code is needed to satisfy mypy/typing
-            _md_version: Callable[[str], str] = __md_version
-        else:
-            from importlib.metadata import version as _md_version
+        from importlib.metadata import version as _md_version
         _this_tool_name = 'cyclonedx-bom'
         _this_tool_version: Optional[str] = _md_version(_this_tool_name)
         bom.metadata.tools.add(Tool(

--- a/cyclonedx_py/parser/environment.py
+++ b/cyclonedx_py/parser/environment.py
@@ -29,25 +29,21 @@ The Environment Parsers support population of the following data about Component
 """
 
 import sys
+from importlib.metadata import metadata
+
+if sys.version_info >= (3, 10):
+    from importlib.metadata import PackageMetadata as _MetadataReturn
+else:
+    from email.message import Message as _MetadataReturn
 
 from cyclonedx.exception.model import CycloneDxModelException
+from cyclonedx.factory.license import LicenseChoiceFactory, LicenseFactory
+from cyclonedx.model.component import Component
+from cyclonedx.parser import BaseParser
 
 # See https://github.com/package-url/packageurl-python/issues/65
 from packageurl import PackageURL
 from pkg_resources import Distribution
-
-if sys.version_info >= (3, 8):
-    if sys.version_info >= (3, 10):
-        from importlib.metadata import PackageMetadata as _MetadataReturn
-    else:
-        from email.message import Message as _MetadataReturn
-    from importlib.metadata import metadata
-else:
-    from importlib_metadata import metadata, PackageMetadata as _MetadataReturn
-
-from cyclonedx.factory.license import LicenseChoiceFactory, LicenseFactory
-from cyclonedx.model.component import Component
-from cyclonedx.parser import BaseParser
 
 from .._internal.license_trove_classifier import (
     PREFIX_LICENSE as _LTC_PREFIX,

--- a/cyclonedx_py/utils/conda.py
+++ b/cyclonedx_py/utils/conda.py
@@ -18,18 +18,12 @@
 # Copyright (c) OWASP Foundation. All Rights Reserved.
 
 import json
-import sys
 from json import JSONDecodeError
-from typing import Optional, Tuple
+from typing import Optional, Tuple, TypedDict
 from urllib.parse import urlparse
 
 # See https://github.com/package-url/packageurl-python/issues/65
 from packageurl import PackageURL
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
 
 
 class CondaPackage(TypedDict):

--- a/deps.lowest.r
+++ b/deps.lowest.r
@@ -3,7 +3,6 @@
 
 cyclonedx-python-lib == 4.2.1
 packageurl-python == 0.11.1
-importlib-metadata == 3.4.0 # ; python_version < '3.8'
 pip-requirements-parser == 32.0.0
 setuptools == 47.0.0
 types-setuptools == 57.0.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -190,7 +190,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-metadata = {version = ">=1.1.0,<4.3", markers = "python_version < \"3.8\""}
 mccabe = ">=0.7.0,<0.8.0"
 pycodestyle = ">=2.9.0,<2.10.0"
 pyflakes = ">=2.5.0,<2.6.0"
@@ -210,7 +209,6 @@ files = [
 [package.dependencies]
 attrs = ">=21.4"
 flake8 = ">=3.7"
-typed-ast = {version = ">=1.4,<2.0", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "flake8-bugbear"
@@ -249,26 +247,6 @@ isort = ">=4.3.5,<6"
 
 [package.extras]
 test = ["pytest-cov"]
-
-[[package]]
-name = "importlib-metadata"
-version = "3.10.1"
-description = "Read metadata from Python packages"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "importlib_metadata-3.10.1-py3-none-any.whl", hash = "sha256:2ec0faae539743ae6aaa84b49a169670a465f7f5d64e6add98388cc29fd1f2f6"},
-    {file = "importlib_metadata-3.10.1.tar.gz", hash = "sha256:c9356b657de65c53744046fa8f7358afe0714a1af7d570c00c3835c2d724a7c1"},
-]
-
-[package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
-zipp = ">=0.5"
-
-[package.extras]
-docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pep517", "pyfakefs", "pytest (>=4.6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
 
 [[package]]
 name = "isort"
@@ -358,7 +336,6 @@ files = [
 [package.dependencies]
 mypy-extensions = ">=1.0.0"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typed-ast = {version = ">=1.4.0,<2", markers = "python_version < \"3.8\""}
 typing-extensions = ">=3.10"
 
 [package.extras]
@@ -441,9 +418,6 @@ files = [
     {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=4.4", markers = "python_version < \"3.8\""}
-
 [package.extras]
 docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
@@ -459,9 +433,6 @@ files = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
-
-[package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
@@ -613,7 +584,6 @@ files = [
 [package.dependencies]
 colorama = {version = ">=0.4.1", markers = "platform_system == \"Windows\""}
 filelock = ">=3.0.0"
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 packaging = ">=14"
 pluggy = ">=0.12.0"
 py = ">=1.4.17"
@@ -624,40 +594,6 @@ virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,
 [package.extras]
 docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
 testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "psutil (>=5.6.1)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)"]
-
-[[package]]
-name = "typed-ast"
-version = "1.5.4"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "typed_ast-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4"},
-    {file = "typed_ast-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62"},
-    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:267e3f78697a6c00c689c03db4876dd1efdfea2f251a5ad6555e82a26847b4ac"},
-    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c542eeda69212fa10a7ada75e668876fdec5f856cd3d06829e6aa64ad17c8dfe"},
-    {file = "typed_ast-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:a9916d2bb8865f973824fb47436fa45e1ebf2efd920f2b9f99342cb7fab93f72"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79b1e0869db7c830ba6a981d58711c88b6677506e648496b1f64ac7d15633aec"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a94d55d142c9265f4ea46fab70977a1944ecae359ae867397757d836ea5a3f47"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:183afdf0ec5b1b211724dfef3d2cad2d767cbefac291f24d69b00546c1837fb6"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:639c5f0b21776605dd6c9dbe592d5228f021404dafd377e2b7ac046b0349b1a1"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf4afcfac006ece570e32d6fa90ab74a17245b83dfd6655a6f68568098345ff6"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6778e1b2f81dfc7bc58e4b259363b83d2e509a65198e85d5700dfae4c6c8ff1c"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2"},
-    {file = "typed_ast-1.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2efae9db7a8c05ad5547d522e7dbe62c83d838d3906a3716d1478b6c1d61388d"},
-    {file = "typed_ast-1.5.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7d5d014b7daa8b0bf2eaef684295acae12b036d79f54178b92a2b6a56f92278f"},
-    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:370788a63915e82fd6f212865a596a0fefcbb7d408bbbb13dea723d971ed8bdc"},
-    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4e964b4ff86550a7a7d56345c7864b18f403f5bd7380edf44a3c1fb4ee7ac6c6"},
-    {file = "typed_ast-1.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:683407d92dc953c8a7347119596f0b0e6c55eb98ebebd9b23437501b28dcbb8e"},
-    {file = "typed_ast-1.5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4879da6c9b73443f97e731b617184a596ac1235fe91f98d279a7af36c796da35"},
-    {file = "typed_ast-1.5.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3e123d878ba170397916557d31c8f589951e353cc95fb7f24f6bb69adc1a8a97"},
-    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3"},
-    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
-    {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
-    {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
-]
 
 [[package]]
 name = "types-setuptools"
@@ -687,7 +623,7 @@ files = [
 name = "typing-extensions"
 version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -710,30 +646,13 @@ files = [
 [package.dependencies]
 distlib = ">=0.3.1,<1"
 filelock = ">=3.2,<4"
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 platformdirs = ">=2,<3"
 
 [package.extras]
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
 testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "packaging (>=20.0)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)"]
 
-[[package]]
-name = "zipp"
-version = "3.15.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "zipp-3.15.0-py3-none-any.whl", hash = "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"},
-    {file = "zipp-3.15.0.tar.gz", hash = "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
-
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.7"
-content-hash = "7db0701e46ae889feefe47178dfd5a959cf157acd00d31692ba507a3152783fb"
+python-versions = "^3.8"
+content-hash = "8c402845349fa835ea3633e1948f2414a093839bd506fb0c480813253e97a596"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,20 +33,18 @@ classifiers = [
     'Topic :: Software Development',
     'Topic :: System :: Software Distribution',
     'License :: OSI Approved :: Apache Software License',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Typing :: Typed'
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 # ATTENTION: keep `deps.lowest.r` file in sync
 cyclonedx-python-lib = "^4.2.1"
 packageurl-python = ">= 0.11"
-importlib-metadata = { version = ">= 3.4", python = "< 3.8" }
 pip-requirements-parser = "^32.0.0"
 setuptools = ">= 47.0.0"
 toml = "^0.10.0"

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ minversion = 3.10
 envlist =
     flake8
     mypy-{locked,lowest}
-    py{311,310,39,38,37}-{locked,lowest}
+    py{311,310,39,38}-{locked,lowest}
 isolated_build = True
 skip_missing_interpreters = True
 usedevelop = False
@@ -32,7 +32,7 @@ skip_install = True
 commands =
     # mypy config is on own file: `.mypy.ini`
     !lowest: poetry run mypy
-     lowest: poetry run mypy --python-version=3.7
+     lowest: poetry run mypy --python-version=3.8
 
 [testenv:flake8]
 skip_install = True


### PR DESCRIPTION
- BREAKING CHANGE: remove support for py37 and below
- removed now unnecessary dependencies

fixes #582