### PR TITLE
feat: have own version visible everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,17 @@ python3 -m cyclonedx_py
 
 ```text
 $ cyclonedx-py --help
-usage: cyclonedx-py [-h] (-c | -cj | -e | -p | -pip | -r) [-i FILE_PATH]
+usage: cyclonedx-py [-h] [--version] 
+                 (-c | -cj | -e | -p | -pip | -r) [-i FILE_PATH]
                  [--format {json,xml}] [--schema-version {1.4,1.3,1.2,1.1,1.0}]
-                 [-o FILE_PATH] [-F] [-X]
+                 [-o FILE_PATH] 
+                 [-F] [-X]
 
 CycloneDX SBOM Generator
 
 optional arguments:
   -h, --help            show this help message and exit
+  --version             show program's version number and exit
   -c, --conda           Build a SBOM based on the output from `conda list
                         --explicit` or `conda list --explicit --md5`
   -cj, --conda-json     Build a SBOM based on the output from `conda list

--- a/cyclonedx_py/__init__.py
+++ b/cyclonedx_py/__init__.py
@@ -14,3 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
+# !! version is managed by semantic_release
+# do not use typing here, or else `semantic_release` might have issues finding the variable
+__version__ = "4.0.0.dev0"

--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -32,6 +32,7 @@ from cyclonedx.output import BaseOutput, get_instance as get_output_instance
 from cyclonedx.parser import BaseParser
 from cyclonedx.schema import OutputFormat, SchemaVersion
 
+from . import __version__ as _this_tool_version
 from .parser._cdx_properties import Pipenv as PipenvProps, Poetry as PoetryProp
 from .parser.conda import CondaListExplicitParser, CondaListJsonParser
 from .parser.environment import EnvironmentParser
@@ -113,16 +114,11 @@ class CycloneDxCmd:
 
         bom = Bom(components=filter(self._component_filter, parser.get_components()))
 
-        # region Add cyclonedx_bom as a Tool to record it being part of the CycloneDX SBOM generation process
-        from importlib.metadata import version as _md_version
-        _this_tool_name = 'cyclonedx-bom'
-        _this_tool_version: Optional[str] = _md_version(_this_tool_name)
         bom.metadata.tools.add(Tool(
             vendor='CycloneDX',
-            name=_this_tool_name,
+            name='cyclonedx-bom',
             version=_this_tool_version
         ))
-        # endregion
 
         return get_output_instance(
             bom=bom,
@@ -159,6 +155,7 @@ class CycloneDxCmd:
     @staticmethod
     def get_arg_parser(*, prog: Optional[str] = None) -> argparse.ArgumentParser:
         arg_parser = argparse.ArgumentParser(prog=prog, description='CycloneDX SBOM Generator')
+        arg_parser.add_argument('--version', action='version', version=_this_tool_version)
 
         input_group = arg_parser.add_mutually_exclusive_group(required=True)
         input_group.add_argument(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,8 @@ copyright = '2022, Copyright (c) OWASP Foundation'
 author = 'Paul Horton, Jan Kowalleck, Steve Springett, Patrick Dwyer'
 
 # The full version, including alpha/beta/rc tags
-release = pkg_resources.get_distribution("cyclonedx-bom").version
+# !! version is managed by semantic_release
+release = "4.0.0.dev0"
 
 # -- General configuration ---------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,10 @@ build-backend = "poetry.core.masonry.api"
 [tool.semantic_release]
 # https://python-semantic-release.readthedocs.io/en/latest/configuration.html
 version_variable = [
-    "pyproject.toml:version"
+  "cyclonedx_py/__init__.py:__version__",
+  "docs/conf.py:release",
 ]
+version_toml = "pyproject.toml:tool.poetry.version"
 branch = "main"
 upload_to_pypi = true
 upload_to_repository = true


### PR DESCRIPTION
adds `--version` CLI switch, which causes the output of the current version.

fixes #583