### PR TITLE
feat: support CDX1.5

### DIFF
--- a/cyclonedx_py/_internal/cli.py
+++ b/cyclonedx_py/_internal/cli.py
@@ -82,7 +82,7 @@ class Command:
                         dest='schema_version',
                         choices=SchemaVersion,
                         type=SchemaVersion.from_version,
-                        default=SchemaVersion.V1_4.to_version())
+                        default=SchemaVersion.V1_5.to_version())
         op.add_argument('--of', '--output-format',
                         metavar='FORMAT',
                         help=f'The output format for your SBOM {choices4enum(OutputFormat)} (default: %(default)s)',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,9 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.8"
 # ATTENTION: keep `deps.lowest.r` file in sync
-cyclonedx-python-lib = { version = "^5.1.1", extras = ['validation'] }
+cyclonedx-python-lib = { version = "^6.0.0", extras = ['validation'] }
 packageurl-python = ">= 0.11"
 pip-requirements-parser = "^32.0.0"
-setuptools = ">= 47.0.0"
 tomli = { version = "^2.0.1", python = "<3.11" }
 chardet = "^5.1"
 

--- a/tests/_data/snapshots/pipenv/category-deps_1.5.json.bin
+++ b/tests/_data/snapshots/pipenv/category-deps_1.5.json.bin
@@ -1,0 +1,63 @@
+{
+  "components": [
+    {
+      "bom-ref": "toml==0.10.2",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "root-component"
+    },
+    {
+      "ref": "toml==0.10.2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "dependencies organized in groups",
+      "name": "category-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/pipenv/category-deps_1.5.xml.bin
+++ b/tests/_data/snapshots/pipenv/category-deps_1.5.xml.bin
@@ -1,0 +1,73 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>category-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="toml==0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="root-component"/>
+    <dependency ref="toml==0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/default-and-dev_1.5.json.bin
+++ b/tests/_data/snapshots/pipenv/default-and-dev_1.5.json.bin
@@ -1,0 +1,96 @@
+{
+  "components": [
+    {
+      "bom-ref": "colorama==0.4.6",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "toml==0.10.2",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "colorama==0.4.6"
+    },
+    {
+      "ref": "root-component"
+    },
+    {
+      "ref": "toml==0.10.2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "default and dev depenndencies",
+      "name": "default-and-dev",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/pipenv/default-and-dev_1.5.xml.bin
+++ b/tests/_data/snapshots/pipenv/default-and-dev_1.5.xml.bin
@@ -1,0 +1,92 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>default-and-dev</name>
+      <version>0.1.0</version>
+      <description>default and dev depenndencies</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="colorama==0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml==0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="colorama==0.4.6"/>
+    <dependency ref="root-component"/>
+    <dependency ref="toml==0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/editable-self_1.5.json.bin
+++ b/tests/_data/snapshots/pipenv/editable-self_1.5.json.bin
@@ -1,0 +1,34 @@
+{
+  "dependencies": [
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "install the current project as an editable",
+      "name": "editable-self",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/pipenv/editable-self_1.5.xml.bin
+++ b/tests/_data/snapshots/pipenv/editable-self_1.5.xml.bin
@@ -1,0 +1,55 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>editable-self</name>
+      <version>0.1.0</version>
+      <description>install the current project as an editable</description>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+  </metadata>
+  <dependencies>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/local_1.5.json.bin
+++ b/tests/_data/snapshots/pipenv/local_1.5.json.bin
@@ -1,0 +1,105 @@
+{
+  "components": [
+    {
+      "bom-ref": "package-a",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3869fe3f4a6cca5b203b2e2cd8858c834f651e1b0fa76d5c0232e36472199592"
+            }
+          ],
+          "type": "distribution",
+          "url": "../../_helpers/local_pckages/a/dist/package-a-23.42.tar.gz"
+        }
+      ],
+      "name": "package-a",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "bom-ref": "package-b",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4aacda53fa274f5ff7eed71a9916904ffb3a11b05dc5ca529d7ddb78ae2dc602"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:../../_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl"
+        }
+      ],
+      "name": "package-b",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "bom-ref": "package-c",
+      "externalReferences": [
+        {
+          "comment": "from path",
+          "type": "distribution",
+          "url": "../../_helpers/local_pckages/c"
+        }
+      ],
+      "name": "package-c",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "package-a"
+    },
+    {
+      "ref": "package-b"
+    },
+    {
+      "ref": "package-c"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "packages from local paths",
+      "name": "local",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/pipenv/local_1.5.xml.bin
+++ b/tests/_data/snapshots/pipenv/local_1.5.xml.bin
@@ -1,0 +1,99 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>local</name>
+      <version>0.1.0</version>
+      <description>packages from local paths</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="package-a">
+      <name>package-a</name>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../_helpers/local_pckages/a/dist/package-a-23.42.tar.gz</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">3869fe3f4a6cca5b203b2e2cd8858c834f651e1b0fa76d5c0232e36472199592</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="package-b">
+      <name>package-b</name>
+      <externalReferences>
+        <reference type="distribution">
+          <url>file:../../_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">4aacda53fa274f5ff7eed71a9916904ffb3a11b05dc5ca529d7ddb78ae2dc602</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="package-c">
+      <name>package-c</name>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../_helpers/local_pckages/c</url>
+          <comment>from path</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="package-a"/>
+    <dependency ref="package-b"/>
+    <dependency ref="package-c"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/no-deps_1.5.json.bin
+++ b/tests/_data/snapshots/pipenv/no-deps_1.5.json.bin
@@ -1,0 +1,33 @@
+{
+  "dependencies": [
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "packages with all meta, but no deps",
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "no-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/pipenv/no-deps_1.5.xml.bin
+++ b/tests/_data/snapshots/pipenv/no-deps_1.5.xml.bin
@@ -1,0 +1,55 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>no-deps</name>
+      <version>0.1.0</version>
+      <description>packages with all meta, but no deps</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+    </component>
+  </metadata>
+  <dependencies>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/private-packages_1.5.json.bin
+++ b/tests/_data/snapshots/pipenv/private-packages_1.5.json.bin
@@ -1,0 +1,129 @@
+{
+  "components": [
+    {
+      "bom-ref": "numpy==1.26.2",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "96ca5482c3dbdd051bcd1fce8034603d6ebfc125a7bd59f55b40d8f5d246832b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/numpy/"
+        }
+      ],
+      "name": "numpy",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/numpy@1.26.2",
+      "type": "library",
+      "version": "1.26.2"
+    },
+    {
+      "bom-ref": "six==1.16.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml==0.10.2",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pysrc1.acme.org",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/toml/"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "numpy==1.26.2"
+    },
+    {
+      "ref": "root-component"
+    },
+    {
+      "ref": "six==1.16.0"
+    },
+    {
+      "ref": "toml==0.10.2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "packages from aternative package repositories",
+      "name": "private-packges",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/pipenv/private-packages_1.5.xml.bin
+++ b/tests/_data/snapshots/pipenv/private-packages_1.5.xml.bin
@@ -1,0 +1,111 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>private-packges</name>
+      <version>0.1.0</version>
+      <description>packages from aternative package repositories</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="numpy==1.26.2">
+      <name>numpy</name>
+      <version>1.26.2</version>
+      <purl>pkg:pypi/numpy@1.26.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/numpy/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">96ca5482c3dbdd051bcd1fce8034603d6ebfc125a7bd59f55b40d8f5d246832b</hash>
+            <hash alg="SHA-256">f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six==1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml==0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <purl>pkg:pypi/toml@0.10.2?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/toml/</url>
+          <comment>from explicit index: pysrc1.acme.org</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="numpy==1.26.2"/>
+    <dependency ref="root-component"/>
+    <dependency ref="six==1.16.0"/>
+    <dependency ref="toml==0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/pypi-mirror_private-packages_1.5.json.bin
+++ b/tests/_data/snapshots/pipenv/pypi-mirror_private-packages_1.5.json.bin
@@ -1,0 +1,119 @@
+{
+  "components": [
+    {
+      "bom-ref": "numpy==1.26.2",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "96ca5482c3dbdd051bcd1fce8034603d6ebfc125a7bd59f55b40d8f5d246832b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypy-mirror.testing.acme.org/simple/numpy/"
+        }
+      ],
+      "name": "numpy",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/numpy@1.26.2?repository_url=https://pypy-mirror.testing.acme.org/simple",
+      "type": "library",
+      "version": "1.26.2"
+    },
+    {
+      "bom-ref": "six==1.16.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypy-mirror.testing.acme.org/simple/six/"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml==0.10.2",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pysrc1.acme.org",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/toml/"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "numpy==1.26.2"
+    },
+    {
+      "ref": "six==1.16.0"
+    },
+    {
+      "ref": "toml==0.10.2"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/pipenv/pypi-mirror_private-packages_1.5.xml.bin
+++ b/tests/_data/snapshots/pipenv/pypi-mirror_private-packages_1.5.xml.bin
@@ -1,0 +1,105 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="numpy==1.26.2">
+      <name>numpy</name>
+      <version>1.26.2</version>
+      <purl>pkg:pypi/numpy@1.26.2?repository_url=https://pypy-mirror.testing.acme.org/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypy-mirror.testing.acme.org/simple/numpy/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">96ca5482c3dbdd051bcd1fce8034603d6ebfc125a7bd59f55b40d8f5d246832b</hash>
+            <hash alg="SHA-256">f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six==1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypy-mirror.testing.acme.org/simple/six/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml==0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <purl>pkg:pypi/toml@0.10.2?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/toml/</url>
+          <comment>from explicit index: pysrc1.acme.org</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="numpy==1.26.2"/>
+    <dependency ref="six==1.16.0"/>
+    <dependency ref="toml==0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/some-categories_category-deps_1.5.json.bin
+++ b/tests/_data/snapshots/pipenv/some-categories_category-deps_1.5.json.bin
@@ -1,0 +1,288 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow==1.3.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "colorama==0.4.6",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "categoryB"
+        },
+        {
+          "name": "cdx:pipenv:category",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "ddt==1.7.0",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a0719acde99dd32767cff64e653ef99c01ad5b042ff265f2ebecd28796ffd114"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d178d115abf25a1b8327e94f85a03ef09b1d7b0ca256f6203284b024f2fc70df"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ddt/"
+        }
+      ],
+      "name": "ddt",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "develop"
+        }
+      ],
+      "purl": "pkg:pypi/ddt@1.7.0",
+      "type": "library",
+      "version": "1.7.0"
+    },
+    {
+      "bom-ref": "isoduration==20.11.0",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil==2.8.2",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six==1.16.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml==0.10.2",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil==2.8.19.14",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "arrow==1.3.0"
+    },
+    {
+      "ref": "colorama==0.4.6"
+    },
+    {
+      "ref": "ddt==1.7.0"
+    },
+    {
+      "ref": "isoduration==20.11.0"
+    },
+    {
+      "ref": "python-dateutil==2.8.2"
+    },
+    {
+      "ref": "six==1.16.0"
+    },
+    {
+      "ref": "toml==0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil==2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/pipenv/some-categories_category-deps_1.5.xml.bin
+++ b/tests/_data/snapshots/pipenv/some-categories_category-deps_1.5.xml.bin
@@ -1,0 +1,201 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow==1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorama==0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">categoryB</property>
+        <property name="cdx:pipenv:category">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="ddt==1.7.0">
+      <name>ddt</name>
+      <version>1.7.0</version>
+      <purl>pkg:pypi/ddt@1.7.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ddt/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">a0719acde99dd32767cff64e653ef99c01ad5b042ff265f2ebecd28796ffd114</hash>
+            <hash alg="SHA-256">d178d115abf25a1b8327e94f85a03ef09b1d7b0ca256f6203284b024f2fc70df</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">develop</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration==20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil==2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six==1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml==0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil==2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">groupA</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow==1.3.0"/>
+    <dependency ref="colorama==0.4.6"/>
+    <dependency ref="ddt==1.7.0"/>
+    <dependency ref="isoduration==20.11.0"/>
+    <dependency ref="python-dateutil==2.8.2"/>
+    <dependency ref="six==1.16.0"/>
+    <dependency ref="toml==0.10.2"/>
+    <dependency ref="types-python-dateutil==2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/with-dev_default-and-dev_1.5.json.bin
+++ b/tests/_data/snapshots/pipenv/with-dev_default-and-dev_1.5.json.bin
@@ -1,0 +1,251 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow==1.3.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "develop"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "colorama==0.4.6",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "isoduration==20.11.0",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "develop"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil==2.8.2",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "develop"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six==1.16.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "develop"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml==0.10.2",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil==2.8.19.14",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "develop"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "arrow==1.3.0"
+    },
+    {
+      "ref": "colorama==0.4.6"
+    },
+    {
+      "ref": "isoduration==20.11.0"
+    },
+    {
+      "ref": "python-dateutil==2.8.2"
+    },
+    {
+      "ref": "six==1.16.0"
+    },
+    {
+      "ref": "toml==0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil==2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/pipenv/with-dev_default-and-dev_1.5.xml.bin
+++ b/tests/_data/snapshots/pipenv/with-dev_default-and-dev_1.5.xml.bin
@@ -1,0 +1,181 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow==1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">develop</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorama==0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration==20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">develop</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil==2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">develop</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six==1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">develop</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml==0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil==2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">develop</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow==1.3.0"/>
+    <dependency ref="colorama==0.4.6"/>
+    <dependency ref="isoduration==20.11.0"/>
+    <dependency ref="python-dateutil==2.8.2"/>
+    <dependency ref="six==1.16.0"/>
+    <dependency ref="toml==0.10.2"/>
+    <dependency ref="types-python-dateutil==2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/with-extras_1.5.json.bin
+++ b/tests/_data/snapshots/pipenv/with-extras_1.5.json.bin
@@ -1,0 +1,1615 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow==1.3.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "attrs==23.1.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/"
+        }
+      ],
+      "name": "attrs",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/attrs@23.1.0",
+      "type": "library",
+      "version": "23.1.0"
+    },
+    {
+      "bom-ref": "boolean.py==4.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "17b9a181630e43dde1851d42bef546d616d5d9b4480357514597e78b203d06e4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2876f2051d7d6394a531d82dc6eb407faa0b01a0a0b3083817ccd7323b8d96bd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/boolean.py/"
+        }
+      ],
+      "name": "boolean.py",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/boolean.py@4.0",
+      "type": "library",
+      "version": "4.0"
+    },
+    {
+      "bom-ref": "cyclonedx-python-lib==5.1.1",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "215a636a4e77385d2cf4c6c9801c9bad4791849634f2c6daa45ab2c6cb0a85f6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2989db0cd8bb4c0c442423d71ed7a84ae059e16a2d0f932cc4bf92da7385cdb3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/cyclonedx-python-lib/"
+        }
+      ],
+      "name": "cyclonedx-python-lib",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        },
+        {
+          "name": "cdx:python:package:extra",
+          "value": "json-validation"
+        },
+        {
+          "name": "cdx:python:package:extra",
+          "value": "xml-validation"
+        }
+      ],
+      "purl": "pkg:pypi/cyclonedx-python-lib@5.1.1",
+      "type": "library",
+      "version": "5.1.1"
+    },
+    {
+      "bom-ref": "defusedxml==0.7.1",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/defusedxml/"
+        }
+      ],
+      "name": "defusedxml",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/defusedxml@0.7.1",
+      "type": "library",
+      "version": "0.7.1"
+    },
+    {
+      "bom-ref": "fqdn==1.5.1",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fqdn/"
+        }
+      ],
+      "name": "fqdn",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/fqdn@1.5.1",
+      "type": "library",
+      "version": "1.5.1"
+    },
+    {
+      "bom-ref": "idna==3.6",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/"
+        }
+      ],
+      "name": "idna",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/idna@3.6",
+      "type": "library",
+      "version": "3.6"
+    },
+    {
+      "bom-ref": "isoduration==20.11.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "jsonpointer==2.4",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonpointer/"
+        }
+      ],
+      "name": "jsonpointer",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/jsonpointer@2.4",
+      "type": "library",
+      "version": "2.4"
+    },
+    {
+      "bom-ref": "jsonschema==4.20.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f614fd46d8d61258610998997743ec5492a648b33cf478c1ddc23ed4598a5fa"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ed6231f0429ecf966f5bc8dfef245998220549cbbcf140f913b7464c52c3b6b3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema/"
+        }
+      ],
+      "name": "jsonschema",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        },
+        {
+          "name": "cdx:python:package:extra",
+          "value": "format"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema@4.20.0",
+      "type": "library",
+      "version": "4.20.0"
+    },
+    {
+      "bom-ref": "jsonschema-specifications==2023.11.2",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9472fc4fea474cd74bea4a2b190daeccb5a9e4db2ea80efcf7a1b582fc9a81b8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e74ba7c0a65e8cb49dc26837d6cfe576557084a8b423ed16a420984228104f93"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/"
+        }
+      ],
+      "name": "jsonschema-specifications",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema-specifications@2023.11.2",
+      "type": "library",
+      "version": "2023.11.2"
+    },
+    {
+      "bom-ref": "license-expression==30.2.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1a7dc2bb2d09cdc983d072e4f9adc787e107e09def84cbb3919baaaf4f8e6fa1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "599928edd995c43fc335e0af342076144dc71cb858afa1ed9c1c30c4e81794f5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/license-expression/"
+        }
+      ],
+      "name": "license-expression",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/license-expression@30.2.0",
+      "type": "library",
+      "version": "30.2.0"
+    },
+    {
+      "bom-ref": "lxml==4.9.3",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05186a0f1346ae12553d66df1cfce6f251589fea3ad3da4f3ef4e34b2d58c6a3"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "075b731ddd9e7f68ad24c635374211376aa05a281673ede86cbe1d1b3455279d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "081d32421db5df44c41b7f08a334a090a545c54ba977e47fd7cc2deece78809a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "0a3d3487f07c1d7f150894c238299934a2a074ef590b583103a45002035be120"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "0bfd0767c5c1de2551a120673b72e5d4b628737cb05414f03c3277bf9bed3305"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "0c0850c8b02c298d3c7006b23e98249515ac57430e16a166873fc47a5d549287"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "0e2cb47860da1f7e9a5256254b74ae331687b9672dfa780eed355c4c9c3dbd23"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "120fa9349a24c7043854c53cae8cec227e1f79195a7493e09e0c12e29f918e52"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1247694b26342a7bf47c02e513d32225ededd18045264d40758abeb3c838a51f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "141f1d1a9b663c679dc524af3ea1773e618907e96075262726c7612c02b149a4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "14e019fd83b831b2e61baed40cab76222139926b1fb5ed0e79225bc0cae14584"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1509dd12b773c02acd154582088820893109f6ca27ef7291b003d0e81666109f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "17a753023436a18e27dd7769e798ce302963c236bc4114ceee5b25c18c52c693"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1e224d5755dba2f4a9498e150c43792392ac9b5380aa1b845f98a1618c94eeef"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1f447ea5429b54f9582d4b955f5f1985f278ce5cf169f72eea8afd9502973dd5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "23eed6d7b1a3336ad92d8e39d4bfe09073c31bfe502f20ca5116b2a334f8ec02"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "25f32acefac14ef7bd53e4218fe93b804ef6f6b92ffdb4322bb6d49d94cad2bc"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2c74524e179f2ad6d2a4f7caf70e2d96639c0954c943ad601a9e146c76408ed7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "303bf1edce6ced16bf67a18a1cf8339d0db79577eec5d9a6d4a80f0fb10aa2da"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3331bece23c9ee066e0fb3f96c61322b9e0f54d775fccefff4c38ca488de283a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3e9bdd30efde2b9ccfa9cb5768ba04fe71b018a25ea093379c857c9dad262c40"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "411007c0d88188d9f621b11d252cce90c4a2d1a49db6c068e3c16422f306eab8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "42871176e7896d5d45138f6d28751053c711ed4d48d8e30b498da155af39aebd"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "46f409a2d60f634fe550f7133ed30ad5321ae2e6630f13657fb9479506b00601"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "48628bd53a426c9eb9bc066a923acaa0878d1e86129fd5359aee99285f4eed9c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "48d6ed886b343d11493129e019da91d4039826794a3e3027321c56d9e71505be"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4930be26af26ac545c3dffb662521d4e6268352866956672231887d18f0eaab2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4aec80cde9197340bc353d2768e2a75f5f60bacda2bab72ab1dc499589b3878c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4c28a9144688aef80d6ea666c809b4b0e50010a2aca784c97f5e6bf143d9f129"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4d2d1edbca80b510443f51afd8496be95529db04a509bc8faee49c7b0fb6d2cc"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4dd9a263e845a72eacb60d12401e37c616438ea2e5442885f65082c276dfb2b2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4f1026bc732b6a7f96369f7bfe1a4f2290fb34dce00d8644bc3036fb351a4ca1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4fb960a632a49f2f089d522f70496640fdf1218f1243889da3822e0a9f5f3ba7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "50670615eaf97227d5dc60de2dc99fb134a7130d310d783314e7724bf163f75d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "50baa9c1c47efcaef189f31e3d00d697c6d4afda5c3cde0302d063492ff9b477"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "53ace1c1fd5a74ef662f844a0413446c0629d151055340e9893da958a374f70d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5515edd2a6d1a5a70bfcdee23b42ec33425e405c5b351478ab7dc9347228f96e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "56dc1f1ebccc656d1b3ed288f11e27172a01503fc016bcabdcbc0978b19352b7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "578695735c5a3f51569810dfebd05dd6f888147a34f0f98d4bb27e92b76e05c2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "57aba1bbdf450b726d58b2aea5fe47c7875f5afb2c4a23784ed78f19a0462574"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "57d6ba0ca2b0c462f339640d22882acc711de224d769edf29962b09f77129cbf"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5c245b783db29c4e4fbbbfc9c5a78be496c9fea25517f90606aa1f6b2b3d5f7b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5c31c7462abdf8f2ac0577d9f05279727e698f97ecbb02f17939ea99ae8daa98"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "64f479d719dc9f4c813ad9bb6b28f8390360660b73b2e4beb4cb0ae7104f1c12"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "65299ea57d82fb91c7f019300d24050c4ddeb7c5a190e076b5f48a2b43d19c42"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6689a3d7fd13dc687e9102a27e98ef33730ac4fe37795d5036d18b4d527abd35"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "690dafd0b187ed38583a648076865d8c229661ed20e48f2335d68e2cf7dc829d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6fc3c450eaa0b56f815c7b62f2b7fba7266c4779adcf1cece9e6deb1de7305ce"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "704f61ba8c1283c71b16135caf697557f5ecf3e74d9e453233e4771d68a1f42d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "71c52db65e4b56b8ddc5bb89fb2e66c558ed9d1a74a45ceb7dcb20c191c3df2f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "71d66ee82e7417828af6ecd7db817913cb0cf9d4e61aa0ac1fde0583d84358db"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "7d298a1bd60c067ea75d9f684f5f3992c9d6766fadbc0bcedd39750bf344c2f4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8b77946fd508cbf0fccd8e400a7f71d4ac0e1595812e66025bac475a8e811694"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8d7e43bd40f65f7d97ad8ef5c9b1778943d02f04febef12def25f7583d19baac"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8df133a2ea5e74eef5e8fc6f19b9e085f758768a16e9877a60aec455ed2609b2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8ed74706b26ad100433da4b9d807eae371efaa266ffc3e9191ea436087a9d6a7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "92af161ecbdb2883c4593d5ed4815ea71b31fafd7fd05789b23100d081ecac96"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "97047f0d25cd4bcae81f9ec9dc290ca3e15927c192df17331b53bebe0e3ff96d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9719fe17307a9e814580af1f5c6e05ca593b12fb7e44fe62450a5384dbf61b4b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9767e79108424fb6c3edf8f81e6730666a50feb01a328f4a016464a5893f835a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9a92d3faef50658dd2c5470af249985782bf754c4e18e15afb67d3ab06233f13"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9bb6ad405121241e99a86efff22d3ef469024ce22875a7ae045896ad23ba2340"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9e28c51fa0ce5674be9f560c6761c1b441631901993f76700b1b30ca6c8378d6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "aca086dc5f9ef98c512bac8efea4483eb84abbf926eaeedf7b91479feb092458"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ae8b9c6deb1e634ba4f1930eb67ef6e6bf6a44b6eb5ad605642b2d6d5ed9ce3c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b0a545b46b526d418eb91754565ba5b63b1c0b12f9bd2f808c852d9b4b2f9b5c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b4e4bc18382088514ebde9328da057775055940a1f2e18f6ad2d78aa0f3ec5b9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b6420a005548ad52154c8ceab4a1290ff78d757f9e5cbc68f8c77089acd3c432"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b86164d2cff4d3aaa1f04a14685cbc072efd0b4f99ca5708b2ad1b9b5988a991"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bb3bb49c7a6ad9d981d734ef7c7193bc349ac338776a0360cc671eaee89bcf69"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bef4e656f7d98aaa3486d2627e7d2df1157d7e88e7efd43a65aa5dd4714916cf"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c0781a98ff5e6586926293e59480b64ddd46282953203c76ae15dbbbf302e8bb"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c2006f5c8d28dee289f7020f721354362fa304acbaaf9745751ac4006650254b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c41bfca0bd3532d53d16fd34d20806d5c2b1ace22a2f2e4c0008570bf2c58833"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "cd47b4a0d41d2afa3e58e5bf1f62069255aa2fd6ff5ee41604418ca925911d76"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "cdb650fc86227eba20de1a29d4b2c1bfe139dc75a0669270033cb2ea3d391b85"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "cef2502e7e8a96fe5ad686d60b49e1ab03e438bd9123987994528febd569868e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d27be7405547d1f958b60837dc4c1007da90b8b23f54ba1f8b728c78fdb19d50"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d37017287a7adb6ab77e1c5bee9bcf9660f90ff445042b790402a654d2ad81d8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d3ff32724f98fbbbfa9f49d82852b159e9784d6094983d9a8b7f2ddaebb063d4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d73d8ecf8ecf10a3bd007f2192725a34bd62898e8da27eb9d32a58084f93962b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "dd708cf4ee4408cf46a48b108fb9427bfa00b9b85812a9262b5c668af2533ea5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e3cd95e10c2610c360154afdc2f1480aea394f4a4f1ea0a5eacce49640c9b190"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e4da8ca0c0c0aea88fd46be8e44bd49716772358d648cce45fe387f7b92374a7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "eadfbbbfb41b44034a4c757fd5d70baccd43296fb894dba0295606a7cf3124aa"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ed667f49b11360951e201453fc3967344d0d0263aa415e1619e85ae7fd17b4e0"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f3df3db1d336b9356dd3112eae5f5c2b8b377f3bc826848567f10bfddfee77e9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f6bdac493b949141b733c5345b6ba8f87a226029cbabc7e9e121a413e49441e0"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "fbf521479bcac1e25a663df882c46a641a9bff6b56dc8b0fafaebd2f66fb231b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "fc9b106a1bf918db68619fdcd6d5ad4f972fdd19c01d19bdb6bf63f3589a9ec5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "fcdd00edfd0a3001e0181eab3e63bd5c74ad3e67152c84f93f13769a40e073a7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "fe4bda6bd4340caa6e5cf95e73f8fea5c4bfc55763dd42f1b50a94c1b4a2fbd4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/"
+        }
+      ],
+      "name": "lxml",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/lxml@4.9.3",
+      "type": "library",
+      "version": "4.9.3"
+    },
+    {
+      "bom-ref": "packageurl-python==0.11.2",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "01fbf74a41ef85cf413f1ede529a1411f658bda66ed22d45d27280ad9ceba471"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "799acfe8d9e6e3534bbc19660be97d5b66754bc033e62c39f1e2f16323fcfa84"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/packageurl-python/"
+        }
+      ],
+      "name": "packageurl-python",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/packageurl-python@0.11.2",
+      "type": "library",
+      "version": "0.11.2"
+    },
+    {
+      "bom-ref": "py-serializable==0.15.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8fc41457d8ee5f5c5a12f41fd87bf1a4f2ecf9da39fee92059b728e78f320771"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d3f1201b33420c481aa83f7860c7bf2c2f036ba3ea82b6e15a96696457c36cd2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-serializable/"
+        }
+      ],
+      "name": "py-serializable",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/py-serializable@0.15.0",
+      "type": "library",
+      "version": "0.15.0"
+    },
+    {
+      "bom-ref": "python-dateutil==2.8.2",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "referencing==0.31.1",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81a1471c68c9d5e3831c30ad1dd9815c45b558e596653db751a2bfdd17b3b9ec"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c19c4d006f1757e3dd75c4f784d38f8698d87b649c54f9ace14e5e8c9667c01d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/"
+        }
+      ],
+      "name": "referencing",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/referencing@0.31.1",
+      "type": "library",
+      "version": "0.31.1"
+    },
+    {
+      "bom-ref": "rfc3339-validator==0.1.4",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3339-validator/"
+        }
+      ],
+      "name": "rfc3339-validator",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/rfc3339-validator@0.1.4",
+      "type": "library",
+      "version": "0.1.4"
+    },
+    {
+      "bom-ref": "rfc3987==1.3.8",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3987/"
+        }
+      ],
+      "name": "rfc3987",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/rfc3987@1.3.8",
+      "type": "library",
+      "version": "1.3.8"
+    },
+    {
+      "bom-ref": "rpds-py==0.13.2",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "06d218e4464d31301e943b65b2c6919318ea6f69703a351961e1baaf60347276"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "12ecf89bd54734c3c2c79898ae2021dca42750c7bcfb67f8fb3315453738ac8f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "15253fff410873ebf3cfba1cc686a37711efcd9b8cb30ea21bb14a973e393f60"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "188435794405c7f0573311747c85a96b63c954a5f2111b1df8018979eca0f2f0"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1ceebd0ae4f3e9b2b6b553b51971921853ae4eebf3f54086be0565d59291e53d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "244e173bb6d8f3b2f0c4d7370a1aa341f35da3e57ffd1798e5b2917b91731fd3"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "25b28b3d33ec0a78e944aaaed7e5e2a94ac811bcd68b557ca48a0c30f87497d2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "25ea41635d22b2eb6326f58e608550e55d01df51b8a580ea7e75396bafbb28e9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "29d311e44dd16d2434d5506d57ef4d7036544fc3c25c14b6992ef41f541b10fb"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2a1472956c5bcc49fb0252b965239bffe801acc9394f8b7c1014ae9258e4572b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2a7bef6977043673750a88da064fd513f89505111014b4e00fbdd13329cd4e9a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2ac26f50736324beb0282c819668328d53fc38543fa61eeea2c32ea8ea6eab8d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2e72f750048b32d39e87fc85c225c50b2a6715034848dbb196bf3348aa761fa1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "31e220a040b89a01505128c2f8a59ee74732f666439a03e65ccbf3824cdddae7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "35f53c76a712e323c779ca39b9a81b13f219a8e3bc15f106ed1e1462d56fcfe9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "38d4f822ee2f338febcc85aaa2547eb5ba31ba6ff68d10b8ec988929d23bb6b4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "38f9bf2ad754b4a45b8210a6c732fe876b8a14e14d5992a8c4b7c1ef78740f53"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3a44c8440183b43167fd1a0819e8356692bf5db1ad14ce140dbd40a1485f2dea"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3ab96754d23372009638a402a1ed12a27711598dd49d8316a22597141962fe66"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3c55d7f2d817183d43220738270efd3ce4e7a7b7cbdaefa6d551ed3d6ed89190"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "46e1ed994a0920f350a4547a38471217eb86f57377e9314fbaaa329b71b7dfe3"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4a5375c5fff13f209527cd886dc75394f040c7d1ecad0a2cb0627f13ebe78a12"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4c2d26aa03d877c9730bf005621c92da263523a1e99247590abbbe252ccb7824"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4c4e314d36d4f31236a545696a480aa04ea170a0b021e9a59ab1ed94d4c3ef27"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4d0c10d803549427f427085ed7aebc39832f6e818a011dcd8785e9c6a1ba9b3e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4dcc5ee1d0275cb78d443fdebd0241e58772a354a6d518b1d7af1580bbd2c4e8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "51967a67ea0d7b9b5cd86036878e2d82c0b6183616961c26d825b8c994d4f2c8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "530190eb0cd778363bbb7596612ded0bb9fef662daa98e9d92a0419ab27ae914"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5379e49d7e80dca9811b36894493d1c1ecb4c57de05c36f5d0dd09982af20211"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5493569f861fb7b05af6d048d00d773c6162415ae521b7010197c98810a14cab"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5a4c1058cdae6237d97af272b326e5f78ee7ee3bbffa6b24b09db4d828810468"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5d75d6d220d55cdced2f32cc22f599475dbe881229aeddba6c79c2e9df35a2b3"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5d97e9ae94fb96df1ee3cb09ca376c34e8a122f36927230f4c8a97f469994bff"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5feae2f9aa7270e2c071f488fab256d768e88e01b958f123a690f1cc3061a09c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "603d5868f7419081d616dab7ac3cfa285296735e7350f7b1e4f548f6f953ee7d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "61d42d2b08430854485135504f672c14d4fc644dd243a9c17e7c4e0faf5ed07e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "61dbc1e01dc0c5875da2f7ae36d6e918dc1b8d2ce04e871793976594aad8a57a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "65cfed9c807c27dee76407e8bb29e6f4e391e436774bcc769a037ff25ad8646e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "67a429520e97621a763cf9b3ba27574779c4e96e49a27ff8a1aa99ee70beb28a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6aadae3042f8e6db3376d9e91f194c606c9a45273c170621d46128f35aef7cd0"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6ba8858933f0c1a979781272a5f65646fca8c18c93c99c6ddb5513ad96fa54b1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6bc568b05e02cd612be53900c88aaa55012e744930ba2eeb56279db4c6676eb3"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "729408136ef8d45a28ee9a7411917c9e3459cf266c7e23c2f7d4bb8ef9e0da42"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "751758d9dd04d548ec679224cc00e3591f5ebf1ff159ed0d4aba6a0746352452"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "76d59d4d451ba77f08cb4cd9268dec07be5bc65f73666302dbb5061989b17198"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "79bf58c08f0756adba691d480b5a20e4ad23f33e1ae121584cf3a21717c36dfa"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "7de12b69d95072394998c622cfd7e8cea8f560db5fca6a62a148f902a1029f8b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "7f55cd9cf1564b7b03f238e4c017ca4794c05b01a783e9291065cb2858d86ce4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "80e5acb81cb49fd9f2d5c08f8b74ffff14ee73b10ca88297ab4619e946bcb1e1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "87a90f5545fd61f6964e65eebde4dc3fa8660bb7d87adb01d4cf17e0a2b484ad"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "881df98f0a8404d32b6de0fd33e91c1b90ed1516a80d4d6dc69d414b8850474c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8a776a29b77fe0cc28fedfd87277b0d0f7aa930174b7e504d764e0b43a05f381"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8c2a61c0e4811012b0ba9f6cdcb4437865df5d29eab5d6018ba13cee1c3064a0"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8fa6bd071ec6d90f6e7baa66ae25820d57a8ab1b0a3c6d3edf1834d4b26fafa2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "96f2975fb14f39c5fe75203f33dd3010fe37d1c4e33177feef1107b5ced750e3"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "96fb0899bb2ab353f42e5374c8f0789f54e0a94ef2f02b9ac7149c56622eaf31"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "97163a1ab265a1073a6372eca9f4eeb9f8c6327457a0b22ddfc4a17dcd613e74"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9c95a1a290f9acf7a8f2ebbdd183e99215d491beea52d61aa2a7a7d2c618ddc6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9d94d78418203904730585efa71002286ac4c8ac0689d0eb61e3c465f9e608ff"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a6ba2cb7d676e9415b9e9ac7e2aae401dc1b1e666943d1f7bc66223d3d73467b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "aa0379c1935c44053c98826bc99ac95f3a5355675a297ac9ce0dfad0ce2d50ca"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ac96d67b37f28e4b6ecf507c3405f52a40658c0a806dffde624a8fcb0314d5fd"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ade2ccb937060c299ab0dfb2dea3d2ddf7e098ed63ee3d651ebfc2c8d1e8632a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "aefbdc934115d2f9278f153952003ac52cd2650e7313750390b334518c589568"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b07501b720cf060c5856f7b5626e75b8e353b5f98b9b354a21eb4bfa47e421b1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b5267feb19070bef34b8dea27e2b504ebd9d31748e3ecacb3a4101da6fcb255c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b5f6328e8e2ae8238fc767703ab7b95785521c42bb2b8790984e3477d7fa71ad"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b8996ffb60c69f677245f5abdbcc623e9442bcc91ed81b6cd6187129ad1fa3e7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b981a370f8f41c4024c170b42fbe9e691ae2dbc19d1d99151a69e2c84a0d194d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b9d121be0217787a7d59a5c6195b0842d3f701007333426e5154bf72346aa658"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bcef4f2d3dc603150421de85c916da19471f24d838c3c62a4f04c1eb511642c1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bed0252c85e21cf73d2d033643c945b460d6a02fc4a7d644e3b2d6f5f2956c64"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bfdfbe6a36bc3059fff845d64c42f2644cf875c65f5005db54f90cdfdf1df815"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c0095b8aa3e432e32d372e9a7737e65b58d5ed23b9620fea7cb81f17672f1fa1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c1f41d32a2ddc5a94df4b829b395916a4b7f103350fa76ba6de625fcb9e773ac"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c45008ca79bad237cbc03c72bc5205e8c6f66403773929b1b50f7d84ef9e4d07"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c82bbf7e03748417c3a88c1b0b291288ce3e4887a795a3addaa7a1cfd9e7153e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c918621ee0a3d1fe61c313f2489464f2ae3d13633e60f520a8002a5e910982ee"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d204957169f0b3511fb95395a9da7d4490fb361763a9f8b32b345a7fe119cb45"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d329896c40d9e1e5c7715c98529e4a188a1f2df51212fd65102b32465612b5dc"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d3a61e928feddc458a55110f42f626a2a20bea942ccedb6fb4cee70b4830ed41"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d48db29bd47814671afdd76c7652aefacc25cf96aad6daefa82d738ee87461e2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d5593855b5b2b73dd8413c3fdfa5d95b99d657658f947ba2c4318591e745d083"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d79c159adea0f1f4617f54aa156568ac69968f9ef4d1e5fefffc0a180830308e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "db09b98c7540df69d4b47218da3fbd7cb466db0fb932e971c321f1c76f155266"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ddf23960cb42b69bce13045d5bc66f18c7d53774c66c13f24cf1b9c144ba3141"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e06cfea0ece444571d24c18ed465bc93afb8c8d8d74422eb7026662f3d3f779b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e7c564c58cf8f248fe859a4f0fe501b050663f3d7fbc342172f259124fb59933"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e86593bf8637659e6a6ed58854b6c87ec4e9e45ee8a4adfd936831cef55c2d21"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "eaffbd8814bb1b5dc3ea156a4c5928081ba50419f9175f4fc95269e040eff8f0"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ee353bb51f648924926ed05e0122b6a0b1ae709396a80eb583449d5d477fcdf7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ee6faebb265e28920a6f23a7d4c362414b3f4bb30607141d718b991669e49ddc"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "efe093acc43e869348f6f2224df7f452eab63a2c60a6c6cd6b50fd35c4e075ba"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f03a1b3a4c03e3e0161642ac5367f08479ab29972ea0ffcd4fa18f729cd2be0a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f0d320e70b6b2300ff6029e234e79fe44e9dbbfc7b98597ba28e054bd6606a57"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f252dfb4852a527987a9156cbcae3022a30f86c9d26f4f17b8c967d7580d65d2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f5f4424cb87a20b016bfdc157ff48757b89d2cc426256961643d443c6c277007"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f8eae66a1304de7368932b42d801c67969fd090ddb1a7a24f27b435ed4bed68f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "fdb82eb60d31b0c033a8e8ee9f3fc7dfbaa042211131c29da29aea8531b4f18f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/"
+        }
+      ],
+      "name": "rpds-py",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/rpds-py@0.13.2",
+      "type": "library",
+      "version": "0.13.2"
+    },
+    {
+      "bom-ref": "six==1.16.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "sortedcontainers==2.4.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/sortedcontainers/"
+        }
+      ],
+      "name": "sortedcontainers",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/sortedcontainers@2.4.0",
+      "type": "library",
+      "version": "2.4.0"
+    },
+    {
+      "bom-ref": "types-python-dateutil==2.8.19.14",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    },
+    {
+      "bom-ref": "uri-template==1.3.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uri-template/"
+        }
+      ],
+      "name": "uri-template",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/uri-template@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "webcolors==1.13",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/webcolors/"
+        }
+      ],
+      "name": "webcolors",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/webcolors@1.13",
+      "type": "library",
+      "version": "1.13"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "arrow==1.3.0"
+    },
+    {
+      "ref": "attrs==23.1.0"
+    },
+    {
+      "ref": "boolean.py==4.0"
+    },
+    {
+      "ref": "cyclonedx-python-lib==5.1.1"
+    },
+    {
+      "ref": "defusedxml==0.7.1"
+    },
+    {
+      "ref": "fqdn==1.5.1"
+    },
+    {
+      "ref": "idna==3.6"
+    },
+    {
+      "ref": "isoduration==20.11.0"
+    },
+    {
+      "ref": "jsonpointer==2.4"
+    },
+    {
+      "ref": "jsonschema-specifications==2023.11.2"
+    },
+    {
+      "ref": "jsonschema==4.20.0"
+    },
+    {
+      "ref": "license-expression==30.2.0"
+    },
+    {
+      "ref": "lxml==4.9.3"
+    },
+    {
+      "ref": "packageurl-python==0.11.2"
+    },
+    {
+      "ref": "py-serializable==0.15.0"
+    },
+    {
+      "ref": "python-dateutil==2.8.2"
+    },
+    {
+      "ref": "referencing==0.31.1"
+    },
+    {
+      "ref": "rfc3339-validator==0.1.4"
+    },
+    {
+      "ref": "rfc3987==1.3.8"
+    },
+    {
+      "ref": "root-component"
+    },
+    {
+      "ref": "rpds-py==0.13.2"
+    },
+    {
+      "ref": "six==1.16.0"
+    },
+    {
+      "ref": "sortedcontainers==2.4.0"
+    },
+    {
+      "ref": "types-python-dateutil==2.8.19.14"
+    },
+    {
+      "ref": "uri-template==1.3.0"
+    },
+    {
+      "ref": "webcolors==1.13"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/pipenv/with-extras_1.5.xml.bin
+++ b/tests/_data/snapshots/pipenv/with-extras_1.5.xml.bin
@@ -1,0 +1,719 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow==1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="attrs==23.1.0">
+      <name>attrs</name>
+      <version>23.1.0</version>
+      <purl>pkg:pypi/attrs@23.1.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04</hash>
+            <hash alg="SHA-256">6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="boolean.py==4.0">
+      <name>boolean.py</name>
+      <version>4.0</version>
+      <purl>pkg:pypi/boolean.py@4.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/boolean.py/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">17b9a181630e43dde1851d42bef546d616d5d9b4480357514597e78b203d06e4</hash>
+            <hash alg="SHA-256">2876f2051d7d6394a531d82dc6eb407faa0b01a0a0b3083817ccd7323b8d96bd</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="cyclonedx-python-lib==5.1.1">
+      <name>cyclonedx-python-lib</name>
+      <version>5.1.1</version>
+      <purl>pkg:pypi/cyclonedx-python-lib@5.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/cyclonedx-python-lib/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">215a636a4e77385d2cf4c6c9801c9bad4791849634f2c6daa45ab2c6cb0a85f6</hash>
+            <hash alg="SHA-256">2989db0cd8bb4c0c442423d71ed7a84ae059e16a2d0f932cc4bf92da7385cdb3</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+        <property name="cdx:python:package:extra">json-validation</property>
+        <property name="cdx:python:package:extra">xml-validation</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="defusedxml==0.7.1">
+      <name>defusedxml</name>
+      <version>0.7.1</version>
+      <purl>pkg:pypi/defusedxml@0.7.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/defusedxml/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69</hash>
+            <hash alg="SHA-256">a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="fqdn==1.5.1">
+      <name>fqdn</name>
+      <version>1.5.1</version>
+      <purl>pkg:pypi/fqdn@1.5.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fqdn/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f</hash>
+            <hash alg="SHA-256">3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="idna==3.6">
+      <name>idna</name>
+      <version>3.6</version>
+      <purl>pkg:pypi/idna@3.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca</hash>
+            <hash alg="SHA-256">c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration==20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonpointer==2.4">
+      <name>jsonpointer</name>
+      <version>2.4</version>
+      <purl>pkg:pypi/jsonpointer@2.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonpointer/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a</hash>
+            <hash alg="SHA-256">585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema==4.20.0">
+      <name>jsonschema</name>
+      <version>4.20.0</version>
+      <purl>pkg:pypi/jsonschema@4.20.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">4f614fd46d8d61258610998997743ec5492a648b33cf478c1ddc23ed4598a5fa</hash>
+            <hash alg="SHA-256">ed6231f0429ecf966f5bc8dfef245998220549cbbcf140f913b7464c52c3b6b3</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+        <property name="cdx:python:package:extra">format</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema-specifications==2023.11.2">
+      <name>jsonschema-specifications</name>
+      <version>2023.11.2</version>
+      <purl>pkg:pypi/jsonschema-specifications@2023.11.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">9472fc4fea474cd74bea4a2b190daeccb5a9e4db2ea80efcf7a1b582fc9a81b8</hash>
+            <hash alg="SHA-256">e74ba7c0a65e8cb49dc26837d6cfe576557084a8b423ed16a420984228104f93</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="license-expression==30.2.0">
+      <name>license-expression</name>
+      <version>30.2.0</version>
+      <purl>pkg:pypi/license-expression@30.2.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/license-expression/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1a7dc2bb2d09cdc983d072e4f9adc787e107e09def84cbb3919baaaf4f8e6fa1</hash>
+            <hash alg="SHA-256">599928edd995c43fc335e0af342076144dc71cb858afa1ed9c1c30c4e81794f5</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="lxml==4.9.3">
+      <name>lxml</name>
+      <version>4.9.3</version>
+      <purl>pkg:pypi/lxml@4.9.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">05186a0f1346ae12553d66df1cfce6f251589fea3ad3da4f3ef4e34b2d58c6a3</hash>
+            <hash alg="SHA-256">075b731ddd9e7f68ad24c635374211376aa05a281673ede86cbe1d1b3455279d</hash>
+            <hash alg="SHA-256">081d32421db5df44c41b7f08a334a090a545c54ba977e47fd7cc2deece78809a</hash>
+            <hash alg="SHA-256">0a3d3487f07c1d7f150894c238299934a2a074ef590b583103a45002035be120</hash>
+            <hash alg="SHA-256">0bfd0767c5c1de2551a120673b72e5d4b628737cb05414f03c3277bf9bed3305</hash>
+            <hash alg="SHA-256">0c0850c8b02c298d3c7006b23e98249515ac57430e16a166873fc47a5d549287</hash>
+            <hash alg="SHA-256">0e2cb47860da1f7e9a5256254b74ae331687b9672dfa780eed355c4c9c3dbd23</hash>
+            <hash alg="SHA-256">120fa9349a24c7043854c53cae8cec227e1f79195a7493e09e0c12e29f918e52</hash>
+            <hash alg="SHA-256">1247694b26342a7bf47c02e513d32225ededd18045264d40758abeb3c838a51f</hash>
+            <hash alg="SHA-256">141f1d1a9b663c679dc524af3ea1773e618907e96075262726c7612c02b149a4</hash>
+            <hash alg="SHA-256">14e019fd83b831b2e61baed40cab76222139926b1fb5ed0e79225bc0cae14584</hash>
+            <hash alg="SHA-256">1509dd12b773c02acd154582088820893109f6ca27ef7291b003d0e81666109f</hash>
+            <hash alg="SHA-256">17a753023436a18e27dd7769e798ce302963c236bc4114ceee5b25c18c52c693</hash>
+            <hash alg="SHA-256">1e224d5755dba2f4a9498e150c43792392ac9b5380aa1b845f98a1618c94eeef</hash>
+            <hash alg="SHA-256">1f447ea5429b54f9582d4b955f5f1985f278ce5cf169f72eea8afd9502973dd5</hash>
+            <hash alg="SHA-256">23eed6d7b1a3336ad92d8e39d4bfe09073c31bfe502f20ca5116b2a334f8ec02</hash>
+            <hash alg="SHA-256">25f32acefac14ef7bd53e4218fe93b804ef6f6b92ffdb4322bb6d49d94cad2bc</hash>
+            <hash alg="SHA-256">2c74524e179f2ad6d2a4f7caf70e2d96639c0954c943ad601a9e146c76408ed7</hash>
+            <hash alg="SHA-256">303bf1edce6ced16bf67a18a1cf8339d0db79577eec5d9a6d4a80f0fb10aa2da</hash>
+            <hash alg="SHA-256">3331bece23c9ee066e0fb3f96c61322b9e0f54d775fccefff4c38ca488de283a</hash>
+            <hash alg="SHA-256">3e9bdd30efde2b9ccfa9cb5768ba04fe71b018a25ea093379c857c9dad262c40</hash>
+            <hash alg="SHA-256">411007c0d88188d9f621b11d252cce90c4a2d1a49db6c068e3c16422f306eab8</hash>
+            <hash alg="SHA-256">42871176e7896d5d45138f6d28751053c711ed4d48d8e30b498da155af39aebd</hash>
+            <hash alg="SHA-256">46f409a2d60f634fe550f7133ed30ad5321ae2e6630f13657fb9479506b00601</hash>
+            <hash alg="SHA-256">48628bd53a426c9eb9bc066a923acaa0878d1e86129fd5359aee99285f4eed9c</hash>
+            <hash alg="SHA-256">48d6ed886b343d11493129e019da91d4039826794a3e3027321c56d9e71505be</hash>
+            <hash alg="SHA-256">4930be26af26ac545c3dffb662521d4e6268352866956672231887d18f0eaab2</hash>
+            <hash alg="SHA-256">4aec80cde9197340bc353d2768e2a75f5f60bacda2bab72ab1dc499589b3878c</hash>
+            <hash alg="SHA-256">4c28a9144688aef80d6ea666c809b4b0e50010a2aca784c97f5e6bf143d9f129</hash>
+            <hash alg="SHA-256">4d2d1edbca80b510443f51afd8496be95529db04a509bc8faee49c7b0fb6d2cc</hash>
+            <hash alg="SHA-256">4dd9a263e845a72eacb60d12401e37c616438ea2e5442885f65082c276dfb2b2</hash>
+            <hash alg="SHA-256">4f1026bc732b6a7f96369f7bfe1a4f2290fb34dce00d8644bc3036fb351a4ca1</hash>
+            <hash alg="SHA-256">4fb960a632a49f2f089d522f70496640fdf1218f1243889da3822e0a9f5f3ba7</hash>
+            <hash alg="SHA-256">50670615eaf97227d5dc60de2dc99fb134a7130d310d783314e7724bf163f75d</hash>
+            <hash alg="SHA-256">50baa9c1c47efcaef189f31e3d00d697c6d4afda5c3cde0302d063492ff9b477</hash>
+            <hash alg="SHA-256">53ace1c1fd5a74ef662f844a0413446c0629d151055340e9893da958a374f70d</hash>
+            <hash alg="SHA-256">5515edd2a6d1a5a70bfcdee23b42ec33425e405c5b351478ab7dc9347228f96e</hash>
+            <hash alg="SHA-256">56dc1f1ebccc656d1b3ed288f11e27172a01503fc016bcabdcbc0978b19352b7</hash>
+            <hash alg="SHA-256">578695735c5a3f51569810dfebd05dd6f888147a34f0f98d4bb27e92b76e05c2</hash>
+            <hash alg="SHA-256">57aba1bbdf450b726d58b2aea5fe47c7875f5afb2c4a23784ed78f19a0462574</hash>
+            <hash alg="SHA-256">57d6ba0ca2b0c462f339640d22882acc711de224d769edf29962b09f77129cbf</hash>
+            <hash alg="SHA-256">5c245b783db29c4e4fbbbfc9c5a78be496c9fea25517f90606aa1f6b2b3d5f7b</hash>
+            <hash alg="SHA-256">5c31c7462abdf8f2ac0577d9f05279727e698f97ecbb02f17939ea99ae8daa98</hash>
+            <hash alg="SHA-256">64f479d719dc9f4c813ad9bb6b28f8390360660b73b2e4beb4cb0ae7104f1c12</hash>
+            <hash alg="SHA-256">65299ea57d82fb91c7f019300d24050c4ddeb7c5a190e076b5f48a2b43d19c42</hash>
+            <hash alg="SHA-256">6689a3d7fd13dc687e9102a27e98ef33730ac4fe37795d5036d18b4d527abd35</hash>
+            <hash alg="SHA-256">690dafd0b187ed38583a648076865d8c229661ed20e48f2335d68e2cf7dc829d</hash>
+            <hash alg="SHA-256">6fc3c450eaa0b56f815c7b62f2b7fba7266c4779adcf1cece9e6deb1de7305ce</hash>
+            <hash alg="SHA-256">704f61ba8c1283c71b16135caf697557f5ecf3e74d9e453233e4771d68a1f42d</hash>
+            <hash alg="SHA-256">71c52db65e4b56b8ddc5bb89fb2e66c558ed9d1a74a45ceb7dcb20c191c3df2f</hash>
+            <hash alg="SHA-256">71d66ee82e7417828af6ecd7db817913cb0cf9d4e61aa0ac1fde0583d84358db</hash>
+            <hash alg="SHA-256">7d298a1bd60c067ea75d9f684f5f3992c9d6766fadbc0bcedd39750bf344c2f4</hash>
+            <hash alg="SHA-256">8b77946fd508cbf0fccd8e400a7f71d4ac0e1595812e66025bac475a8e811694</hash>
+            <hash alg="SHA-256">8d7e43bd40f65f7d97ad8ef5c9b1778943d02f04febef12def25f7583d19baac</hash>
+            <hash alg="SHA-256">8df133a2ea5e74eef5e8fc6f19b9e085f758768a16e9877a60aec455ed2609b2</hash>
+            <hash alg="SHA-256">8ed74706b26ad100433da4b9d807eae371efaa266ffc3e9191ea436087a9d6a7</hash>
+            <hash alg="SHA-256">92af161ecbdb2883c4593d5ed4815ea71b31fafd7fd05789b23100d081ecac96</hash>
+            <hash alg="SHA-256">97047f0d25cd4bcae81f9ec9dc290ca3e15927c192df17331b53bebe0e3ff96d</hash>
+            <hash alg="SHA-256">9719fe17307a9e814580af1f5c6e05ca593b12fb7e44fe62450a5384dbf61b4b</hash>
+            <hash alg="SHA-256">9767e79108424fb6c3edf8f81e6730666a50feb01a328f4a016464a5893f835a</hash>
+            <hash alg="SHA-256">9a92d3faef50658dd2c5470af249985782bf754c4e18e15afb67d3ab06233f13</hash>
+            <hash alg="SHA-256">9bb6ad405121241e99a86efff22d3ef469024ce22875a7ae045896ad23ba2340</hash>
+            <hash alg="SHA-256">9e28c51fa0ce5674be9f560c6761c1b441631901993f76700b1b30ca6c8378d6</hash>
+            <hash alg="SHA-256">aca086dc5f9ef98c512bac8efea4483eb84abbf926eaeedf7b91479feb092458</hash>
+            <hash alg="SHA-256">ae8b9c6deb1e634ba4f1930eb67ef6e6bf6a44b6eb5ad605642b2d6d5ed9ce3c</hash>
+            <hash alg="SHA-256">b0a545b46b526d418eb91754565ba5b63b1c0b12f9bd2f808c852d9b4b2f9b5c</hash>
+            <hash alg="SHA-256">b4e4bc18382088514ebde9328da057775055940a1f2e18f6ad2d78aa0f3ec5b9</hash>
+            <hash alg="SHA-256">b6420a005548ad52154c8ceab4a1290ff78d757f9e5cbc68f8c77089acd3c432</hash>
+            <hash alg="SHA-256">b86164d2cff4d3aaa1f04a14685cbc072efd0b4f99ca5708b2ad1b9b5988a991</hash>
+            <hash alg="SHA-256">bb3bb49c7a6ad9d981d734ef7c7193bc349ac338776a0360cc671eaee89bcf69</hash>
+            <hash alg="SHA-256">bef4e656f7d98aaa3486d2627e7d2df1157d7e88e7efd43a65aa5dd4714916cf</hash>
+            <hash alg="SHA-256">c0781a98ff5e6586926293e59480b64ddd46282953203c76ae15dbbbf302e8bb</hash>
+            <hash alg="SHA-256">c2006f5c8d28dee289f7020f721354362fa304acbaaf9745751ac4006650254b</hash>
+            <hash alg="SHA-256">c41bfca0bd3532d53d16fd34d20806d5c2b1ace22a2f2e4c0008570bf2c58833</hash>
+            <hash alg="SHA-256">cd47b4a0d41d2afa3e58e5bf1f62069255aa2fd6ff5ee41604418ca925911d76</hash>
+            <hash alg="SHA-256">cdb650fc86227eba20de1a29d4b2c1bfe139dc75a0669270033cb2ea3d391b85</hash>
+            <hash alg="SHA-256">cef2502e7e8a96fe5ad686d60b49e1ab03e438bd9123987994528febd569868e</hash>
+            <hash alg="SHA-256">d27be7405547d1f958b60837dc4c1007da90b8b23f54ba1f8b728c78fdb19d50</hash>
+            <hash alg="SHA-256">d37017287a7adb6ab77e1c5bee9bcf9660f90ff445042b790402a654d2ad81d8</hash>
+            <hash alg="SHA-256">d3ff32724f98fbbbfa9f49d82852b159e9784d6094983d9a8b7f2ddaebb063d4</hash>
+            <hash alg="SHA-256">d73d8ecf8ecf10a3bd007f2192725a34bd62898e8da27eb9d32a58084f93962b</hash>
+            <hash alg="SHA-256">dd708cf4ee4408cf46a48b108fb9427bfa00b9b85812a9262b5c668af2533ea5</hash>
+            <hash alg="SHA-256">e3cd95e10c2610c360154afdc2f1480aea394f4a4f1ea0a5eacce49640c9b190</hash>
+            <hash alg="SHA-256">e4da8ca0c0c0aea88fd46be8e44bd49716772358d648cce45fe387f7b92374a7</hash>
+            <hash alg="SHA-256">eadfbbbfb41b44034a4c757fd5d70baccd43296fb894dba0295606a7cf3124aa</hash>
+            <hash alg="SHA-256">ed667f49b11360951e201453fc3967344d0d0263aa415e1619e85ae7fd17b4e0</hash>
+            <hash alg="SHA-256">f3df3db1d336b9356dd3112eae5f5c2b8b377f3bc826848567f10bfddfee77e9</hash>
+            <hash alg="SHA-256">f6bdac493b949141b733c5345b6ba8f87a226029cbabc7e9e121a413e49441e0</hash>
+            <hash alg="SHA-256">fbf521479bcac1e25a663df882c46a641a9bff6b56dc8b0fafaebd2f66fb231b</hash>
+            <hash alg="SHA-256">fc9b106a1bf918db68619fdcd6d5ad4f972fdd19c01d19bdb6bf63f3589a9ec5</hash>
+            <hash alg="SHA-256">fcdd00edfd0a3001e0181eab3e63bd5c74ad3e67152c84f93f13769a40e073a7</hash>
+            <hash alg="SHA-256">fe4bda6bd4340caa6e5cf95e73f8fea5c4bfc55763dd42f1b50a94c1b4a2fbd4</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="packageurl-python==0.11.2">
+      <name>packageurl-python</name>
+      <version>0.11.2</version>
+      <purl>pkg:pypi/packageurl-python@0.11.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/packageurl-python/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">01fbf74a41ef85cf413f1ede529a1411f658bda66ed22d45d27280ad9ceba471</hash>
+            <hash alg="SHA-256">799acfe8d9e6e3534bbc19660be97d5b66754bc033e62c39f1e2f16323fcfa84</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="py-serializable==0.15.0">
+      <name>py-serializable</name>
+      <version>0.15.0</version>
+      <purl>pkg:pypi/py-serializable@0.15.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-serializable/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">8fc41457d8ee5f5c5a12f41fd87bf1a4f2ecf9da39fee92059b728e78f320771</hash>
+            <hash alg="SHA-256">d3f1201b33420c481aa83f7860c7bf2c2f036ba3ea82b6e15a96696457c36cd2</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil==2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="referencing==0.31.1">
+      <name>referencing</name>
+      <version>0.31.1</version>
+      <purl>pkg:pypi/referencing@0.31.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">81a1471c68c9d5e3831c30ad1dd9815c45b558e596653db751a2bfdd17b3b9ec</hash>
+            <hash alg="SHA-256">c19c4d006f1757e3dd75c4f784d38f8698d87b649c54f9ace14e5e8c9667c01d</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rfc3339-validator==0.1.4">
+      <name>rfc3339-validator</name>
+      <version>0.1.4</version>
+      <purl>pkg:pypi/rfc3339-validator@0.1.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3339-validator/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b</hash>
+            <hash alg="SHA-256">24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rfc3987==1.3.8">
+      <name>rfc3987</name>
+      <version>1.3.8</version>
+      <purl>pkg:pypi/rfc3987@1.3.8</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3987/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53</hash>
+            <hash alg="SHA-256">d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rpds-py==0.13.2">
+      <name>rpds-py</name>
+      <version>0.13.2</version>
+      <purl>pkg:pypi/rpds-py@0.13.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">06d218e4464d31301e943b65b2c6919318ea6f69703a351961e1baaf60347276</hash>
+            <hash alg="SHA-256">12ecf89bd54734c3c2c79898ae2021dca42750c7bcfb67f8fb3315453738ac8f</hash>
+            <hash alg="SHA-256">15253fff410873ebf3cfba1cc686a37711efcd9b8cb30ea21bb14a973e393f60</hash>
+            <hash alg="SHA-256">188435794405c7f0573311747c85a96b63c954a5f2111b1df8018979eca0f2f0</hash>
+            <hash alg="SHA-256">1ceebd0ae4f3e9b2b6b553b51971921853ae4eebf3f54086be0565d59291e53d</hash>
+            <hash alg="SHA-256">244e173bb6d8f3b2f0c4d7370a1aa341f35da3e57ffd1798e5b2917b91731fd3</hash>
+            <hash alg="SHA-256">25b28b3d33ec0a78e944aaaed7e5e2a94ac811bcd68b557ca48a0c30f87497d2</hash>
+            <hash alg="SHA-256">25ea41635d22b2eb6326f58e608550e55d01df51b8a580ea7e75396bafbb28e9</hash>
+            <hash alg="SHA-256">29d311e44dd16d2434d5506d57ef4d7036544fc3c25c14b6992ef41f541b10fb</hash>
+            <hash alg="SHA-256">2a1472956c5bcc49fb0252b965239bffe801acc9394f8b7c1014ae9258e4572b</hash>
+            <hash alg="SHA-256">2a7bef6977043673750a88da064fd513f89505111014b4e00fbdd13329cd4e9a</hash>
+            <hash alg="SHA-256">2ac26f50736324beb0282c819668328d53fc38543fa61eeea2c32ea8ea6eab8d</hash>
+            <hash alg="SHA-256">2e72f750048b32d39e87fc85c225c50b2a6715034848dbb196bf3348aa761fa1</hash>
+            <hash alg="SHA-256">31e220a040b89a01505128c2f8a59ee74732f666439a03e65ccbf3824cdddae7</hash>
+            <hash alg="SHA-256">35f53c76a712e323c779ca39b9a81b13f219a8e3bc15f106ed1e1462d56fcfe9</hash>
+            <hash alg="SHA-256">38d4f822ee2f338febcc85aaa2547eb5ba31ba6ff68d10b8ec988929d23bb6b4</hash>
+            <hash alg="SHA-256">38f9bf2ad754b4a45b8210a6c732fe876b8a14e14d5992a8c4b7c1ef78740f53</hash>
+            <hash alg="SHA-256">3a44c8440183b43167fd1a0819e8356692bf5db1ad14ce140dbd40a1485f2dea</hash>
+            <hash alg="SHA-256">3ab96754d23372009638a402a1ed12a27711598dd49d8316a22597141962fe66</hash>
+            <hash alg="SHA-256">3c55d7f2d817183d43220738270efd3ce4e7a7b7cbdaefa6d551ed3d6ed89190</hash>
+            <hash alg="SHA-256">46e1ed994a0920f350a4547a38471217eb86f57377e9314fbaaa329b71b7dfe3</hash>
+            <hash alg="SHA-256">4a5375c5fff13f209527cd886dc75394f040c7d1ecad0a2cb0627f13ebe78a12</hash>
+            <hash alg="SHA-256">4c2d26aa03d877c9730bf005621c92da263523a1e99247590abbbe252ccb7824</hash>
+            <hash alg="SHA-256">4c4e314d36d4f31236a545696a480aa04ea170a0b021e9a59ab1ed94d4c3ef27</hash>
+            <hash alg="SHA-256">4d0c10d803549427f427085ed7aebc39832f6e818a011dcd8785e9c6a1ba9b3e</hash>
+            <hash alg="SHA-256">4dcc5ee1d0275cb78d443fdebd0241e58772a354a6d518b1d7af1580bbd2c4e8</hash>
+            <hash alg="SHA-256">51967a67ea0d7b9b5cd86036878e2d82c0b6183616961c26d825b8c994d4f2c8</hash>
+            <hash alg="SHA-256">530190eb0cd778363bbb7596612ded0bb9fef662daa98e9d92a0419ab27ae914</hash>
+            <hash alg="SHA-256">5379e49d7e80dca9811b36894493d1c1ecb4c57de05c36f5d0dd09982af20211</hash>
+            <hash alg="SHA-256">5493569f861fb7b05af6d048d00d773c6162415ae521b7010197c98810a14cab</hash>
+            <hash alg="SHA-256">5a4c1058cdae6237d97af272b326e5f78ee7ee3bbffa6b24b09db4d828810468</hash>
+            <hash alg="SHA-256">5d75d6d220d55cdced2f32cc22f599475dbe881229aeddba6c79c2e9df35a2b3</hash>
+            <hash alg="SHA-256">5d97e9ae94fb96df1ee3cb09ca376c34e8a122f36927230f4c8a97f469994bff</hash>
+            <hash alg="SHA-256">5feae2f9aa7270e2c071f488fab256d768e88e01b958f123a690f1cc3061a09c</hash>
+            <hash alg="SHA-256">603d5868f7419081d616dab7ac3cfa285296735e7350f7b1e4f548f6f953ee7d</hash>
+            <hash alg="SHA-256">61d42d2b08430854485135504f672c14d4fc644dd243a9c17e7c4e0faf5ed07e</hash>
+            <hash alg="SHA-256">61dbc1e01dc0c5875da2f7ae36d6e918dc1b8d2ce04e871793976594aad8a57a</hash>
+            <hash alg="SHA-256">65cfed9c807c27dee76407e8bb29e6f4e391e436774bcc769a037ff25ad8646e</hash>
+            <hash alg="SHA-256">67a429520e97621a763cf9b3ba27574779c4e96e49a27ff8a1aa99ee70beb28a</hash>
+            <hash alg="SHA-256">6aadae3042f8e6db3376d9e91f194c606c9a45273c170621d46128f35aef7cd0</hash>
+            <hash alg="SHA-256">6ba8858933f0c1a979781272a5f65646fca8c18c93c99c6ddb5513ad96fa54b1</hash>
+            <hash alg="SHA-256">6bc568b05e02cd612be53900c88aaa55012e744930ba2eeb56279db4c6676eb3</hash>
+            <hash alg="SHA-256">729408136ef8d45a28ee9a7411917c9e3459cf266c7e23c2f7d4bb8ef9e0da42</hash>
+            <hash alg="SHA-256">751758d9dd04d548ec679224cc00e3591f5ebf1ff159ed0d4aba6a0746352452</hash>
+            <hash alg="SHA-256">76d59d4d451ba77f08cb4cd9268dec07be5bc65f73666302dbb5061989b17198</hash>
+            <hash alg="SHA-256">79bf58c08f0756adba691d480b5a20e4ad23f33e1ae121584cf3a21717c36dfa</hash>
+            <hash alg="SHA-256">7de12b69d95072394998c622cfd7e8cea8f560db5fca6a62a148f902a1029f8b</hash>
+            <hash alg="SHA-256">7f55cd9cf1564b7b03f238e4c017ca4794c05b01a783e9291065cb2858d86ce4</hash>
+            <hash alg="SHA-256">80e5acb81cb49fd9f2d5c08f8b74ffff14ee73b10ca88297ab4619e946bcb1e1</hash>
+            <hash alg="SHA-256">87a90f5545fd61f6964e65eebde4dc3fa8660bb7d87adb01d4cf17e0a2b484ad</hash>
+            <hash alg="SHA-256">881df98f0a8404d32b6de0fd33e91c1b90ed1516a80d4d6dc69d414b8850474c</hash>
+            <hash alg="SHA-256">8a776a29b77fe0cc28fedfd87277b0d0f7aa930174b7e504d764e0b43a05f381</hash>
+            <hash alg="SHA-256">8c2a61c0e4811012b0ba9f6cdcb4437865df5d29eab5d6018ba13cee1c3064a0</hash>
+            <hash alg="SHA-256">8fa6bd071ec6d90f6e7baa66ae25820d57a8ab1b0a3c6d3edf1834d4b26fafa2</hash>
+            <hash alg="SHA-256">96f2975fb14f39c5fe75203f33dd3010fe37d1c4e33177feef1107b5ced750e3</hash>
+            <hash alg="SHA-256">96fb0899bb2ab353f42e5374c8f0789f54e0a94ef2f02b9ac7149c56622eaf31</hash>
+            <hash alg="SHA-256">97163a1ab265a1073a6372eca9f4eeb9f8c6327457a0b22ddfc4a17dcd613e74</hash>
+            <hash alg="SHA-256">9c95a1a290f9acf7a8f2ebbdd183e99215d491beea52d61aa2a7a7d2c618ddc6</hash>
+            <hash alg="SHA-256">9d94d78418203904730585efa71002286ac4c8ac0689d0eb61e3c465f9e608ff</hash>
+            <hash alg="SHA-256">a6ba2cb7d676e9415b9e9ac7e2aae401dc1b1e666943d1f7bc66223d3d73467b</hash>
+            <hash alg="SHA-256">aa0379c1935c44053c98826bc99ac95f3a5355675a297ac9ce0dfad0ce2d50ca</hash>
+            <hash alg="SHA-256">ac96d67b37f28e4b6ecf507c3405f52a40658c0a806dffde624a8fcb0314d5fd</hash>
+            <hash alg="SHA-256">ade2ccb937060c299ab0dfb2dea3d2ddf7e098ed63ee3d651ebfc2c8d1e8632a</hash>
+            <hash alg="SHA-256">aefbdc934115d2f9278f153952003ac52cd2650e7313750390b334518c589568</hash>
+            <hash alg="SHA-256">b07501b720cf060c5856f7b5626e75b8e353b5f98b9b354a21eb4bfa47e421b1</hash>
+            <hash alg="SHA-256">b5267feb19070bef34b8dea27e2b504ebd9d31748e3ecacb3a4101da6fcb255c</hash>
+            <hash alg="SHA-256">b5f6328e8e2ae8238fc767703ab7b95785521c42bb2b8790984e3477d7fa71ad</hash>
+            <hash alg="SHA-256">b8996ffb60c69f677245f5abdbcc623e9442bcc91ed81b6cd6187129ad1fa3e7</hash>
+            <hash alg="SHA-256">b981a370f8f41c4024c170b42fbe9e691ae2dbc19d1d99151a69e2c84a0d194d</hash>
+            <hash alg="SHA-256">b9d121be0217787a7d59a5c6195b0842d3f701007333426e5154bf72346aa658</hash>
+            <hash alg="SHA-256">bcef4f2d3dc603150421de85c916da19471f24d838c3c62a4f04c1eb511642c1</hash>
+            <hash alg="SHA-256">bed0252c85e21cf73d2d033643c945b460d6a02fc4a7d644e3b2d6f5f2956c64</hash>
+            <hash alg="SHA-256">bfdfbe6a36bc3059fff845d64c42f2644cf875c65f5005db54f90cdfdf1df815</hash>
+            <hash alg="SHA-256">c0095b8aa3e432e32d372e9a7737e65b58d5ed23b9620fea7cb81f17672f1fa1</hash>
+            <hash alg="SHA-256">c1f41d32a2ddc5a94df4b829b395916a4b7f103350fa76ba6de625fcb9e773ac</hash>
+            <hash alg="SHA-256">c45008ca79bad237cbc03c72bc5205e8c6f66403773929b1b50f7d84ef9e4d07</hash>
+            <hash alg="SHA-256">c82bbf7e03748417c3a88c1b0b291288ce3e4887a795a3addaa7a1cfd9e7153e</hash>
+            <hash alg="SHA-256">c918621ee0a3d1fe61c313f2489464f2ae3d13633e60f520a8002a5e910982ee</hash>
+            <hash alg="SHA-256">d204957169f0b3511fb95395a9da7d4490fb361763a9f8b32b345a7fe119cb45</hash>
+            <hash alg="SHA-256">d329896c40d9e1e5c7715c98529e4a188a1f2df51212fd65102b32465612b5dc</hash>
+            <hash alg="SHA-256">d3a61e928feddc458a55110f42f626a2a20bea942ccedb6fb4cee70b4830ed41</hash>
+            <hash alg="SHA-256">d48db29bd47814671afdd76c7652aefacc25cf96aad6daefa82d738ee87461e2</hash>
+            <hash alg="SHA-256">d5593855b5b2b73dd8413c3fdfa5d95b99d657658f947ba2c4318591e745d083</hash>
+            <hash alg="SHA-256">d79c159adea0f1f4617f54aa156568ac69968f9ef4d1e5fefffc0a180830308e</hash>
+            <hash alg="SHA-256">db09b98c7540df69d4b47218da3fbd7cb466db0fb932e971c321f1c76f155266</hash>
+            <hash alg="SHA-256">ddf23960cb42b69bce13045d5bc66f18c7d53774c66c13f24cf1b9c144ba3141</hash>
+            <hash alg="SHA-256">e06cfea0ece444571d24c18ed465bc93afb8c8d8d74422eb7026662f3d3f779b</hash>
+            <hash alg="SHA-256">e7c564c58cf8f248fe859a4f0fe501b050663f3d7fbc342172f259124fb59933</hash>
+            <hash alg="SHA-256">e86593bf8637659e6a6ed58854b6c87ec4e9e45ee8a4adfd936831cef55c2d21</hash>
+            <hash alg="SHA-256">eaffbd8814bb1b5dc3ea156a4c5928081ba50419f9175f4fc95269e040eff8f0</hash>
+            <hash alg="SHA-256">ee353bb51f648924926ed05e0122b6a0b1ae709396a80eb583449d5d477fcdf7</hash>
+            <hash alg="SHA-256">ee6faebb265e28920a6f23a7d4c362414b3f4bb30607141d718b991669e49ddc</hash>
+            <hash alg="SHA-256">efe093acc43e869348f6f2224df7f452eab63a2c60a6c6cd6b50fd35c4e075ba</hash>
+            <hash alg="SHA-256">f03a1b3a4c03e3e0161642ac5367f08479ab29972ea0ffcd4fa18f729cd2be0a</hash>
+            <hash alg="SHA-256">f0d320e70b6b2300ff6029e234e79fe44e9dbbfc7b98597ba28e054bd6606a57</hash>
+            <hash alg="SHA-256">f252dfb4852a527987a9156cbcae3022a30f86c9d26f4f17b8c967d7580d65d2</hash>
+            <hash alg="SHA-256">f5f4424cb87a20b016bfdc157ff48757b89d2cc426256961643d443c6c277007</hash>
+            <hash alg="SHA-256">f8eae66a1304de7368932b42d801c67969fd090ddb1a7a24f27b435ed4bed68f</hash>
+            <hash alg="SHA-256">fdb82eb60d31b0c033a8e8ee9f3fc7dfbaa042211131c29da29aea8531b4f18f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six==1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="sortedcontainers==2.4.0">
+      <name>sortedcontainers</name>
+      <version>2.4.0</version>
+      <purl>pkg:pypi/sortedcontainers@2.4.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/sortedcontainers/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88</hash>
+            <hash alg="SHA-256">a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil==2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="uri-template==1.3.0">
+      <name>uri-template</name>
+      <version>1.3.0</version>
+      <purl>pkg:pypi/uri-template@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uri-template/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7</hash>
+            <hash alg="SHA-256">a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="webcolors==1.13">
+      <name>webcolors</name>
+      <version>1.13</version>
+      <purl>pkg:pypi/webcolors@1.13</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/webcolors/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf</hash>
+            <hash alg="SHA-256">c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow==1.3.0"/>
+    <dependency ref="attrs==23.1.0"/>
+    <dependency ref="boolean.py==4.0"/>
+    <dependency ref="cyclonedx-python-lib==5.1.1"/>
+    <dependency ref="defusedxml==0.7.1"/>
+    <dependency ref="fqdn==1.5.1"/>
+    <dependency ref="idna==3.6"/>
+    <dependency ref="isoduration==20.11.0"/>
+    <dependency ref="jsonpointer==2.4"/>
+    <dependency ref="jsonschema-specifications==2023.11.2"/>
+    <dependency ref="jsonschema==4.20.0"/>
+    <dependency ref="license-expression==30.2.0"/>
+    <dependency ref="lxml==4.9.3"/>
+    <dependency ref="packageurl-python==0.11.2"/>
+    <dependency ref="py-serializable==0.15.0"/>
+    <dependency ref="python-dateutil==2.8.2"/>
+    <dependency ref="referencing==0.31.1"/>
+    <dependency ref="rfc3339-validator==0.1.4"/>
+    <dependency ref="rfc3987==1.3.8"/>
+    <dependency ref="root-component"/>
+    <dependency ref="rpds-py==0.13.2"/>
+    <dependency ref="six==1.16.0"/>
+    <dependency ref="sortedcontainers==2.4.0"/>
+    <dependency ref="types-python-dateutil==2.8.19.14"/>
+    <dependency ref="uri-template==1.3.0"/>
+    <dependency ref="webcolors==1.13"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/with-urls_1.5.json.bin
+++ b/tests/_data/snapshots/pipenv/with-urls_1.5.json.bin
@@ -1,0 +1,569 @@
+{
+  "components": [
+    {
+      "bom-ref": "certifi==2023.11.17",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/"
+        }
+      ],
+      "name": "certifi",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/certifi@2023.11.17",
+      "type": "library",
+      "version": "2023.11.17"
+    },
+    {
+      "bom-ref": "charset-normalizer==3.3.2",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2127566c664442652f024c837091890cb1942c30937add288223dc895793f898"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/"
+        }
+      ],
+      "name": "charset-normalizer",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/charset-normalizer@3.3.2",
+      "type": "library",
+      "version": "3.3.2"
+    },
+    {
+      "bom-ref": "idna==3.6",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/"
+        }
+      ],
+      "name": "idna",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/idna@3.6",
+      "type": "library",
+      "version": "3.6"
+    },
+    {
+      "bom-ref": "pillow",
+      "externalReferences": [
+        {
+          "comment": "from git",
+          "type": "vcs",
+          "url": "git+https://github.com/python-pillow/Pillow.git#da59ad000d1405eaecd557175e29083a87d19f7c"
+        }
+      ],
+      "name": "pillow",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/pillow?vcs_url=git%2Bhttps://github.com/python-pillow/Pillow.git%40da59ad000d1405eaecd557175e29083a87d19f7c",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requests",
+      "externalReferences": [
+        {
+          "comment": "from git",
+          "type": "vcs",
+          "url": "git+https://github.com/requests/requests.git#a25fde6989f8df5c3d823bc9f2e2fc24aa71f375"
+        }
+      ],
+      "name": "requests",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%40a25fde6989f8df5c3d823bc9f2e2fc24aa71f375",
+      "type": "library"
+    },
+    {
+      "bom-ref": "six",
+      "externalReferences": [
+        {
+          "comment": "from git",
+          "type": "vcs",
+          "url": "git+ssh://git@github.com/benjaminp/six.git#65486e4383f9f411da95937451205d3c7b61b9e1"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/six?vcs_url=git%2Bssh://git%40github.com/benjaminp/six.git%4065486e4383f9f411da95937451205d3c7b61b9e1",
+      "type": "library"
+    },
+    {
+      "bom-ref": "urllib3",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "type": "distribution",
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+        }
+      ],
+      "name": "urllib3",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "certifi==2023.11.17"
+    },
+    {
+      "ref": "charset-normalizer==3.3.2"
+    },
+    {
+      "ref": "idna==3.6"
+    },
+    {
+      "ref": "pillow"
+    },
+    {
+      "ref": "requests"
+    },
+    {
+      "ref": "root-component"
+    },
+    {
+      "ref": "six"
+    },
+    {
+      "ref": "urllib3"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "packages from direct urls",
+      "name": "with-urls",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/pipenv/with-urls_1.5.xml.bin
+++ b/tests/_data/snapshots/pipenv/with-urls_1.5.xml.bin
@@ -1,0 +1,255 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>with-urls</name>
+      <version>0.1.0</version>
+      <description>packages from direct urls</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="certifi==2023.11.17">
+      <name>certifi</name>
+      <version>2023.11.17</version>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</hash>
+            <hash alg="SHA-256">e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="charset-normalizer==3.3.2">
+      <name>charset-normalizer</name>
+      <version>3.3.2</version>
+      <purl>pkg:pypi/charset-normalizer@3.3.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027</hash>
+            <hash alg="SHA-256">06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087</hash>
+            <hash alg="SHA-256">0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786</hash>
+            <hash alg="SHA-256">0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8</hash>
+            <hash alg="SHA-256">10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09</hash>
+            <hash alg="SHA-256">122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185</hash>
+            <hash alg="SHA-256">1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574</hash>
+            <hash alg="SHA-256">1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e</hash>
+            <hash alg="SHA-256">1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519</hash>
+            <hash alg="SHA-256">2127566c664442652f024c837091890cb1942c30937add288223dc895793f898</hash>
+            <hash alg="SHA-256">22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269</hash>
+            <hash alg="SHA-256">25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3</hash>
+            <hash alg="SHA-256">2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f</hash>
+            <hash alg="SHA-256">3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6</hash>
+            <hash alg="SHA-256">34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8</hash>
+            <hash alg="SHA-256">37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a</hash>
+            <hash alg="SHA-256">3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73</hash>
+            <hash alg="SHA-256">3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc</hash>
+            <hash alg="SHA-256">42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714</hash>
+            <hash alg="SHA-256">45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2</hash>
+            <hash alg="SHA-256">4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc</hash>
+            <hash alg="SHA-256">4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce</hash>
+            <hash alg="SHA-256">4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d</hash>
+            <hash alg="SHA-256">549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e</hash>
+            <hash alg="SHA-256">55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6</hash>
+            <hash alg="SHA-256">572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269</hash>
+            <hash alg="SHA-256">573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96</hash>
+            <hash alg="SHA-256">5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d</hash>
+            <hash alg="SHA-256">6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a</hash>
+            <hash alg="SHA-256">65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4</hash>
+            <hash alg="SHA-256">663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77</hash>
+            <hash alg="SHA-256">6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d</hash>
+            <hash alg="SHA-256">68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0</hash>
+            <hash alg="SHA-256">6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed</hash>
+            <hash alg="SHA-256">6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068</hash>
+            <hash alg="SHA-256">6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac</hash>
+            <hash alg="SHA-256">6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25</hash>
+            <hash alg="SHA-256">753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8</hash>
+            <hash alg="SHA-256">7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab</hash>
+            <hash alg="SHA-256">7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26</hash>
+            <hash alg="SHA-256">7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2</hash>
+            <hash alg="SHA-256">802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db</hash>
+            <hash alg="SHA-256">80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f</hash>
+            <hash alg="SHA-256">8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5</hash>
+            <hash alg="SHA-256">86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99</hash>
+            <hash alg="SHA-256">87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c</hash>
+            <hash alg="SHA-256">8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d</hash>
+            <hash alg="SHA-256">8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811</hash>
+            <hash alg="SHA-256">8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa</hash>
+            <hash alg="SHA-256">8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a</hash>
+            <hash alg="SHA-256">9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03</hash>
+            <hash alg="SHA-256">90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b</hash>
+            <hash alg="SHA-256">923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04</hash>
+            <hash alg="SHA-256">95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c</hash>
+            <hash alg="SHA-256">96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001</hash>
+            <hash alg="SHA-256">9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458</hash>
+            <hash alg="SHA-256">a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389</hash>
+            <hash alg="SHA-256">a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99</hash>
+            <hash alg="SHA-256">a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985</hash>
+            <hash alg="SHA-256">a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537</hash>
+            <hash alg="SHA-256">ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238</hash>
+            <hash alg="SHA-256">aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f</hash>
+            <hash alg="SHA-256">b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d</hash>
+            <hash alg="SHA-256">b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796</hash>
+            <hash alg="SHA-256">b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a</hash>
+            <hash alg="SHA-256">b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143</hash>
+            <hash alg="SHA-256">bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8</hash>
+            <hash alg="SHA-256">beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c</hash>
+            <hash alg="SHA-256">c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5</hash>
+            <hash alg="SHA-256">c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5</hash>
+            <hash alg="SHA-256">c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711</hash>
+            <hash alg="SHA-256">c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4</hash>
+            <hash alg="SHA-256">cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6</hash>
+            <hash alg="SHA-256">d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c</hash>
+            <hash alg="SHA-256">d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7</hash>
+            <hash alg="SHA-256">db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4</hash>
+            <hash alg="SHA-256">ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b</hash>
+            <hash alg="SHA-256">deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae</hash>
+            <hash alg="SHA-256">e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12</hash>
+            <hash alg="SHA-256">e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c</hash>
+            <hash alg="SHA-256">e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae</hash>
+            <hash alg="SHA-256">eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8</hash>
+            <hash alg="SHA-256">eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887</hash>
+            <hash alg="SHA-256">eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b</hash>
+            <hash alg="SHA-256">efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4</hash>
+            <hash alg="SHA-256">f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f</hash>
+            <hash alg="SHA-256">f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5</hash>
+            <hash alg="SHA-256">fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33</hash>
+            <hash alg="SHA-256">fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519</hash>
+            <hash alg="SHA-256">ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="idna==3.6">
+      <name>idna</name>
+      <version>3.6</version>
+      <purl>pkg:pypi/idna@3.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca</hash>
+            <hash alg="SHA-256">c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pillow">
+      <name>pillow</name>
+      <purl>pkg:pypi/pillow?vcs_url=git%2Bhttps://github.com/python-pillow/Pillow.git%40da59ad000d1405eaecd557175e29083a87d19f7c</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/python-pillow/Pillow.git#da59ad000d1405eaecd557175e29083a87d19f7c</url>
+          <comment>from git</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="requests">
+      <name>requests</name>
+      <purl>pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%40a25fde6989f8df5c3d823bc9f2e2fc24aa71f375</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/requests/requests.git#a25fde6989f8df5c3d823bc9f2e2fc24aa71f375</url>
+          <comment>from git</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six">
+      <name>six</name>
+      <purl>pkg:pypi/six?vcs_url=git%2Bssh://git%40github.com/benjaminp/six.git%4065486e4383f9f411da95937451205d3c7b61b9e1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+ssh://git@github.com/benjaminp/six.git#65486e4383f9f411da95937451205d3c7b61b9e1</url>
+          <comment>from git</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="urllib3">
+      <name>urllib3</name>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <comment>from file</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="certifi==2023.11.17"/>
+    <dependency ref="charset-normalizer==3.3.2"/>
+    <dependency ref="idna==3.6"/>
+    <dependency ref="pillow"/>
+    <dependency ref="requests"/>
+    <dependency ref="root-component"/>
+    <dependency ref="six"/>
+    <dependency ref="urllib3"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/group-deps-lock11-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/group-deps-lock11-1.5.json.bin
@@ -1,0 +1,337 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "ddt@1.7.0",
+      "description": "Data-Driven/Decorated Tests",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a0719acde99dd32767cff64e653ef99c01ad5b042ff265f2ebecd28796ffd114"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ddt/#ddt-1.7.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d178d115abf25a1b8327e94f85a03ef09b1d7b0ca256f6203284b024f2fc70df"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ddt/#ddt-1.7.0.tar.gz"
+        }
+      ],
+      "name": "ddt",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/ddt@1.7.0",
+      "type": "library",
+      "version": "1.7.0"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        },
+        {
+          "name": "cdx:poetry:group",
+          "value": "groupB"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "ddt@1.7.0"
+    },
+    {
+      "dependsOn": [
+        "ddt@1.7.0",
+        "isoduration@20.11.0",
+        "toml@0.10.2"
+      ],
+      "ref": "group-deps"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "group-deps",
+      "description": "dependencies organized in groups",
+      "name": "group-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/group-deps-lock11-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/group-deps-lock11-1.5.xml.bin
@@ -1,0 +1,249 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="group-deps">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>group-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="ddt@1.7.0">
+      <name>ddt</name>
+      <version>1.7.0</version>
+      <description>Data-Driven/Decorated Tests</description>
+      <purl>pkg:pypi/ddt@1.7.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ddt/#ddt-1.7.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a0719acde99dd32767cff64e653ef99c01ad5b042ff265f2ebecd28796ffd114</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ddt/#ddt-1.7.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d178d115abf25a1b8327e94f85a03ef09b1d7b0ca256f6203284b024f2fc70df</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+        <property name="cdx:poetry:group">groupB</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="ddt@1.7.0"/>
+    <dependency ref="group-deps">
+      <dependency ref="ddt@1.7.0"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/group-deps-lock20-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/group-deps-lock20-1.5.json.bin
@@ -1,0 +1,309 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "ddt@1.7.0",
+      "description": "Data-Driven/Decorated Tests",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a0719acde99dd32767cff64e653ef99c01ad5b042ff265f2ebecd28796ffd114"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ddt/#ddt-1.7.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d178d115abf25a1b8327e94f85a03ef09b1d7b0ca256f6203284b024f2fc70df"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ddt/#ddt-1.7.0.tar.gz"
+        }
+      ],
+      "name": "ddt",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/ddt@1.7.0",
+      "type": "library",
+      "version": "1.7.0"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "groupB"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "ddt@1.7.0"
+    },
+    {
+      "dependsOn": [
+        "ddt@1.7.0",
+        "isoduration@20.11.0",
+        "toml@0.10.2"
+      ],
+      "ref": "group-deps"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "group-deps",
+      "description": "dependencies organized in groups",
+      "name": "group-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/group-deps-lock20-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/group-deps-lock20-1.5.xml.bin
@@ -1,0 +1,236 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="group-deps">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>group-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="ddt@1.7.0">
+      <name>ddt</name>
+      <version>1.7.0</version>
+      <description>Data-Driven/Decorated Tests</description>
+      <purl>pkg:pypi/ddt@1.7.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ddt/#ddt-1.7.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a0719acde99dd32767cff64e653ef99c01ad5b042ff265f2ebecd28796ffd114</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ddt/#ddt-1.7.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d178d115abf25a1b8327e94f85a03ef09b1d7b0ca256f6203284b024f2fc70df</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">groupB</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="ddt@1.7.0"/>
+    <dependency ref="group-deps">
+      <dependency ref="ddt@1.7.0"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/local-lock10-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/local-lock10-1.5.json.bin
@@ -1,0 +1,93 @@
+{
+  "components": [
+    {
+      "bom-ref": "package-a@23.42",
+      "description": "some package A",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3869fe3f4a6cca5b203b2e2cd8858c834f651e1b0fa76d5c0232e36472199592"
+            }
+          ],
+          "type": "distribution",
+          "url": "../../../_helpers/local_pckages/a/dist/package-a-23.42.tar.gz"
+        }
+      ],
+      "name": "package-a",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "type": "library",
+      "version": "23.42"
+    },
+    {
+      "bom-ref": "package-b@23.42",
+      "description": "some package B",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4aacda53fa274f5ff7eed71a9916904ffb3a11b05dc5ca529d7ddb78ae2dc602"
+            }
+          ],
+          "type": "distribution",
+          "url": "../../../_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl"
+        }
+      ],
+      "name": "package-b",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "type": "library",
+      "version": "23.42"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "package-a@23.42",
+        "package-b@23.42"
+      ],
+      "ref": "local"
+    },
+    {
+      "ref": "package-a@23.42"
+    },
+    {
+      "ref": "package-b@23.42"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "local",
+      "description": "packages from local paths",
+      "name": "local",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/local-lock10-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/local-lock10-1.5.xml.bin
@@ -1,0 +1,94 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="local">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>local</name>
+      <version>0.1.0</version>
+      <description>packages from local paths</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="package-a@23.42">
+      <name>package-a</name>
+      <version>23.42</version>
+      <description>some package A</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../../_helpers/local_pckages/a/dist/package-a-23.42.tar.gz</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">3869fe3f4a6cca5b203b2e2cd8858c834f651e1b0fa76d5c0232e36472199592</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="package-b@23.42">
+      <name>package-b</name>
+      <version>23.42</version>
+      <description>some package B</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../../_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">4aacda53fa274f5ff7eed71a9916904ffb3a11b05dc5ca529d7ddb78ae2dc602</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="local">
+      <dependency ref="package-a@23.42"/>
+      <dependency ref="package-b@23.42"/>
+    </dependency>
+    <dependency ref="package-a@23.42"/>
+    <dependency ref="package-b@23.42"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/local-lock11-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/local-lock11-1.5.json.bin
@@ -1,0 +1,117 @@
+{
+  "components": [
+    {
+      "bom-ref": "package-a@23.42",
+      "description": "some package A",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3869fe3f4a6cca5b203b2e2cd8858c834f651e1b0fa76d5c0232e36472199592"
+            }
+          ],
+          "type": "distribution",
+          "url": "../../../_helpers/local_pckages/a/dist/package-a-23.42.tar.gz"
+        }
+      ],
+      "name": "package-a",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "type": "library",
+      "version": "23.42"
+    },
+    {
+      "bom-ref": "package-b@23.42",
+      "description": "some package B",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4aacda53fa274f5ff7eed71a9916904ffb3a11b05dc5ca529d7ddb78ae2dc602"
+            }
+          ],
+          "type": "distribution",
+          "url": "../../../_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl"
+        }
+      ],
+      "name": "package-b",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "type": "library",
+      "version": "23.42"
+    },
+    {
+      "bom-ref": "package-c@23.42",
+      "description": "some package C",
+      "externalReferences": [
+        {
+          "comment": "from directory",
+          "type": "distribution",
+          "url": "../../../_helpers/local_pckages/c"
+        }
+      ],
+      "name": "package-c",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "type": "library",
+      "version": "23.42"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "package-a@23.42",
+        "package-b@23.42",
+        "package-c@23.42"
+      ],
+      "ref": "local"
+    },
+    {
+      "ref": "package-a@23.42"
+    },
+    {
+      "ref": "package-b@23.42"
+    },
+    {
+      "ref": "package-c@23.42"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "local",
+      "description": "packages from local paths",
+      "name": "local",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/local-lock11-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/local-lock11-1.5.xml.bin
@@ -1,0 +1,110 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="local">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>local</name>
+      <version>0.1.0</version>
+      <description>packages from local paths</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="package-a@23.42">
+      <name>package-a</name>
+      <version>23.42</version>
+      <description>some package A</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../../_helpers/local_pckages/a/dist/package-a-23.42.tar.gz</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">3869fe3f4a6cca5b203b2e2cd8858c834f651e1b0fa76d5c0232e36472199592</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="package-b@23.42">
+      <name>package-b</name>
+      <version>23.42</version>
+      <description>some package B</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../../_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">4aacda53fa274f5ff7eed71a9916904ffb3a11b05dc5ca529d7ddb78ae2dc602</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="package-c@23.42">
+      <name>package-c</name>
+      <version>23.42</version>
+      <description>some package C</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../../_helpers/local_pckages/c</url>
+          <comment>from directory</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="local">
+      <dependency ref="package-a@23.42"/>
+      <dependency ref="package-b@23.42"/>
+      <dependency ref="package-c@23.42"/>
+    </dependency>
+    <dependency ref="package-a@23.42"/>
+    <dependency ref="package-b@23.42"/>
+    <dependency ref="package-c@23.42"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/local-lock20-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/local-lock20-1.5.json.bin
@@ -1,0 +1,117 @@
+{
+  "components": [
+    {
+      "bom-ref": "package-a@23.42",
+      "description": "some package A",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3869fe3f4a6cca5b203b2e2cd8858c834f651e1b0fa76d5c0232e36472199592"
+            }
+          ],
+          "type": "distribution",
+          "url": "../../../_helpers/local_pckages/a/dist/package-a-23.42.tar.gz"
+        }
+      ],
+      "name": "package-a",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "type": "library",
+      "version": "23.42"
+    },
+    {
+      "bom-ref": "package-b@23.42",
+      "description": "some package B",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4aacda53fa274f5ff7eed71a9916904ffb3a11b05dc5ca529d7ddb78ae2dc602"
+            }
+          ],
+          "type": "distribution",
+          "url": "../../../_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl"
+        }
+      ],
+      "name": "package-b",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "type": "library",
+      "version": "23.42"
+    },
+    {
+      "bom-ref": "package-c@23.42",
+      "description": "some package C",
+      "externalReferences": [
+        {
+          "comment": "from directory",
+          "type": "distribution",
+          "url": "../../../_helpers/local_pckages/c"
+        }
+      ],
+      "name": "package-c",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "type": "library",
+      "version": "23.42"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "package-a@23.42",
+        "package-b@23.42",
+        "package-c@23.42"
+      ],
+      "ref": "local"
+    },
+    {
+      "ref": "package-a@23.42"
+    },
+    {
+      "ref": "package-b@23.42"
+    },
+    {
+      "ref": "package-c@23.42"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "local",
+      "description": "packages from local paths",
+      "name": "local",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/local-lock20-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/local-lock20-1.5.xml.bin
@@ -1,0 +1,110 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="local">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>local</name>
+      <version>0.1.0</version>
+      <description>packages from local paths</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="package-a@23.42">
+      <name>package-a</name>
+      <version>23.42</version>
+      <description>some package A</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../../_helpers/local_pckages/a/dist/package-a-23.42.tar.gz</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">3869fe3f4a6cca5b203b2e2cd8858c834f651e1b0fa76d5c0232e36472199592</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="package-b@23.42">
+      <name>package-b</name>
+      <version>23.42</version>
+      <description>some package B</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../../_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">4aacda53fa274f5ff7eed71a9916904ffb3a11b05dc5ca529d7ddb78ae2dc602</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="package-c@23.42">
+      <name>package-c</name>
+      <version>23.42</version>
+      <description>some package C</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../../_helpers/local_pckages/c</url>
+          <comment>from directory</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="local">
+      <dependency ref="package-a@23.42"/>
+      <dependency ref="package-b@23.42"/>
+      <dependency ref="package-c@23.42"/>
+    </dependency>
+    <dependency ref="package-a@23.42"/>
+    <dependency ref="package-b@23.42"/>
+    <dependency ref="package-c@23.42"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/main-and-dev-lock10-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/main-and-dev-lock10-1.5.json.bin
@@ -1,0 +1,261 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6",
+        "isoduration@20.11.0",
+        "toml@0.10.2"
+      ],
+      "ref": "main-and-dev"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "main-and-dev",
+      "description": "main and dev depenndencies",
+      "name": "main-and-dev",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/main-and-dev-lock10-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/main-and-dev-lock10-1.5.xml.bin
@@ -1,0 +1,200 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="main-and-dev">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>main-and-dev</name>
+      <version>0.1.0</version>
+      <description>main and dev depenndencies</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="main-and-dev">
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/main-and-dev-lock11-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/main-and-dev-lock11-1.5.json.bin
@@ -1,0 +1,333 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6",
+        "isoduration@20.11.0",
+        "toml@0.10.2"
+      ],
+      "ref": "main-and-dev"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "main-and-dev",
+      "description": "main and dev depenndencies",
+      "name": "main-and-dev",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/main-and-dev-lock11-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/main-and-dev-lock11-1.5.xml.bin
@@ -1,0 +1,248 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="main-and-dev">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>main-and-dev</name>
+      <version>0.1.0</version>
+      <description>main and dev depenndencies</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="main-and-dev">
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/main-and-dev-lock20-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/main-and-dev-lock20-1.5.json.bin
@@ -1,0 +1,309 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6",
+        "isoduration@20.11.0",
+        "toml@0.10.2"
+      ],
+      "ref": "main-and-dev"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "main-and-dev",
+      "description": "main and dev depenndencies",
+      "name": "main-and-dev",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/main-and-dev-lock20-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/main-and-dev-lock20-1.5.xml.bin
@@ -1,0 +1,236 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="main-and-dev">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>main-and-dev</name>
+      <version>0.1.0</version>
+      <description>main and dev depenndencies</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="main-and-dev">
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/no-deps-lock20-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/no-deps-lock20-1.5.json.bin
@@ -1,0 +1,66 @@
+{
+  "dependencies": [
+    {
+      "ref": "no-deps"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com> | My Name",
+      "bom-ref": "no-deps",
+      "description": "packages with all meta, but no deps",
+      "externalReferences": [
+        {
+          "comment": "project metadata: documentation",
+          "type": "documentation",
+          "url": "https://oss.acme.org/my-project/docs/"
+        },
+        {
+          "comment": "package urls: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://oss.acme.org/my-project/bugs/"
+        },
+        {
+          "comment": "package urls: Change log",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/changelog/"
+        },
+        {
+          "comment": "package urls: Funding",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/funding/"
+        },
+        {
+          "comment": "project metadata: repository",
+          "type": "vcs",
+          "url": "https://oss.acme.org/my-project.git"
+        },
+        {
+          "comment": "project metadata: homepage",
+          "type": "website",
+          "url": "https://oss.acme.org/my-project/"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "no-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/no-deps-lock20-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/no-deps-lock20-1.5.xml.bin
@@ -1,0 +1,82 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="no-deps">
+      <author>Your Name &lt;you@example.com&gt; | My Name</author>
+      <name>no-deps</name>
+      <version>0.1.0</version>
+      <description>packages with all meta, but no deps</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://oss.acme.org/my-project/docs/</url>
+          <comment>project metadata: documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://oss.acme.org/my-project/bugs/</url>
+          <comment>package urls: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/changelog/</url>
+          <comment>package urls: Change log</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/funding/</url>
+          <comment>package urls: Funding</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://oss.acme.org/my-project.git</url>
+          <comment>project metadata: repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://oss.acme.org/my-project/</url>
+          <comment>project metadata: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </metadata>
+  <dependencies>
+    <dependency ref="no-deps"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/no-dev-lock11-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/no-dev-lock11-1.5.json.bin
@@ -1,0 +1,75 @@
+{
+  "components": [
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "toml@0.10.2"
+      ],
+      "ref": "group-deps"
+    },
+    {
+      "ref": "toml@0.10.2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "group-deps",
+      "description": "dependencies organized in groups",
+      "name": "group-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/no-dev-lock11-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/no-dev-lock11-1.5.xml.bin
@@ -1,0 +1,83 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="group-deps">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>group-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="group-deps">
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="toml@0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/no-dev-lock20-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/no-dev-lock20-1.5.json.bin
@@ -1,0 +1,75 @@
+{
+  "components": [
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "toml@0.10.2"
+      ],
+      "ref": "group-deps"
+    },
+    {
+      "ref": "toml@0.10.2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "group-deps",
+      "description": "dependencies organized in groups",
+      "name": "group-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/no-dev-lock20-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/no-dev-lock20-1.5.xml.bin
@@ -1,0 +1,83 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="group-deps">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>group-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="group-deps">
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="toml@0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/only-groups-lock11-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/only-groups-lock11-1.5.json.bin
@@ -1,0 +1,253 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        },
+        {
+          "name": "cdx:poetry:group",
+          "value": "groupB"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "dependsOn": [
+        "isoduration@20.11.0"
+      ],
+      "ref": "group-deps"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "group-deps",
+      "description": "dependencies organized in groups",
+      "name": "group-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/only-groups-lock11-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/only-groups-lock11-1.5.xml.bin
@@ -1,0 +1,195 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="group-deps">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>group-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+        <property name="cdx:poetry:group">groupB</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="group-deps">
+      <dependency ref="isoduration@20.11.0"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/only-groups-lock20-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/only-groups-lock20-1.5.json.bin
@@ -1,0 +1,225 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "groupB"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "dependsOn": [
+        "isoduration@20.11.0"
+      ],
+      "ref": "group-deps"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "group-deps",
+      "description": "dependencies organized in groups",
+      "name": "group-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/only-groups-lock20-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/only-groups-lock20-1.5.xml.bin
@@ -1,0 +1,182 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="group-deps">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>group-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">groupB</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="group-deps">
+      <dependency ref="isoduration@20.11.0"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/private-packges-lock10-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/private-packges-lock10-1.5.json.bin
@@ -1,0 +1,117 @@
+{
+  "components": [
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2?repository_url=http://pysrc2.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6",
+        "toml@0.10.2"
+      ],
+      "ref": "private-packges"
+    },
+    {
+      "ref": "toml@0.10.2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "private-packges",
+      "description": "packages from aternative package repositories",
+      "name": "private-packges",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/private-packges-lock10-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/private-packges-lock10-1.5.xml.bin
@@ -1,0 +1,110 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="private-packges">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>private-packges</name>
+      <version>0.1.0</version>
+      <description>packages from aternative package repositories</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2?repository_url=http://pysrc2.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="private-packges">
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="toml@0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/private-packges-lock11-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/private-packges-lock11-1.5.json.bin
@@ -1,0 +1,1172 @@
+{
+  "components": [
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "importlib-metadata@6.8.0",
+      "description": "Read metadata from Python packages",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/importlib-metadata/#importlib_metadata-6.8.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/importlib-metadata/#importlib_metadata-6.8.0.tar.gz"
+        }
+      ],
+      "name": "importlib-metadata",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/importlib-metadata@6.8.0?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "6.8.0"
+    },
+    {
+      "bom-ref": "jax@0.4.20",
+      "description": "Differentiate, compile, and transform Numpy code.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3d5952197adca548d99310f1c326bf00548f1cc8652b89edb369166482c2aec2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://storage.googleapis.com/jax-releases/jax_releases.html/jax/#jax-0.4.20-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ea96a763a8b1a9374639d1159ab4de163461d01cd022f67c34c09581b71ed2ac"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://storage.googleapis.com/jax-releases/jax_releases.html/jax/#jax-0.4.20.tar.gz"
+        }
+      ],
+      "name": "jax",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/jax@0.4.20?repository_url=https://storage.googleapis.com/jax-releases/jax_releases.html",
+      "type": "library",
+      "version": "0.4.20"
+    },
+    {
+      "bom-ref": "ml-dtypes@0.3.1",
+      "description": "",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "510d249a91face47211762eb294d6fe64f325356b965fb6388c1bf51bd339267"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f83ff080df8910c0f987f615b03e4f8198638e0c00c6e679ea8892dda909763b"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fcae2c69715410d96906e1dfe8f017d9f78a0d10e0df91aae52e91f51fdfe45e"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "da274599e4950a9b488d21571061f49a185537cc77f2d3f8121151d58a9e9f16"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5e0b0b6bb07fa5ad11bb61d174667176bee5e05857225067aabfc5adc1b51d23"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5727effa7650f7ab10906542d137cfb3244fdc3b2b519beff42f82def8ba59be"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "42a8980afd8b7c8e270e8b5c260237286b5b26acd276fcb758d13cd7cb567e99"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cb0c404e0dd3e25b56362c1c1e5de0ef717f727dde59fa721af4ce6ab2acca44"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3d8ca0acbd377082792d8b97081ba580abdad67c6afb7f827012c675b052f058"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4828b62fa3bf1ae35faa40f3db9a38ec72fbce02f328a1d14c3a9da4606af364"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d1a8dc3bac1da2a17d0e2e4cba36ee89721d0bd33ea4765af2eefb5f41409e0f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a777928dcba8865ab4a8157eeb25d23aed7bc82e5fd74e1d5eca821d3f148b39"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "438437e2e614a3c91d75581653b6c40ec890e8b5994d7190a90c931740151c95"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "70984b473db6489ec1d8c79b082a1322105155193049d08a3b0c515094e9777b"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d94b2d1bed77284694f7fd0479640fa7aa5d96433dca3cbcec407a5ef752e77"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "979d7d196d9a17e0135ae22878f74241fbd3522cef58d7b292f1fd5b32282201"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "60778f99194b4c4f36ba42da200b35ef851ce4d4af698aaf70f5b91fe70fc611"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1.tar.gz"
+        }
+      ],
+      "name": "ml-dtypes",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/ml-dtypes@0.3.1?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.3.1"
+    },
+    {
+      "bom-ref": "numpy@1.26.1",
+      "description": "Fundamental package for array computing in Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "82e871307a6331b5f09efda3c22e03c095d957f04bf6bc1804f30048d0e5e7af"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cdd9ec98f0063d93baeb01aad472a1a0840dee302842a2746a7a8e92968f9575"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d78f269e0c4fd365fc2992c00353e4530d274ba68f15e968d8bc3c69ce5f5244"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8ab9163ca8aeb7fd32fe93866490654d2f7dda4e61bc6297bf72ce07fdc02f67"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "78ca54b2f9daffa5f323f34cdf21e1d9779a54073f0018a3094ab907938331a2"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d1cfc92db6af1fd37a7bb58e55c8383b4aa1ba23d012bdbba26b4bcca45ac297"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d2984cb6caaf05294b8466966627e80bf6c7afd273279077679cb010acb0e5ab"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd7837b2b734ca72959a1caf3309457a318c934abef7a43a14bb984e574bbb9a"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1c59c046c31a43310ad0199d6299e59f57a289e22f0f36951ced1c9eac3665b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d58e8c51a7cf43090d124d5073bc29ab2755822181fcad978b12e144e5e5a4b3"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6081aed64714a18c72b168a9276095ef9155dd7888b9e74b5987808f0dd0a974"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "97e5d6a9f0702c2863aaabf19f0d1b6c2628fbe476438ce0b5ce06e83085064c"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b9d45d1dbb9de84894cc50efece5b09939752a2d75aab3a8b0cef6f3a35ecd6b"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3649d566e2fc067597125428db15d60eb42a4e0897fc48d28cb75dc2e0454e53"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1d1bd82d539607951cac963388534da3b7ea0e18b149a53cf883d8f699178c0f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "afd5ced4e5a96dac6725daeb5242a35494243f2239244fad10a90ce58b071d24"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a03fb25610ef560a6201ff06df4f8105292ba56e7cdd196ea350d123fc32e24e"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dcfaf015b79d1f9f9c9fd0731a907407dc3e45769262d657d754c3a028586124"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e509cbc488c735b43b5ffea175235cec24bbc57b227ef1acc691725beb230d1c"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "af22f3d8e228d84d1c0c44c1fbdeb80f97a15a0abe4f080960393a00db733b66"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9f42284ebf91bdf32fafac29d29d4c07e5e9d1af862ea73686581773ef9e73a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bb894accfd16b867d8643fc2ba6c8617c78ba2828051e9a69511644ce86ce83e"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e44ccb93f30c75dfc0c3aa3ce38f33486a75ec9abadabd4e59f114994a9c4617"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9696aa2e35cc41e398a6d42d147cf326f8f9d81befcb399bc1ed7ffea339b64e"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a5b411040beead47a228bde3b2241100454a6abde9df139ed087bd73fc0a4908"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e11668d6f756ca5ef534b5be8653d16c5352cbb210a5c2a79ff288e937010d5"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d1d2c6b7dd618c41e202c59c1413ef9b2c8e8a15f5039e344af64195459e3104"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "59227c981d43425ca5e5c01094d59eb14e8772ce6975d4b2fc1e106a833d5ae2"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "06934e1a22c54636a059215d6da99e23286424f316fddd979f5071093b648668"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "76ff661a867d9272cd2a99eed002470f46dbe0943a5ffd140f49be84f68ffc42"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6965888d65d2848e8768824ca8288db0a81263c1efccec881cb35a0d805fcd2f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-pp39-pypy39_pp73-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c8c6c72d4a9f831f328efb1312642a1cafafaa88981d9ab76368d50d07d93cbe"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1.tar.gz"
+        }
+      ],
+      "name": "numpy",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/numpy@1.26.1?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "1.26.1"
+    },
+    {
+      "bom-ref": "opt-einsum@3.3.0",
+      "description": "Optimizing numpys einsum function",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2455e59e3947d3c275477df7f5205b30635e266fe6dc300e3d9f9646bfcea147"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/opt-einsum/#opt_einsum-3.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "59f6475f77bbc37dcf7cd748519c0ec60722e91e63ca114e68821c0c54a46549"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/opt-einsum/#opt_einsum-3.3.0.tar.gz"
+        }
+      ],
+      "name": "opt-einsum",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/opt-einsum@3.3.0?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "3.3.0"
+    },
+    {
+      "bom-ref": "scipy@1.11.3",
+      "description": "Fundamental algorithms for scientific computing in Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "370f569c57e1d888304052c18e58f4a927338eafdaef78613c685ca2ea0d1fa0"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9885e3e4f13b2bd44aaf2a1a6390a11add9f48d5295f7a592393ceb8991577a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-macosx_12_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e04aa19acc324a1a076abb4035dabe9b64badb19f76ad9c798bde39d41025cdc"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e1a8a4657673bfae1e05e1e1d6e94b0cabe5ed0c7c144c8aa7b7dbb774ce5c1"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7abda0e62ef00cde826d441485e2e32fe737bdddee3324e35c0e01dee65e2a88"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "033c3fd95d55012dd1148b201b72ae854d5086d25e7c316ec9850de4fe776929"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "925c6f09d0053b1c0f90b2d92d03b261e889b20d1c9b08a3a51f61afc5f58165"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5664e364f90be8219283eeb844323ff8cd79d7acbd64e15eb9c46b9bc7f6a42a"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-macosx_12_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "00f325434b6424952fbb636506f0567898dca7b0f7654d48f1c382ea338ce9a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5f290cf561a4b4edfe8d1001ee4be6da60c1c4ea712985b58bf6bc62badee221"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "91770cb3b1e81ae19463b3c235bf1e0e330767dca9eb4cd73ba3ded6c4151e4d"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e1f97cd89c0fe1a0685f8f89d85fa305deb3067d0668151571ba50913e445820"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dfcc1552add7cb7c13fb70efcb2389d0624d571aaf2c80b04117e2755a0c5d15"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0d3a136ae1ff0883fffbb1b05b0b2fea251cb1046a5077d0b435a1839b3e52b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-macosx_12_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bae66a2d7d5768eaa33008fa5a974389f167183c87bf39160d3fefe6664f8ddc"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d2f6dee6cbb0e263b8142ed587bc93e3ed5e777f1f75448d24fb923d9fd4dce6"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "74e89dc5e00201e71dd94f5f382ab1c6a9f3ff806c7d24e4e90928bb1aafb280"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "90271dbde4be191522b3903fc97334e3956d7cfb9cce3f0718d0ab4fd7d8bfd6"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a63d1ec9cadecce838467ce0631c17c15c7197ae61e49429434ba01d618caa83"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5305792c7110e32ff155aed0df46aa60a60fc6e52cd4ee02cdeb67eaccd5356e"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-macosx_12_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9ea7f579182d83d00fed0e5c11a4aa5ffe01460444219dedc448a36adf0c3917"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c77da50c9a91e23beb63c2a711ef9e9ca9a2060442757dffee34ea41847d8156"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "15f237e890c24aef6891c7d008f9ff7e758c6ef39a2b5df264650eb7900403c0"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b4bb134c7aa457e26cc6ea482b016fef45db71417d55cc6d8f43d799cdf9ef2"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bba4d955f54edd61899776bad459bf7326e14b9fa1c552181f0479cc60a568cd"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3.tar.gz"
+        }
+      ],
+      "name": "scipy",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/scipy@1.11.3?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "1.11.3"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2?repository_url=http://pysrc2.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "zipp@3.17.0",
+      "description": "Backport of pathlib-compatible object wrapper for zip files",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/zipp/#zipp-3.17.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/zipp/#zipp-3.17.0.tar.gz"
+        }
+      ],
+      "name": "zipp",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/zipp@3.17.0?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "3.17.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "zipp@3.17.0"
+      ],
+      "ref": "importlib-metadata@6.8.0"
+    },
+    {
+      "dependsOn": [
+        "importlib-metadata@6.8.0",
+        "ml-dtypes@0.3.1",
+        "numpy@1.26.1",
+        "opt-einsum@3.3.0",
+        "scipy@1.11.3"
+      ],
+      "ref": "jax@0.4.20"
+    },
+    {
+      "dependsOn": [
+        "numpy@1.26.1"
+      ],
+      "ref": "ml-dtypes@0.3.1"
+    },
+    {
+      "ref": "numpy@1.26.1"
+    },
+    {
+      "dependsOn": [
+        "numpy@1.26.1"
+      ],
+      "ref": "opt-einsum@3.3.0"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6",
+        "jax@0.4.20",
+        "toml@0.10.2"
+      ],
+      "ref": "private-packges"
+    },
+    {
+      "dependsOn": [
+        "numpy@1.26.1"
+      ],
+      "ref": "scipy@1.11.3"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "zipp@3.17.0"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "private-packges",
+      "description": "packages from aternative package repositories",
+      "name": "private-packges",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/private-packges-lock11-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/private-packges-lock11-1.5.xml.bin
@@ -1,0 +1,783 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="private-packges">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>private-packges</name>
+      <version>0.1.0</version>
+      <description>packages from aternative package repositories</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="importlib-metadata@6.8.0">
+      <name>importlib-metadata</name>
+      <version>6.8.0</version>
+      <description>Read metadata from Python packages</description>
+      <purl>pkg:pypi/importlib-metadata@6.8.0?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/importlib-metadata/#importlib_metadata-6.8.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/importlib-metadata/#importlib_metadata-6.8.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jax@0.4.20">
+      <name>jax</name>
+      <version>0.4.20</version>
+      <description>Differentiate, compile, and transform Numpy code.</description>
+      <purl>pkg:pypi/jax@0.4.20?repository_url=https://storage.googleapis.com/jax-releases/jax_releases.html</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://storage.googleapis.com/jax-releases/jax_releases.html/jax/#jax-0.4.20-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3d5952197adca548d99310f1c326bf00548f1cc8652b89edb369166482c2aec2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://storage.googleapis.com/jax-releases/jax_releases.html/jax/#jax-0.4.20.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ea96a763a8b1a9374639d1159ab4de163461d01cd022f67c34c09581b71ed2ac</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="ml-dtypes@0.3.1">
+      <name>ml-dtypes</name>
+      <version>0.3.1</version>
+      <description/>
+      <purl>pkg:pypi/ml-dtypes@0.3.1?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">510d249a91face47211762eb294d6fe64f325356b965fb6388c1bf51bd339267</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f83ff080df8910c0f987f615b03e4f8198638e0c00c6e679ea8892dda909763b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fcae2c69715410d96906e1dfe8f017d9f78a0d10e0df91aae52e91f51fdfe45e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">da274599e4950a9b488d21571061f49a185537cc77f2d3f8121151d58a9e9f16</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5e0b0b6bb07fa5ad11bb61d174667176bee5e05857225067aabfc5adc1b51d23</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5727effa7650f7ab10906542d137cfb3244fdc3b2b519beff42f82def8ba59be</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">42a8980afd8b7c8e270e8b5c260237286b5b26acd276fcb758d13cd7cb567e99</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cb0c404e0dd3e25b56362c1c1e5de0ef717f727dde59fa721af4ce6ab2acca44</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3d8ca0acbd377082792d8b97081ba580abdad67c6afb7f827012c675b052f058</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4828b62fa3bf1ae35faa40f3db9a38ec72fbce02f328a1d14c3a9da4606af364</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d1a8dc3bac1da2a17d0e2e4cba36ee89721d0bd33ea4765af2eefb5f41409e0f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a777928dcba8865ab4a8157eeb25d23aed7bc82e5fd74e1d5eca821d3f148b39</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">438437e2e614a3c91d75581653b6c40ec890e8b5994d7190a90c931740151c95</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">70984b473db6489ec1d8c79b082a1322105155193049d08a3b0c515094e9777b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d94b2d1bed77284694f7fd0479640fa7aa5d96433dca3cbcec407a5ef752e77</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">979d7d196d9a17e0135ae22878f74241fbd3522cef58d7b292f1fd5b32282201</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">60778f99194b4c4f36ba42da200b35ef851ce4d4af698aaf70f5b91fe70fc611</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="numpy@1.26.1">
+      <name>numpy</name>
+      <version>1.26.1</version>
+      <description>Fundamental package for array computing in Python</description>
+      <purl>pkg:pypi/numpy@1.26.1?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">82e871307a6331b5f09efda3c22e03c095d957f04bf6bc1804f30048d0e5e7af</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cdd9ec98f0063d93baeb01aad472a1a0840dee302842a2746a7a8e92968f9575</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d78f269e0c4fd365fc2992c00353e4530d274ba68f15e968d8bc3c69ce5f5244</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8ab9163ca8aeb7fd32fe93866490654d2f7dda4e61bc6297bf72ce07fdc02f67</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">78ca54b2f9daffa5f323f34cdf21e1d9779a54073f0018a3094ab907938331a2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d1cfc92db6af1fd37a7bb58e55c8383b4aa1ba23d012bdbba26b4bcca45ac297</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d2984cb6caaf05294b8466966627e80bf6c7afd273279077679cb010acb0e5ab</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd7837b2b734ca72959a1caf3309457a318c934abef7a43a14bb984e574bbb9a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1c59c046c31a43310ad0199d6299e59f57a289e22f0f36951ced1c9eac3665b9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d58e8c51a7cf43090d124d5073bc29ab2755822181fcad978b12e144e5e5a4b3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6081aed64714a18c72b168a9276095ef9155dd7888b9e74b5987808f0dd0a974</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">97e5d6a9f0702c2863aaabf19f0d1b6c2628fbe476438ce0b5ce06e83085064c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b9d45d1dbb9de84894cc50efece5b09939752a2d75aab3a8b0cef6f3a35ecd6b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3649d566e2fc067597125428db15d60eb42a4e0897fc48d28cb75dc2e0454e53</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1d1bd82d539607951cac963388534da3b7ea0e18b149a53cf883d8f699178c0f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">afd5ced4e5a96dac6725daeb5242a35494243f2239244fad10a90ce58b071d24</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a03fb25610ef560a6201ff06df4f8105292ba56e7cdd196ea350d123fc32e24e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dcfaf015b79d1f9f9c9fd0731a907407dc3e45769262d657d754c3a028586124</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e509cbc488c735b43b5ffea175235cec24bbc57b227ef1acc691725beb230d1c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">af22f3d8e228d84d1c0c44c1fbdeb80f97a15a0abe4f080960393a00db733b66</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9f42284ebf91bdf32fafac29d29d4c07e5e9d1af862ea73686581773ef9e73a7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bb894accfd16b867d8643fc2ba6c8617c78ba2828051e9a69511644ce86ce83e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e44ccb93f30c75dfc0c3aa3ce38f33486a75ec9abadabd4e59f114994a9c4617</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9696aa2e35cc41e398a6d42d147cf326f8f9d81befcb399bc1ed7ffea339b64e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a5b411040beead47a228bde3b2241100454a6abde9df139ed087bd73fc0a4908</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e11668d6f756ca5ef534b5be8653d16c5352cbb210a5c2a79ff288e937010d5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d1d2c6b7dd618c41e202c59c1413ef9b2c8e8a15f5039e344af64195459e3104</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">59227c981d43425ca5e5c01094d59eb14e8772ce6975d4b2fc1e106a833d5ae2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">06934e1a22c54636a059215d6da99e23286424f316fddd979f5071093b648668</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">76ff661a867d9272cd2a99eed002470f46dbe0943a5ffd140f49be84f68ffc42</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-pp39-pypy39_pp73-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6965888d65d2848e8768824ca8288db0a81263c1efccec881cb35a0d805fcd2f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c8c6c72d4a9f831f328efb1312642a1cafafaa88981d9ab76368d50d07d93cbe</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="opt-einsum@3.3.0">
+      <name>opt-einsum</name>
+      <version>3.3.0</version>
+      <description>Optimizing numpys einsum function</description>
+      <purl>pkg:pypi/opt-einsum@3.3.0?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/opt-einsum/#opt_einsum-3.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2455e59e3947d3c275477df7f5205b30635e266fe6dc300e3d9f9646bfcea147</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/opt-einsum/#opt_einsum-3.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">59f6475f77bbc37dcf7cd748519c0ec60722e91e63ca114e68821c0c54a46549</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="scipy@1.11.3">
+      <name>scipy</name>
+      <version>1.11.3</version>
+      <description>Fundamental algorithms for scientific computing in Python</description>
+      <purl>pkg:pypi/scipy@1.11.3?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">370f569c57e1d888304052c18e58f4a927338eafdaef78613c685ca2ea0d1fa0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-macosx_12_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9885e3e4f13b2bd44aaf2a1a6390a11add9f48d5295f7a592393ceb8991577a3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e04aa19acc324a1a076abb4035dabe9b64badb19f76ad9c798bde39d41025cdc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3e1a8a4657673bfae1e05e1e1d6e94b0cabe5ed0c7c144c8aa7b7dbb774ce5c1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7abda0e62ef00cde826d441485e2e32fe737bdddee3324e35c0e01dee65e2a88</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">033c3fd95d55012dd1148b201b72ae854d5086d25e7c316ec9850de4fe776929</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">925c6f09d0053b1c0f90b2d92d03b261e889b20d1c9b08a3a51f61afc5f58165</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-macosx_12_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5664e364f90be8219283eeb844323ff8cd79d7acbd64e15eb9c46b9bc7f6a42a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">00f325434b6424952fbb636506f0567898dca7b0f7654d48f1c382ea338ce9a3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5f290cf561a4b4edfe8d1001ee4be6da60c1c4ea712985b58bf6bc62badee221</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">91770cb3b1e81ae19463b3c235bf1e0e330767dca9eb4cd73ba3ded6c4151e4d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e1f97cd89c0fe1a0685f8f89d85fa305deb3067d0668151571ba50913e445820</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dfcc1552add7cb7c13fb70efcb2389d0624d571aaf2c80b04117e2755a0c5d15</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-macosx_12_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0d3a136ae1ff0883fffbb1b05b0b2fea251cb1046a5077d0b435a1839b3e52b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bae66a2d7d5768eaa33008fa5a974389f167183c87bf39160d3fefe6664f8ddc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d2f6dee6cbb0e263b8142ed587bc93e3ed5e777f1f75448d24fb923d9fd4dce6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">74e89dc5e00201e71dd94f5f382ab1c6a9f3ff806c7d24e4e90928bb1aafb280</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">90271dbde4be191522b3903fc97334e3956d7cfb9cce3f0718d0ab4fd7d8bfd6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a63d1ec9cadecce838467ce0631c17c15c7197ae61e49429434ba01d618caa83</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-macosx_12_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5305792c7110e32ff155aed0df46aa60a60fc6e52cd4ee02cdeb67eaccd5356e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9ea7f579182d83d00fed0e5c11a4aa5ffe01460444219dedc448a36adf0c3917</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c77da50c9a91e23beb63c2a711ef9e9ca9a2060442757dffee34ea41847d8156</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">15f237e890c24aef6891c7d008f9ff7e758c6ef39a2b5df264650eb7900403c0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4b4bb134c7aa457e26cc6ea482b016fef45db71417d55cc6d8f43d799cdf9ef2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bba4d955f54edd61899776bad459bf7326e14b9fa1c552181f0479cc60a568cd</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2?repository_url=http://pysrc2.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="zipp@3.17.0">
+      <name>zipp</name>
+      <version>3.17.0</version>
+      <description>Backport of pathlib-compatible object wrapper for zip files</description>
+      <purl>pkg:pypi/zipp@3.17.0?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/zipp/#zipp-3.17.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/zipp/#zipp-3.17.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="importlib-metadata@6.8.0">
+      <dependency ref="zipp@3.17.0"/>
+    </dependency>
+    <dependency ref="jax@0.4.20">
+      <dependency ref="importlib-metadata@6.8.0"/>
+      <dependency ref="ml-dtypes@0.3.1"/>
+      <dependency ref="numpy@1.26.1"/>
+      <dependency ref="opt-einsum@3.3.0"/>
+      <dependency ref="scipy@1.11.3"/>
+    </dependency>
+    <dependency ref="ml-dtypes@0.3.1">
+      <dependency ref="numpy@1.26.1"/>
+    </dependency>
+    <dependency ref="numpy@1.26.1"/>
+    <dependency ref="opt-einsum@3.3.0">
+      <dependency ref="numpy@1.26.1"/>
+    </dependency>
+    <dependency ref="private-packges">
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="jax@0.4.20"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="scipy@1.11.3">
+      <dependency ref="numpy@1.26.1"/>
+    </dependency>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="zipp@3.17.0"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/private-packges-lock20-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/private-packges-lock20-1.5.json.bin
@@ -1,0 +1,1136 @@
+{
+  "components": [
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "importlib-metadata@6.8.0",
+      "description": "Read metadata from Python packages",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/importlib-metadata/#importlib_metadata-6.8.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/importlib-metadata/#importlib_metadata-6.8.0.tar.gz"
+        }
+      ],
+      "name": "importlib-metadata",
+      "purl": "pkg:pypi/importlib-metadata@6.8.0?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "6.8.0"
+    },
+    {
+      "bom-ref": "jax@0.4.20",
+      "description": "Differentiate, compile, and transform Numpy code.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3d5952197adca548d99310f1c326bf00548f1cc8652b89edb369166482c2aec2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://storage.googleapis.com/jax-releases/jax_releases.html/jax/#jax-0.4.20-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ea96a763a8b1a9374639d1159ab4de163461d01cd022f67c34c09581b71ed2ac"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://storage.googleapis.com/jax-releases/jax_releases.html/jax/#jax-0.4.20.tar.gz"
+        }
+      ],
+      "name": "jax",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/jax@0.4.20?repository_url=https://storage.googleapis.com/jax-releases/jax_releases.html",
+      "type": "library",
+      "version": "0.4.20"
+    },
+    {
+      "bom-ref": "ml-dtypes@0.3.1",
+      "description": "",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "510d249a91face47211762eb294d6fe64f325356b965fb6388c1bf51bd339267"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f83ff080df8910c0f987f615b03e4f8198638e0c00c6e679ea8892dda909763b"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fcae2c69715410d96906e1dfe8f017d9f78a0d10e0df91aae52e91f51fdfe45e"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "da274599e4950a9b488d21571061f49a185537cc77f2d3f8121151d58a9e9f16"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5e0b0b6bb07fa5ad11bb61d174667176bee5e05857225067aabfc5adc1b51d23"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5727effa7650f7ab10906542d137cfb3244fdc3b2b519beff42f82def8ba59be"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "42a8980afd8b7c8e270e8b5c260237286b5b26acd276fcb758d13cd7cb567e99"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cb0c404e0dd3e25b56362c1c1e5de0ef717f727dde59fa721af4ce6ab2acca44"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3d8ca0acbd377082792d8b97081ba580abdad67c6afb7f827012c675b052f058"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4828b62fa3bf1ae35faa40f3db9a38ec72fbce02f328a1d14c3a9da4606af364"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d1a8dc3bac1da2a17d0e2e4cba36ee89721d0bd33ea4765af2eefb5f41409e0f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a777928dcba8865ab4a8157eeb25d23aed7bc82e5fd74e1d5eca821d3f148b39"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "438437e2e614a3c91d75581653b6c40ec890e8b5994d7190a90c931740151c95"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "70984b473db6489ec1d8c79b082a1322105155193049d08a3b0c515094e9777b"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d94b2d1bed77284694f7fd0479640fa7aa5d96433dca3cbcec407a5ef752e77"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "979d7d196d9a17e0135ae22878f74241fbd3522cef58d7b292f1fd5b32282201"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "60778f99194b4c4f36ba42da200b35ef851ce4d4af698aaf70f5b91fe70fc611"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1.tar.gz"
+        }
+      ],
+      "name": "ml-dtypes",
+      "purl": "pkg:pypi/ml-dtypes@0.3.1?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.3.1"
+    },
+    {
+      "bom-ref": "numpy@1.26.1",
+      "description": "Fundamental package for array computing in Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "82e871307a6331b5f09efda3c22e03c095d957f04bf6bc1804f30048d0e5e7af"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cdd9ec98f0063d93baeb01aad472a1a0840dee302842a2746a7a8e92968f9575"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d78f269e0c4fd365fc2992c00353e4530d274ba68f15e968d8bc3c69ce5f5244"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8ab9163ca8aeb7fd32fe93866490654d2f7dda4e61bc6297bf72ce07fdc02f67"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "78ca54b2f9daffa5f323f34cdf21e1d9779a54073f0018a3094ab907938331a2"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d1cfc92db6af1fd37a7bb58e55c8383b4aa1ba23d012bdbba26b4bcca45ac297"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d2984cb6caaf05294b8466966627e80bf6c7afd273279077679cb010acb0e5ab"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd7837b2b734ca72959a1caf3309457a318c934abef7a43a14bb984e574bbb9a"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1c59c046c31a43310ad0199d6299e59f57a289e22f0f36951ced1c9eac3665b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d58e8c51a7cf43090d124d5073bc29ab2755822181fcad978b12e144e5e5a4b3"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6081aed64714a18c72b168a9276095ef9155dd7888b9e74b5987808f0dd0a974"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "97e5d6a9f0702c2863aaabf19f0d1b6c2628fbe476438ce0b5ce06e83085064c"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b9d45d1dbb9de84894cc50efece5b09939752a2d75aab3a8b0cef6f3a35ecd6b"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3649d566e2fc067597125428db15d60eb42a4e0897fc48d28cb75dc2e0454e53"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1d1bd82d539607951cac963388534da3b7ea0e18b149a53cf883d8f699178c0f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "afd5ced4e5a96dac6725daeb5242a35494243f2239244fad10a90ce58b071d24"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a03fb25610ef560a6201ff06df4f8105292ba56e7cdd196ea350d123fc32e24e"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dcfaf015b79d1f9f9c9fd0731a907407dc3e45769262d657d754c3a028586124"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e509cbc488c735b43b5ffea175235cec24bbc57b227ef1acc691725beb230d1c"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "af22f3d8e228d84d1c0c44c1fbdeb80f97a15a0abe4f080960393a00db733b66"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9f42284ebf91bdf32fafac29d29d4c07e5e9d1af862ea73686581773ef9e73a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bb894accfd16b867d8643fc2ba6c8617c78ba2828051e9a69511644ce86ce83e"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e44ccb93f30c75dfc0c3aa3ce38f33486a75ec9abadabd4e59f114994a9c4617"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9696aa2e35cc41e398a6d42d147cf326f8f9d81befcb399bc1ed7ffea339b64e"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a5b411040beead47a228bde3b2241100454a6abde9df139ed087bd73fc0a4908"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e11668d6f756ca5ef534b5be8653d16c5352cbb210a5c2a79ff288e937010d5"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d1d2c6b7dd618c41e202c59c1413ef9b2c8e8a15f5039e344af64195459e3104"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "59227c981d43425ca5e5c01094d59eb14e8772ce6975d4b2fc1e106a833d5ae2"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "06934e1a22c54636a059215d6da99e23286424f316fddd979f5071093b648668"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "76ff661a867d9272cd2a99eed002470f46dbe0943a5ffd140f49be84f68ffc42"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6965888d65d2848e8768824ca8288db0a81263c1efccec881cb35a0d805fcd2f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-pp39-pypy39_pp73-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c8c6c72d4a9f831f328efb1312642a1cafafaa88981d9ab76368d50d07d93cbe"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1.tar.gz"
+        }
+      ],
+      "name": "numpy",
+      "purl": "pkg:pypi/numpy@1.26.1?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "1.26.1"
+    },
+    {
+      "bom-ref": "opt-einsum@3.3.0",
+      "description": "Optimizing numpys einsum function",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2455e59e3947d3c275477df7f5205b30635e266fe6dc300e3d9f9646bfcea147"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/opt-einsum/#opt_einsum-3.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "59f6475f77bbc37dcf7cd748519c0ec60722e91e63ca114e68821c0c54a46549"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/opt-einsum/#opt_einsum-3.3.0.tar.gz"
+        }
+      ],
+      "name": "opt-einsum",
+      "purl": "pkg:pypi/opt-einsum@3.3.0?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "3.3.0"
+    },
+    {
+      "bom-ref": "scipy@1.11.3",
+      "description": "Fundamental algorithms for scientific computing in Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "370f569c57e1d888304052c18e58f4a927338eafdaef78613c685ca2ea0d1fa0"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9885e3e4f13b2bd44aaf2a1a6390a11add9f48d5295f7a592393ceb8991577a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-macosx_12_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e04aa19acc324a1a076abb4035dabe9b64badb19f76ad9c798bde39d41025cdc"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e1a8a4657673bfae1e05e1e1d6e94b0cabe5ed0c7c144c8aa7b7dbb774ce5c1"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7abda0e62ef00cde826d441485e2e32fe737bdddee3324e35c0e01dee65e2a88"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "033c3fd95d55012dd1148b201b72ae854d5086d25e7c316ec9850de4fe776929"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "925c6f09d0053b1c0f90b2d92d03b261e889b20d1c9b08a3a51f61afc5f58165"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5664e364f90be8219283eeb844323ff8cd79d7acbd64e15eb9c46b9bc7f6a42a"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-macosx_12_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "00f325434b6424952fbb636506f0567898dca7b0f7654d48f1c382ea338ce9a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5f290cf561a4b4edfe8d1001ee4be6da60c1c4ea712985b58bf6bc62badee221"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "91770cb3b1e81ae19463b3c235bf1e0e330767dca9eb4cd73ba3ded6c4151e4d"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e1f97cd89c0fe1a0685f8f89d85fa305deb3067d0668151571ba50913e445820"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dfcc1552add7cb7c13fb70efcb2389d0624d571aaf2c80b04117e2755a0c5d15"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0d3a136ae1ff0883fffbb1b05b0b2fea251cb1046a5077d0b435a1839b3e52b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-macosx_12_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bae66a2d7d5768eaa33008fa5a974389f167183c87bf39160d3fefe6664f8ddc"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d2f6dee6cbb0e263b8142ed587bc93e3ed5e777f1f75448d24fb923d9fd4dce6"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "74e89dc5e00201e71dd94f5f382ab1c6a9f3ff806c7d24e4e90928bb1aafb280"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "90271dbde4be191522b3903fc97334e3956d7cfb9cce3f0718d0ab4fd7d8bfd6"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a63d1ec9cadecce838467ce0631c17c15c7197ae61e49429434ba01d618caa83"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5305792c7110e32ff155aed0df46aa60a60fc6e52cd4ee02cdeb67eaccd5356e"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-macosx_12_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9ea7f579182d83d00fed0e5c11a4aa5ffe01460444219dedc448a36adf0c3917"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c77da50c9a91e23beb63c2a711ef9e9ca9a2060442757dffee34ea41847d8156"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "15f237e890c24aef6891c7d008f9ff7e758c6ef39a2b5df264650eb7900403c0"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b4bb134c7aa457e26cc6ea482b016fef45db71417d55cc6d8f43d799cdf9ef2"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bba4d955f54edd61899776bad459bf7326e14b9fa1c552181f0479cc60a568cd"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3.tar.gz"
+        }
+      ],
+      "name": "scipy",
+      "purl": "pkg:pypi/scipy@1.11.3?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "1.11.3"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2?repository_url=http://pysrc2.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "zipp@3.17.0",
+      "description": "Backport of pathlib-compatible object wrapper for zip files",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/zipp/#zipp-3.17.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/zipp/#zipp-3.17.0.tar.gz"
+        }
+      ],
+      "name": "zipp",
+      "purl": "pkg:pypi/zipp@3.17.0?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "3.17.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "zipp@3.17.0"
+      ],
+      "ref": "importlib-metadata@6.8.0"
+    },
+    {
+      "dependsOn": [
+        "importlib-metadata@6.8.0",
+        "ml-dtypes@0.3.1",
+        "numpy@1.26.1",
+        "opt-einsum@3.3.0",
+        "scipy@1.11.3"
+      ],
+      "ref": "jax@0.4.20"
+    },
+    {
+      "dependsOn": [
+        "numpy@1.26.1"
+      ],
+      "ref": "ml-dtypes@0.3.1"
+    },
+    {
+      "ref": "numpy@1.26.1"
+    },
+    {
+      "dependsOn": [
+        "numpy@1.26.1"
+      ],
+      "ref": "opt-einsum@3.3.0"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6",
+        "jax@0.4.20",
+        "toml@0.10.2"
+      ],
+      "ref": "private-packges"
+    },
+    {
+      "dependsOn": [
+        "numpy@1.26.1"
+      ],
+      "ref": "scipy@1.11.3"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "zipp@3.17.0"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "private-packges",
+      "description": "packages from aternative package repositories",
+      "name": "private-packges",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/private-packges-lock20-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/private-packges-lock20-1.5.xml.bin
@@ -1,0 +1,765 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="private-packges">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>private-packges</name>
+      <version>0.1.0</version>
+      <description>packages from aternative package repositories</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="importlib-metadata@6.8.0">
+      <name>importlib-metadata</name>
+      <version>6.8.0</version>
+      <description>Read metadata from Python packages</description>
+      <purl>pkg:pypi/importlib-metadata@6.8.0?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/importlib-metadata/#importlib_metadata-6.8.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/importlib-metadata/#importlib_metadata-6.8.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="jax@0.4.20">
+      <name>jax</name>
+      <version>0.4.20</version>
+      <description>Differentiate, compile, and transform Numpy code.</description>
+      <purl>pkg:pypi/jax@0.4.20?repository_url=https://storage.googleapis.com/jax-releases/jax_releases.html</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://storage.googleapis.com/jax-releases/jax_releases.html/jax/#jax-0.4.20-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3d5952197adca548d99310f1c326bf00548f1cc8652b89edb369166482c2aec2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://storage.googleapis.com/jax-releases/jax_releases.html/jax/#jax-0.4.20.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ea96a763a8b1a9374639d1159ab4de163461d01cd022f67c34c09581b71ed2ac</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="ml-dtypes@0.3.1">
+      <name>ml-dtypes</name>
+      <version>0.3.1</version>
+      <description/>
+      <purl>pkg:pypi/ml-dtypes@0.3.1?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">510d249a91face47211762eb294d6fe64f325356b965fb6388c1bf51bd339267</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f83ff080df8910c0f987f615b03e4f8198638e0c00c6e679ea8892dda909763b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fcae2c69715410d96906e1dfe8f017d9f78a0d10e0df91aae52e91f51fdfe45e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">da274599e4950a9b488d21571061f49a185537cc77f2d3f8121151d58a9e9f16</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5e0b0b6bb07fa5ad11bb61d174667176bee5e05857225067aabfc5adc1b51d23</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5727effa7650f7ab10906542d137cfb3244fdc3b2b519beff42f82def8ba59be</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">42a8980afd8b7c8e270e8b5c260237286b5b26acd276fcb758d13cd7cb567e99</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cb0c404e0dd3e25b56362c1c1e5de0ef717f727dde59fa721af4ce6ab2acca44</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3d8ca0acbd377082792d8b97081ba580abdad67c6afb7f827012c675b052f058</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4828b62fa3bf1ae35faa40f3db9a38ec72fbce02f328a1d14c3a9da4606af364</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d1a8dc3bac1da2a17d0e2e4cba36ee89721d0bd33ea4765af2eefb5f41409e0f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a777928dcba8865ab4a8157eeb25d23aed7bc82e5fd74e1d5eca821d3f148b39</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">438437e2e614a3c91d75581653b6c40ec890e8b5994d7190a90c931740151c95</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">70984b473db6489ec1d8c79b082a1322105155193049d08a3b0c515094e9777b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d94b2d1bed77284694f7fd0479640fa7aa5d96433dca3cbcec407a5ef752e77</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">979d7d196d9a17e0135ae22878f74241fbd3522cef58d7b292f1fd5b32282201</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">60778f99194b4c4f36ba42da200b35ef851ce4d4af698aaf70f5b91fe70fc611</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="numpy@1.26.1">
+      <name>numpy</name>
+      <version>1.26.1</version>
+      <description>Fundamental package for array computing in Python</description>
+      <purl>pkg:pypi/numpy@1.26.1?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">82e871307a6331b5f09efda3c22e03c095d957f04bf6bc1804f30048d0e5e7af</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cdd9ec98f0063d93baeb01aad472a1a0840dee302842a2746a7a8e92968f9575</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d78f269e0c4fd365fc2992c00353e4530d274ba68f15e968d8bc3c69ce5f5244</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8ab9163ca8aeb7fd32fe93866490654d2f7dda4e61bc6297bf72ce07fdc02f67</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">78ca54b2f9daffa5f323f34cdf21e1d9779a54073f0018a3094ab907938331a2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d1cfc92db6af1fd37a7bb58e55c8383b4aa1ba23d012bdbba26b4bcca45ac297</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d2984cb6caaf05294b8466966627e80bf6c7afd273279077679cb010acb0e5ab</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd7837b2b734ca72959a1caf3309457a318c934abef7a43a14bb984e574bbb9a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1c59c046c31a43310ad0199d6299e59f57a289e22f0f36951ced1c9eac3665b9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d58e8c51a7cf43090d124d5073bc29ab2755822181fcad978b12e144e5e5a4b3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6081aed64714a18c72b168a9276095ef9155dd7888b9e74b5987808f0dd0a974</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">97e5d6a9f0702c2863aaabf19f0d1b6c2628fbe476438ce0b5ce06e83085064c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b9d45d1dbb9de84894cc50efece5b09939752a2d75aab3a8b0cef6f3a35ecd6b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3649d566e2fc067597125428db15d60eb42a4e0897fc48d28cb75dc2e0454e53</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1d1bd82d539607951cac963388534da3b7ea0e18b149a53cf883d8f699178c0f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">afd5ced4e5a96dac6725daeb5242a35494243f2239244fad10a90ce58b071d24</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a03fb25610ef560a6201ff06df4f8105292ba56e7cdd196ea350d123fc32e24e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dcfaf015b79d1f9f9c9fd0731a907407dc3e45769262d657d754c3a028586124</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e509cbc488c735b43b5ffea175235cec24bbc57b227ef1acc691725beb230d1c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">af22f3d8e228d84d1c0c44c1fbdeb80f97a15a0abe4f080960393a00db733b66</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9f42284ebf91bdf32fafac29d29d4c07e5e9d1af862ea73686581773ef9e73a7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bb894accfd16b867d8643fc2ba6c8617c78ba2828051e9a69511644ce86ce83e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e44ccb93f30c75dfc0c3aa3ce38f33486a75ec9abadabd4e59f114994a9c4617</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9696aa2e35cc41e398a6d42d147cf326f8f9d81befcb399bc1ed7ffea339b64e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a5b411040beead47a228bde3b2241100454a6abde9df139ed087bd73fc0a4908</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e11668d6f756ca5ef534b5be8653d16c5352cbb210a5c2a79ff288e937010d5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d1d2c6b7dd618c41e202c59c1413ef9b2c8e8a15f5039e344af64195459e3104</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">59227c981d43425ca5e5c01094d59eb14e8772ce6975d4b2fc1e106a833d5ae2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">06934e1a22c54636a059215d6da99e23286424f316fddd979f5071093b648668</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">76ff661a867d9272cd2a99eed002470f46dbe0943a5ffd140f49be84f68ffc42</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1-pp39-pypy39_pp73-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6965888d65d2848e8768824ca8288db0a81263c1efccec881cb35a0d805fcd2f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c8c6c72d4a9f831f328efb1312642a1cafafaa88981d9ab76368d50d07d93cbe</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="opt-einsum@3.3.0">
+      <name>opt-einsum</name>
+      <version>3.3.0</version>
+      <description>Optimizing numpys einsum function</description>
+      <purl>pkg:pypi/opt-einsum@3.3.0?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/opt-einsum/#opt_einsum-3.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2455e59e3947d3c275477df7f5205b30635e266fe6dc300e3d9f9646bfcea147</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/opt-einsum/#opt_einsum-3.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">59f6475f77bbc37dcf7cd748519c0ec60722e91e63ca114e68821c0c54a46549</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="scipy@1.11.3">
+      <name>scipy</name>
+      <version>1.11.3</version>
+      <description>Fundamental algorithms for scientific computing in Python</description>
+      <purl>pkg:pypi/scipy@1.11.3?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">370f569c57e1d888304052c18e58f4a927338eafdaef78613c685ca2ea0d1fa0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-macosx_12_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9885e3e4f13b2bd44aaf2a1a6390a11add9f48d5295f7a592393ceb8991577a3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e04aa19acc324a1a076abb4035dabe9b64badb19f76ad9c798bde39d41025cdc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3e1a8a4657673bfae1e05e1e1d6e94b0cabe5ed0c7c144c8aa7b7dbb774ce5c1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7abda0e62ef00cde826d441485e2e32fe737bdddee3324e35c0e01dee65e2a88</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">033c3fd95d55012dd1148b201b72ae854d5086d25e7c316ec9850de4fe776929</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">925c6f09d0053b1c0f90b2d92d03b261e889b20d1c9b08a3a51f61afc5f58165</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-macosx_12_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5664e364f90be8219283eeb844323ff8cd79d7acbd64e15eb9c46b9bc7f6a42a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">00f325434b6424952fbb636506f0567898dca7b0f7654d48f1c382ea338ce9a3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5f290cf561a4b4edfe8d1001ee4be6da60c1c4ea712985b58bf6bc62badee221</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">91770cb3b1e81ae19463b3c235bf1e0e330767dca9eb4cd73ba3ded6c4151e4d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e1f97cd89c0fe1a0685f8f89d85fa305deb3067d0668151571ba50913e445820</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dfcc1552add7cb7c13fb70efcb2389d0624d571aaf2c80b04117e2755a0c5d15</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-macosx_12_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0d3a136ae1ff0883fffbb1b05b0b2fea251cb1046a5077d0b435a1839b3e52b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bae66a2d7d5768eaa33008fa5a974389f167183c87bf39160d3fefe6664f8ddc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d2f6dee6cbb0e263b8142ed587bc93e3ed5e777f1f75448d24fb923d9fd4dce6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">74e89dc5e00201e71dd94f5f382ab1c6a9f3ff806c7d24e4e90928bb1aafb280</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">90271dbde4be191522b3903fc97334e3956d7cfb9cce3f0718d0ab4fd7d8bfd6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a63d1ec9cadecce838467ce0631c17c15c7197ae61e49429434ba01d618caa83</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-macosx_12_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5305792c7110e32ff155aed0df46aa60a60fc6e52cd4ee02cdeb67eaccd5356e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9ea7f579182d83d00fed0e5c11a4aa5ffe01460444219dedc448a36adf0c3917</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c77da50c9a91e23beb63c2a711ef9e9ca9a2060442757dffee34ea41847d8156</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">15f237e890c24aef6891c7d008f9ff7e758c6ef39a2b5df264650eb7900403c0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4b4bb134c7aa457e26cc6ea482b016fef45db71417d55cc6d8f43d799cdf9ef2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bba4d955f54edd61899776bad459bf7326e14b9fa1c552181f0479cc60a568cd</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2?repository_url=http://pysrc2.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="zipp@3.17.0">
+      <name>zipp</name>
+      <version>3.17.0</version>
+      <description>Backport of pathlib-compatible object wrapper for zip files</description>
+      <purl>pkg:pypi/zipp@3.17.0?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/zipp/#zipp-3.17.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/zipp/#zipp-3.17.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="importlib-metadata@6.8.0">
+      <dependency ref="zipp@3.17.0"/>
+    </dependency>
+    <dependency ref="jax@0.4.20">
+      <dependency ref="importlib-metadata@6.8.0"/>
+      <dependency ref="ml-dtypes@0.3.1"/>
+      <dependency ref="numpy@1.26.1"/>
+      <dependency ref="opt-einsum@3.3.0"/>
+      <dependency ref="scipy@1.11.3"/>
+    </dependency>
+    <dependency ref="ml-dtypes@0.3.1">
+      <dependency ref="numpy@1.26.1"/>
+    </dependency>
+    <dependency ref="numpy@1.26.1"/>
+    <dependency ref="opt-einsum@3.3.0">
+      <dependency ref="numpy@1.26.1"/>
+    </dependency>
+    <dependency ref="private-packges">
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="jax@0.4.20"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="scipy@1.11.3">
+      <dependency ref="numpy@1.26.1"/>
+    </dependency>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="zipp@3.17.0"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/regression-issue611-lock20-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/regression-issue611-lock20-1.5.json.bin
@@ -1,0 +1,75 @@
+{
+  "components": [
+    {
+      "bom-ref": "pyhumps@3.7.1",
+      "description": "\ud83d\udc2b  Convert strings (and dictionary keys) between snake case, camel case and pascal case in Python. Inspired by Humps for Node",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c6f2d833f2c7afae039d71b7dc0aba5412ae5b8c8c33d4a208c1d412de17229e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyhumps/#pyhumps-3.7.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5616f0afdbc73ef479fa9999f4abdcb336a0232707ff1a0b86e29fc9339e18da"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyhumps/#pyhumps-3.7.1.tar.gz"
+        }
+      ],
+      "name": "pyhumps",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pyhumps@3.7.1",
+      "type": "library",
+      "version": "3.7.1"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pyhumps@3.7.1"
+    },
+    {
+      "dependsOn": [
+        "pyhumps@3.7.1"
+      ],
+      "ref": "regression-issue611"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "regression-issue611",
+      "description": "regression for issue #611",
+      "name": "regression-issue611",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/regression-issue611-lock20-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/regression-issue611-lock20-1.5.xml.bin
@@ -1,0 +1,83 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="regression-issue611">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>regression-issue611</name>
+      <version>0.1.0</version>
+      <description>regression for issue #611</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="pyhumps@3.7.1">
+      <name>pyhumps</name>
+      <version>3.7.1</version>
+      <description>🐫  Convert strings (and dictionary keys) between snake case, camel case and pascal case in Python. Inspired by Humps for Node</description>
+      <purl>pkg:pypi/pyhumps@3.7.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyhumps/#pyhumps-3.7.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c6f2d833f2c7afae039d71b7dc0aba5412ae5b8c8c33d4a208c1d412de17229e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyhumps/#pyhumps-3.7.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5616f0afdbc73ef479fa9999f4abdcb336a0232707ff1a0b86e29fc9339e18da</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="pyhumps@3.7.1"/>
+    <dependency ref="regression-issue611">
+      <dependency ref="pyhumps@3.7.1"/>
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/some-extras-lock10-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/some-extras-lock10-1.5.json.bin
@@ -1,0 +1,186 @@
+{
+  "components": [
+    {
+      "bom-ref": "boolean.py@4.0",
+      "description": "Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.",
+      "name": "boolean.py",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/boolean.py@4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.0"
+    },
+    {
+      "bom-ref": "cyclonedx-python-lib@5.1.1",
+      "description": "Python library for CycloneDX",
+      "name": "cyclonedx-python-lib",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:extra",
+          "value": "json-validation"
+        },
+        {
+          "name": "cdx:python:package:extra",
+          "value": "xml-validation"
+        }
+      ],
+      "purl": "pkg:pypi/cyclonedx-python-lib@5.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "5.1.1"
+    },
+    {
+      "bom-ref": "defusedxml@0.7.1",
+      "description": "XML bomb protection for Python stdlib modules",
+      "name": "defusedxml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/defusedxml@0.7.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.7.1"
+    },
+    {
+      "bom-ref": "license-expression@30.1.1",
+      "description": "license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.",
+      "name": "license-expression",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/license-expression@30.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "30.1.1"
+    },
+    {
+      "bom-ref": "packageurl-python@0.11.2",
+      "description": "A purl aka. Package URL parser and builder",
+      "name": "packageurl-python",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/packageurl-python@0.11.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.11.2"
+    },
+    {
+      "bom-ref": "py-serializable@0.15.0",
+      "description": "Library for serializing and deserializing Python Objects to and from JSON and XML.",
+      "name": "py-serializable",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/py-serializable@0.15.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.15.0"
+    },
+    {
+      "bom-ref": "sortedcontainers@2.4.0",
+      "description": "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set",
+      "name": "sortedcontainers",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/sortedcontainers@2.4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.4.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "boolean.py@4.0"
+    },
+    {
+      "dependsOn": [
+        "license-expression@30.1.1",
+        "packageurl-python@0.11.2",
+        "py-serializable@0.15.0",
+        "sortedcontainers@2.4.0"
+      ],
+      "ref": "cyclonedx-python-lib@5.1.1"
+    },
+    {
+      "ref": "defusedxml@0.7.1"
+    },
+    {
+      "dependsOn": [
+        "boolean.py@4.0"
+      ],
+      "ref": "license-expression@30.1.1"
+    },
+    {
+      "ref": "packageurl-python@0.11.2"
+    },
+    {
+      "dependsOn": [
+        "defusedxml@0.7.1"
+      ],
+      "ref": "py-serializable@0.15.0"
+    },
+    {
+      "ref": "sortedcontainers@2.4.0"
+    },
+    {
+      "dependsOn": [
+        "cyclonedx-python-lib@5.1.1"
+      ],
+      "ref": "with-extras"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "with-extras",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "properties": [
+        {
+          "name": "cdx:python:package:extra",
+          "value": "my-extra"
+        }
+      ],
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/some-extras-lock10-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/some-extras-lock10-1.5.xml.bin
@@ -1,0 +1,148 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-extras">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+      <properties>
+        <property name="cdx:python:package:extra">my-extra</property>
+      </properties>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="boolean.py@4.0">
+      <name>boolean.py</name>
+      <version>4.0</version>
+      <description>Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/boolean.py@4.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="cyclonedx-python-lib@5.1.1">
+      <name>cyclonedx-python-lib</name>
+      <version>5.1.1</version>
+      <description>Python library for CycloneDX</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/cyclonedx-python-lib@5.1.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:extra">json-validation</property>
+        <property name="cdx:python:package:extra">xml-validation</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="defusedxml@0.7.1">
+      <name>defusedxml</name>
+      <version>0.7.1</version>
+      <description>XML bomb protection for Python stdlib modules</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/defusedxml@0.7.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="license-expression@30.1.1">
+      <name>license-expression</name>
+      <version>30.1.1</version>
+      <description>license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/license-expression@30.1.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="packageurl-python@0.11.2">
+      <name>packageurl-python</name>
+      <version>0.11.2</version>
+      <description>A purl aka. Package URL parser and builder</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/packageurl-python@0.11.2</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="py-serializable@0.15.0">
+      <name>py-serializable</name>
+      <version>0.15.0</version>
+      <description>Library for serializing and deserializing Python Objects to and from JSON and XML.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/py-serializable@0.15.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="sortedcontainers@2.4.0">
+      <name>sortedcontainers</name>
+      <version>2.4.0</version>
+      <description>Sorted Containers -- Sorted List, Sorted Dict, Sorted Set</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/sortedcontainers@2.4.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="boolean.py@4.0"/>
+    <dependency ref="cyclonedx-python-lib@5.1.1">
+      <dependency ref="license-expression@30.1.1"/>
+      <dependency ref="packageurl-python@0.11.2"/>
+      <dependency ref="py-serializable@0.15.0"/>
+      <dependency ref="sortedcontainers@2.4.0"/>
+    </dependency>
+    <dependency ref="defusedxml@0.7.1"/>
+    <dependency ref="license-expression@30.1.1">
+      <dependency ref="boolean.py@4.0"/>
+    </dependency>
+    <dependency ref="packageurl-python@0.11.2"/>
+    <dependency ref="py-serializable@0.15.0">
+      <dependency ref="defusedxml@0.7.1"/>
+    </dependency>
+    <dependency ref="sortedcontainers@2.4.0"/>
+    <dependency ref="with-extras">
+      <dependency ref="cyclonedx-python-lib@5.1.1"/>
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/some-extras-lock11-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/some-extras-lock11-1.5.json.bin
@@ -1,0 +1,2133 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "attrs@23.1.0",
+      "description": "Classes Without Boilerplate",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/#attrs-23.1.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/#attrs-23.1.0.tar.gz"
+        }
+      ],
+      "name": "attrs",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/attrs@23.1.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "23.1.0"
+    },
+    {
+      "bom-ref": "boolean.py@4.0",
+      "description": "Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.",
+      "name": "boolean.py",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/boolean.py@4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.0"
+    },
+    {
+      "bom-ref": "cyclonedx-python-lib@5.1.1",
+      "description": "Python library for CycloneDX",
+      "name": "cyclonedx-python-lib",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:extra",
+          "value": "json-validation"
+        },
+        {
+          "name": "cdx:python:package:extra",
+          "value": "xml-validation"
+        }
+      ],
+      "purl": "pkg:pypi/cyclonedx-python-lib@5.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "5.1.1"
+    },
+    {
+      "bom-ref": "defusedxml@0.7.1",
+      "description": "XML bomb protection for Python stdlib modules",
+      "name": "defusedxml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/defusedxml@0.7.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.7.1"
+    },
+    {
+      "bom-ref": "fqdn@1.5.1",
+      "description": "Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fqdn/#fqdn-1.5.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fqdn/#fqdn-1.5.1.tar.gz"
+        }
+      ],
+      "name": "fqdn",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/fqdn@1.5.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.5.1"
+    },
+    {
+      "bom-ref": "idna@3.4",
+      "description": "Internationalized Domain Names in Applications (IDNA)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/#idna-3.4-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/#idna-3.4.tar.gz"
+        }
+      ],
+      "name": "idna",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/idna@3.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "3.4"
+    },
+    {
+      "bom-ref": "importlib-resources@6.1.1",
+      "description": "Read resources from Python packages",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e8bf90d8213b486f428c9c39714b920041cb02c184686a3dee24905aaa8105d6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1.tar.gz"
+        }
+      ],
+      "name": "importlib-resources",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/importlib-resources@6.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "6.1.1"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "jsonpointer@2.4",
+      "description": "Identify specific nodes in a JSON document (RFC 6901)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonpointer/#jsonpointer-2.4-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonpointer/#jsonpointer-2.4.tar.gz"
+        }
+      ],
+      "name": "jsonpointer",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/jsonpointer@2.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.4"
+    },
+    {
+      "bom-ref": "jsonschema@4.19.2",
+      "description": "An implementation of JSON Schema validation for Python",
+      "name": "jsonschema",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:extra",
+          "value": "format"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema@4.19.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.19.2"
+    },
+    {
+      "bom-ref": "jsonschema-specifications@2023.7.1",
+      "description": "The JSON Schema meta-schemas and vocabularies, exposed as a Registry",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05adf340b659828a004220a9613be00fa3f223f2b82002e273dee62fd50524b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c91a50404e88a1f6ba40636778e2ee08f6e24c5613fe4c53ac24578a5a7f72bb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1.tar.gz"
+        }
+      ],
+      "name": "jsonschema-specifications",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema-specifications@2023.7.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "2023.7.1"
+    },
+    {
+      "bom-ref": "license-expression@30.1.1",
+      "description": "license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.",
+      "name": "license-expression",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/license-expression@30.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "30.1.1"
+    },
+    {
+      "bom-ref": "lxml@4.9.3",
+      "description": "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.",
+      "name": "lxml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/lxml@4.9.3",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.9.3"
+    },
+    {
+      "bom-ref": "packageurl-python@0.11.2",
+      "description": "A purl aka. Package URL parser and builder",
+      "name": "packageurl-python",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/packageurl-python@0.11.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.11.2"
+    },
+    {
+      "bom-ref": "pkgutil-resolve-name@1.3.10",
+      "description": "Resolve a name to an object.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10.tar.gz"
+        }
+      ],
+      "name": "pkgutil-resolve-name",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pkgutil-resolve-name@1.3.10",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.10"
+    },
+    {
+      "bom-ref": "py-serializable@0.15.0",
+      "description": "Library for serializing and deserializing Python Objects to and from JSON and XML.",
+      "name": "py-serializable",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/py-serializable@0.15.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.15.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "referencing@0.30.2",
+      "description": "JSON Referencing + Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "449b6669b6121a9e96a7f9e410b245d471e8d48964c67113ce9afe50c8dd7bdf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/#referencing-0.30.2-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "794ad8003c65938edcdbc027f1933215e0d0ccc0291e3ce20a4d87432b59efc0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/#referencing-0.30.2.tar.gz"
+        }
+      ],
+      "name": "referencing",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/referencing@0.30.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.30.2"
+    },
+    {
+      "bom-ref": "rfc3339-validator@0.1.4",
+      "description": "A pure python RFC3339 validator",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4.tar.gz"
+        }
+      ],
+      "name": "rfc3339-validator",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/rfc3339-validator@0.1.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.1.4"
+    },
+    {
+      "bom-ref": "rfc3987@1.3.8",
+      "description": "Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3987/#rfc3987-1.3.8-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3987/#rfc3987-1.3.8.tar.gz"
+        }
+      ],
+      "name": "rfc3987",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/rfc3987@1.3.8",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.8"
+    },
+    {
+      "bom-ref": "rpds-py@0.12.0",
+      "description": "Python bindings to Rust's persistent data structures (rpds)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c694bee70ece3b232df4678448fdda245fd3b1bb4ba481fb6cd20e13bb784c46"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "30e5ce9f501fb1f970e4a59098028cf20676dee64fc496d55c33e04bbbee097d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d72a4315514e5a0b9837a086cb433b004eea630afb0cc129de76d77654a9606f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eebaf8c76c39604d52852366249ab807fe6f7a3ffb0dd5484b9944917244cdbe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a239303acb0315091d54c7ff36712dba24554993b9a93941cf301391d8a997ee"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ced40cdbb6dd47a032725a038896cceae9ce267d340f59508b23537f05455431"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3c8c0226c71bd0ce9892eaf6afa77ae8f43a3d9313124a03df0b389c01f832de"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b8e11715178f3608874508f08e990d3771e0b8c66c73eb4e183038d600a9b274"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5210a0018c7e09c75fa788648617ebba861ae242944111d3079034e14498223f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "171d9a159f1b2f42a42a64a985e4ba46fc7268c78299272ceba970743a67ee50"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "57ec6baec231bb19bb5fd5fc7bae21231860a1605174b11585660236627e390e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7188ddc1a8887194f984fa4110d5a3d5b9b5cd35f6bafdff1b649049cbc0ce29"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e04581c6117ad9479b6cfae313e212fe0dfa226ac727755f0d539cd54792963"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0a38612d07a36138507d69646c470aedbfe2b75b43a4643f7bd8e51e52779624"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f12d69d568f5647ec503b64932874dade5a20255736c89936bf690951a5e79f5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f8a1d990dc198a6c68ec3d9a637ba1ce489b38cbfb65440a27901afbc5df575"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8c567c664fc2f44130a20edac73e0a867f8e012bf7370276f15c6adc3586c37c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e9e976e0dbed4f51c56db10831c9623d0fd67aac02853fe5476262e5a22acb7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efddca2d02254a52078c35cadad34762adbae3ff01c6b0c7787b59d038b63e0d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d9e7f29c00577aff6b318681e730a519b235af292732a149337f6aaa4d1c5e31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "389c0e38358fdc4e38e9995e7291269a3aead7acfcf8942010ee7bc5baee091c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "33ab498f9ac30598b6406e2be1b45fd231195b83d948ebd4bd77f337cb6a2bff"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d56b1cd606ba4cedd64bb43479d56580e147c6ef3f5d1c5e64203a1adab784a2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1fa73ed22c40a1bec98d7c93b5659cd35abcfa5a0a95ce876b91adbda170537c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dbc25baa6abb205766fb8606f8263b02c3503a55957fcb4576a6bb0a59d37d10"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c6b52b7028b547866c2413f614ee306c2d4eafdd444b1ff656bf3295bf1484aa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9620650c364c01ed5b497dcae7c3d4b948daeae6e1883ae185fef1c927b6b534"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2124f9e645a94ab7c853bc0a3644e0ca8ffbe5bb2d72db49aef8f9ec1c285733"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "281c8b219d4f4b3581b918b816764098d04964915b2f272d1476654143801aa2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27ccc93c7457ef890b0dd31564d2a05e1aca330623c942b7e818e9e7c2669ee4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d1c562a9bb72244fa767d1c1ab55ca1d92dd5f7c4d77878fee5483a22ffac808"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e57919c32ee295a2fca458bb73e4b20b05c115627f96f95a10f9f5acbd61172d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fa35ad36440aaf1ac8332b4a4a433d4acd28f1613f0d480995f5cfd3580e90b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e6aea5c0eb5b0faf52c7b5c4a47c8bb64437173be97227c819ffa31801fa4e34"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81cf9d306c04df1b45971c13167dc3bad625808aa01281d55f3cf852dde0e206"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08e6e7ff286254016b945e1ab632ee843e43d45e40683b66dd12b73791366dd1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d0a675a7acbbc16179188d8c6d0afb8628604fc1241faf41007255957335a0b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2287c09482949e0ca0c0eb68b2aca6cf57f8af8c6dfd29dcd3bc45f17b57978"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8015835494b21aa7abd3b43fdea0614ee35ef6b03db7ecba9beb58eadf01c24f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6174d6ad6b58a6bcf67afbbf1723420a53d06c4b89f4c50763d6fa0a6ac9afd2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a689e1ded7137552bea36305a7a16ad2b40be511740b80748d3140614993db98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f45321224144c25a62052035ce96cbcf264667bcb0d81823b1bbc22c4addd194"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aa32205358a76bf578854bf31698a86dc8b2cb591fd1d79a833283f4a403f04b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "91bd2b7cf0f4d252eec8b7046fa6a43cee17e8acdfc00eaa8b3dbf2f9a59d061"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3acadbab8b59f63b87b518e09c4c64b142e7286b9ca7a208107d6f9f4c393c5c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "429349a510da82c85431f0f3e66212d83efe9fd2850f50f339341b6532c62fe4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05942656cb2cb4989cd50ced52df16be94d344eae5097e8583966a1d27da73a5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0c5441b7626c29dbd54a3f6f3713ec8e956b009f419ffdaaa3c80eaf98ddb523"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b6b0e17d39d21698185097652c611f9cf30f7c56ccec189789920e3e7f1cee56"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3b7a64d43e2a1fa2dd46b678e00cabd9a49ebb123b339ce799204c44a593ae1c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e5bbe011a2cea9060fef1bb3d668a2fd8432b8888e6d92e74c9c794d3c101595"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bec29b801b4adbf388314c0d050e851d53762ab424af22657021ce4b6eb41543"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1096ca0bf2d3426cbe79d4ccc91dc5aaa73629b08ea2d8467375fad8447ce11a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48aa98987d54a46e13e6954880056c204700c65616af4395d1f0639eba11764b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7979d90ee2190d000129598c2b0c82f13053dba432b94e45e68253b09bb1f0f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "88857060b690a57d2ea8569bca58758143c8faa4639fb17d745ce60ff84c867e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4eb74d44776b0fb0782560ea84d986dffec8ddd94947f383eba2284b0f32e35e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f62581d7e884dd01ee1707b7c21148f61f2febb7de092ae2f108743fcbef5985"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6f5dcb658d597410bb7c967c1d24eaf9377b0d621358cbe9d2ff804e5dd12e81"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9bf9acce44e967a5103fcd820fc7580c7b0ab8583eec4e2051aec560f7b31a63"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "240687b5be0f91fbde4936a329c9b7589d9259742766f74de575e1b2046575e4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25740fb56e8bd37692ed380e15ec734be44d7c71974d8993f452b4527814601e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a54917b7e9cd3a67e429a630e237a90b096e0ba18897bfb99ee8bd1068a5fea0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b92aafcfab3d41580d54aca35a8057341f1cfc7c9af9e8bdfc652f83a20ced31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd316dbcc74c76266ba94eb021b0cc090b97cca122f50bd7a845f587ff4bf03f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0853da3d5e9bc6a07b2486054a410b7b03f34046c123c6561b535bb48cc509e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cb41ad20064e18a900dd427d7cf41cfaec83bcd1184001f3d91a1f76b3fcea4e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b710bf7e7ae61957d5c4026b486be593ed3ec3dca3e5be15e0f6d8cf5d0a4990"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a952ae3eb460c6712388ac2ec706d24b0e651b9396d90c9a9e0a69eb27737fdc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0bedd91ae1dd142a4dc15970ed2c729ff6c73f33a40fa84ed0cdbf55de87c777"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "761531076df51309075133a6bc1db02d98ec7f66e22b064b1d513bc909f29743"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a2baa6be130e8a00b6cbb9f18a33611ec150b4537f8563bddadb54c1b74b8193"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f05450fa1cd7c525c0b9d1a7916e595d3041ac0afbed2ff6926e5afb6a781b7f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81c4d1a3a564775c44732b94135d06e33417e829ff25226c164664f4a1046213"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e888be685fa42d8b8a3d3911d5604d14db87538aa7d0b29b1a7ea80d354c732d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6f8d7fe73d1816eeb5378409adc658f9525ecbfaf9e1ede1e2d67a338b0c7348"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0831d3ecdea22e4559cc1793f22e77067c9d8c451d55ae6a75bf1d116a8e7f42"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "513ccbf7420c30e283c25c82d5a8f439d625a838d3ba69e79a110c260c46813f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "301bd744a1adaa2f6a5e06c98f1ac2b6f8dc31a5c23b838f862d65e32fca0d4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f8832a4f83d4782a8f5a7b831c47e8ffe164e43c2c148c8160ed9a6d630bc02a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b2416ed743ec5debcf61e1242e012652a4348de14ecc7df3512da072b074440"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "35585a8cb5917161f42c2104567bb83a1d96194095fc54a543113ed5df9fa436"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d389ff1e95b6e46ebedccf7fd1fadd10559add595ac6a7c2ea730268325f832c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9b007c2444705a2dc4a525964fd4dd28c3320b19b3410da6517cab28716f27d3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "188912b22b6c8225f4c4ffa020a2baa6ad8fabb3c141a12dbe6edbb34e7f1425"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b4cf9ab9a0ae0cb122685209806d3f1dcb63b9fccdf1424fb42a129dc8c2faa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2d34a5450a402b00d20aeb7632489ffa2556ca7b26f4a63c35f6fccae1977427"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "466030a42724780794dea71eb32db83cc51214d66ab3fb3156edd88b9c8f0d78"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "68172622a5a57deb079a2c78511c40f91193548e8ab342c31e8cb0764d362459"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54cdfcda59251b9c2f87a05d038c2ae02121219a04d4a1e6fc345794295bdc07"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b75b912a0baa033350367a8a07a8b2d44fd5b90c890bfbd063a8a5f945f644b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "47aeceb4363851d17f63069318ba5721ae695d9da55d599b4d6fb31508595278"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0525847f83f506aa1e28eb2057b696fe38217e12931c8b1b02198cfe6975e142"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efbe0b5e0fd078ed7b005faa0170da4f72666360f66f0bb2d7f73526ecfd99f9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0fadfdda275c838cba5102c7f90a20f2abd7727bf8f4a2b654a5b617529c5c18"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "56dd500411d03c5e9927a1eb55621e906837a83b02350a9dc401247d0353717c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6915fc9fa6b3ec3569566832e1bb03bd801c12cea030200e68663b9a87974e76"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5f1519b080d8ce0a814f17ad9fb49fb3a1d4d7ce5891f5c85fc38631ca3a8dc4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7036316cc26b93e401cedd781a579be606dad174829e6ad9e9c5a0da6e036f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0.tar.gz"
+        }
+      ],
+      "name": "rpds-py",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/rpds-py@0.12.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.12.0"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "sortedcontainers@2.4.0",
+      "description": "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set",
+      "name": "sortedcontainers",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/sortedcontainers@2.4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.4.0"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.8.19.14"
+    },
+    {
+      "bom-ref": "uri-template@1.3.0",
+      "description": "RFC 6570 URI Template Processor",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uri-template/#uri-template-1.3.0.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uri-template/#uri_template-1.3.0-py3-none-any.whl"
+        }
+      ],
+      "name": "uri-template",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/uri-template@1.3.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "webcolors@1.13",
+      "description": "A library for working with the color formats defined by HTML and CSS.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/webcolors/#webcolors-1.13-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/webcolors/#webcolors-1.13.tar.gz"
+        }
+      ],
+      "name": "webcolors",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/webcolors@1.13",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.13"
+    },
+    {
+      "bom-ref": "zipp@3.17.0",
+      "description": "Backport of pathlib-compatible object wrapper for zip files",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/zipp/#zipp-3.17.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/zipp/#zipp-3.17.0.tar.gz"
+        }
+      ],
+      "name": "zipp",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/zipp@3.17.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "3.17.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "attrs@23.1.0"
+    },
+    {
+      "ref": "boolean.py@4.0"
+    },
+    {
+      "dependsOn": [
+        "jsonschema@4.19.2",
+        "license-expression@30.1.1",
+        "lxml@4.9.3",
+        "packageurl-python@0.11.2",
+        "py-serializable@0.15.0",
+        "sortedcontainers@2.4.0"
+      ],
+      "ref": "cyclonedx-python-lib@5.1.1"
+    },
+    {
+      "ref": "defusedxml@0.7.1"
+    },
+    {
+      "ref": "fqdn@1.5.1"
+    },
+    {
+      "ref": "idna@3.4"
+    },
+    {
+      "dependsOn": [
+        "zipp@3.17.0"
+      ],
+      "ref": "importlib-resources@6.1.1"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "ref": "jsonpointer@2.4"
+    },
+    {
+      "dependsOn": [
+        "importlib-resources@6.1.1",
+        "referencing@0.30.2"
+      ],
+      "ref": "jsonschema-specifications@2023.7.1"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.1.0",
+        "fqdn@1.5.1",
+        "idna@3.4",
+        "importlib-resources@6.1.1",
+        "isoduration@20.11.0",
+        "jsonpointer@2.4",
+        "jsonschema-specifications@2023.7.1",
+        "pkgutil-resolve-name@1.3.10",
+        "referencing@0.30.2",
+        "rfc3339-validator@0.1.4",
+        "rfc3987@1.3.8",
+        "rpds-py@0.12.0",
+        "uri-template@1.3.0",
+        "webcolors@1.13"
+      ],
+      "ref": "jsonschema@4.19.2"
+    },
+    {
+      "dependsOn": [
+        "boolean.py@4.0"
+      ],
+      "ref": "license-expression@30.1.1"
+    },
+    {
+      "ref": "lxml@4.9.3"
+    },
+    {
+      "ref": "packageurl-python@0.11.2"
+    },
+    {
+      "ref": "pkgutil-resolve-name@1.3.10"
+    },
+    {
+      "dependsOn": [
+        "defusedxml@0.7.1"
+      ],
+      "ref": "py-serializable@0.15.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.1.0",
+        "rpds-py@0.12.0"
+      ],
+      "ref": "referencing@0.30.2"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "rfc3339-validator@0.1.4"
+    },
+    {
+      "ref": "rfc3987@1.3.8"
+    },
+    {
+      "ref": "rpds-py@0.12.0"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "sortedcontainers@2.4.0"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    },
+    {
+      "ref": "uri-template@1.3.0"
+    },
+    {
+      "ref": "webcolors@1.13"
+    },
+    {
+      "dependsOn": [
+        "cyclonedx-python-lib@5.1.1"
+      ],
+      "ref": "with-extras"
+    },
+    {
+      "ref": "zipp@3.17.0"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "with-extras",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "properties": [
+        {
+          "name": "cdx:python:package:extra",
+          "value": "my-extra"
+        }
+      ],
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/some-extras-lock11-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/some-extras-lock11-1.5.xml.bin
@@ -1,0 +1,1397 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-extras">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+      <properties>
+        <property name="cdx:python:package:extra">my-extra</property>
+      </properties>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="attrs@23.1.0">
+      <name>attrs</name>
+      <version>23.1.0</version>
+      <description>Classes Without Boilerplate</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/attrs@23.1.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/#attrs-23.1.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/#attrs-23.1.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="boolean.py@4.0">
+      <name>boolean.py</name>
+      <version>4.0</version>
+      <description>Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/boolean.py@4.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="cyclonedx-python-lib@5.1.1">
+      <name>cyclonedx-python-lib</name>
+      <version>5.1.1</version>
+      <description>Python library for CycloneDX</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/cyclonedx-python-lib@5.1.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:extra">json-validation</property>
+        <property name="cdx:python:package:extra">xml-validation</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="defusedxml@0.7.1">
+      <name>defusedxml</name>
+      <version>0.7.1</version>
+      <description>XML bomb protection for Python stdlib modules</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/defusedxml@0.7.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="fqdn@1.5.1">
+      <name>fqdn</name>
+      <version>1.5.1</version>
+      <description>Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/fqdn@1.5.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fqdn/#fqdn-1.5.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fqdn/#fqdn-1.5.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="idna@3.4">
+      <name>idna</name>
+      <version>3.4</version>
+      <description>Internationalized Domain Names in Applications (IDNA)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/idna@3.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/#idna-3.4-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/#idna-3.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="importlib-resources@6.1.1">
+      <name>importlib-resources</name>
+      <version>6.1.1</version>
+      <description>Read resources from Python packages</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/importlib-resources@6.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e8bf90d8213b486f428c9c39714b920041cb02c184686a3dee24905aaa8105d6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonpointer@2.4">
+      <name>jsonpointer</name>
+      <version>2.4</version>
+      <description>Identify specific nodes in a JSON document (RFC 6901)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonpointer@2.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonpointer/#jsonpointer-2.4-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonpointer/#jsonpointer-2.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema@4.19.2">
+      <name>jsonschema</name>
+      <version>4.19.2</version>
+      <description>An implementation of JSON Schema validation for Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonschema@4.19.2</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:extra">format</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema-specifications@2023.7.1">
+      <name>jsonschema-specifications</name>
+      <version>2023.7.1</version>
+      <description>The JSON Schema meta-schemas and vocabularies, exposed as a Registry</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonschema-specifications@2023.7.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">05adf340b659828a004220a9613be00fa3f223f2b82002e273dee62fd50524b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c91a50404e88a1f6ba40636778e2ee08f6e24c5613fe4c53ac24578a5a7f72bb</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="license-expression@30.1.1">
+      <name>license-expression</name>
+      <version>30.1.1</version>
+      <description>license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/license-expression@30.1.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="lxml@4.9.3">
+      <name>lxml</name>
+      <version>4.9.3</version>
+      <description>Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/lxml@4.9.3</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="packageurl-python@0.11.2">
+      <name>packageurl-python</name>
+      <version>0.11.2</version>
+      <description>A purl aka. Package URL parser and builder</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/packageurl-python@0.11.2</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pkgutil-resolve-name@1.3.10">
+      <name>pkgutil-resolve-name</name>
+      <version>1.3.10</version>
+      <description>Resolve a name to an object.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/pkgutil-resolve-name@1.3.10</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="py-serializable@0.15.0">
+      <name>py-serializable</name>
+      <version>0.15.0</version>
+      <description>Library for serializing and deserializing Python Objects to and from JSON and XML.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/py-serializable@0.15.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="referencing@0.30.2">
+      <name>referencing</name>
+      <version>0.30.2</version>
+      <description>JSON Referencing + Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/referencing@0.30.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/#referencing-0.30.2-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">449b6669b6121a9e96a7f9e410b245d471e8d48964c67113ce9afe50c8dd7bdf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/#referencing-0.30.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">794ad8003c65938edcdbc027f1933215e0d0ccc0291e3ce20a4d87432b59efc0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rfc3339-validator@0.1.4">
+      <name>rfc3339-validator</name>
+      <version>0.1.4</version>
+      <description>A pure python RFC3339 validator</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rfc3339-validator@0.1.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rfc3987@1.3.8">
+      <name>rfc3987</name>
+      <version>1.3.8</version>
+      <description>Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rfc3987@1.3.8</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3987/#rfc3987-1.3.8-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3987/#rfc3987-1.3.8.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rpds-py@0.12.0">
+      <name>rpds-py</name>
+      <version>0.12.0</version>
+      <description>Python bindings to Rust's persistent data structures (rpds)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rpds-py@0.12.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c694bee70ece3b232df4678448fdda245fd3b1bb4ba481fb6cd20e13bb784c46</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">30e5ce9f501fb1f970e4a59098028cf20676dee64fc496d55c33e04bbbee097d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d72a4315514e5a0b9837a086cb433b004eea630afb0cc129de76d77654a9606f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eebaf8c76c39604d52852366249ab807fe6f7a3ffb0dd5484b9944917244cdbe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a239303acb0315091d54c7ff36712dba24554993b9a93941cf301391d8a997ee</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ced40cdbb6dd47a032725a038896cceae9ce267d340f59508b23537f05455431</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3c8c0226c71bd0ce9892eaf6afa77ae8f43a3d9313124a03df0b389c01f832de</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b8e11715178f3608874508f08e990d3771e0b8c66c73eb4e183038d600a9b274</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5210a0018c7e09c75fa788648617ebba861ae242944111d3079034e14498223f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">171d9a159f1b2f42a42a64a985e4ba46fc7268c78299272ceba970743a67ee50</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">57ec6baec231bb19bb5fd5fc7bae21231860a1605174b11585660236627e390e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7188ddc1a8887194f984fa4110d5a3d5b9b5cd35f6bafdff1b649049cbc0ce29</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e04581c6117ad9479b6cfae313e212fe0dfa226ac727755f0d539cd54792963</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0a38612d07a36138507d69646c470aedbfe2b75b43a4643f7bd8e51e52779624</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f12d69d568f5647ec503b64932874dade5a20255736c89936bf690951a5e79f5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f8a1d990dc198a6c68ec3d9a637ba1ce489b38cbfb65440a27901afbc5df575</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8c567c664fc2f44130a20edac73e0a867f8e012bf7370276f15c6adc3586c37c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e9e976e0dbed4f51c56db10831c9623d0fd67aac02853fe5476262e5a22acb7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efddca2d02254a52078c35cadad34762adbae3ff01c6b0c7787b59d038b63e0d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d9e7f29c00577aff6b318681e730a519b235af292732a149337f6aaa4d1c5e31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">389c0e38358fdc4e38e9995e7291269a3aead7acfcf8942010ee7bc5baee091c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">33ab498f9ac30598b6406e2be1b45fd231195b83d948ebd4bd77f337cb6a2bff</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d56b1cd606ba4cedd64bb43479d56580e147c6ef3f5d1c5e64203a1adab784a2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1fa73ed22c40a1bec98d7c93b5659cd35abcfa5a0a95ce876b91adbda170537c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dbc25baa6abb205766fb8606f8263b02c3503a55957fcb4576a6bb0a59d37d10</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c6b52b7028b547866c2413f614ee306c2d4eafdd444b1ff656bf3295bf1484aa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9620650c364c01ed5b497dcae7c3d4b948daeae6e1883ae185fef1c927b6b534</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2124f9e645a94ab7c853bc0a3644e0ca8ffbe5bb2d72db49aef8f9ec1c285733</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">281c8b219d4f4b3581b918b816764098d04964915b2f272d1476654143801aa2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">27ccc93c7457ef890b0dd31564d2a05e1aca330623c942b7e818e9e7c2669ee4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d1c562a9bb72244fa767d1c1ab55ca1d92dd5f7c4d77878fee5483a22ffac808</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e57919c32ee295a2fca458bb73e4b20b05c115627f96f95a10f9f5acbd61172d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fa35ad36440aaf1ac8332b4a4a433d4acd28f1613f0d480995f5cfd3580e90b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e6aea5c0eb5b0faf52c7b5c4a47c8bb64437173be97227c819ffa31801fa4e34</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">81cf9d306c04df1b45971c13167dc3bad625808aa01281d55f3cf852dde0e206</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08e6e7ff286254016b945e1ab632ee843e43d45e40683b66dd12b73791366dd1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d0a675a7acbbc16179188d8c6d0afb8628604fc1241faf41007255957335a0b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2287c09482949e0ca0c0eb68b2aca6cf57f8af8c6dfd29dcd3bc45f17b57978</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8015835494b21aa7abd3b43fdea0614ee35ef6b03db7ecba9beb58eadf01c24f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6174d6ad6b58a6bcf67afbbf1723420a53d06c4b89f4c50763d6fa0a6ac9afd2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a689e1ded7137552bea36305a7a16ad2b40be511740b80748d3140614993db98</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f45321224144c25a62052035ce96cbcf264667bcb0d81823b1bbc22c4addd194</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aa32205358a76bf578854bf31698a86dc8b2cb591fd1d79a833283f4a403f04b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">91bd2b7cf0f4d252eec8b7046fa6a43cee17e8acdfc00eaa8b3dbf2f9a59d061</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3acadbab8b59f63b87b518e09c4c64b142e7286b9ca7a208107d6f9f4c393c5c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">429349a510da82c85431f0f3e66212d83efe9fd2850f50f339341b6532c62fe4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">05942656cb2cb4989cd50ced52df16be94d344eae5097e8583966a1d27da73a5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0c5441b7626c29dbd54a3f6f3713ec8e956b009f419ffdaaa3c80eaf98ddb523</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b6b0e17d39d21698185097652c611f9cf30f7c56ccec189789920e3e7f1cee56</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3b7a64d43e2a1fa2dd46b678e00cabd9a49ebb123b339ce799204c44a593ae1c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e5bbe011a2cea9060fef1bb3d668a2fd8432b8888e6d92e74c9c794d3c101595</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bec29b801b4adbf388314c0d050e851d53762ab424af22657021ce4b6eb41543</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1096ca0bf2d3426cbe79d4ccc91dc5aaa73629b08ea2d8467375fad8447ce11a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48aa98987d54a46e13e6954880056c204700c65616af4395d1f0639eba11764b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7979d90ee2190d000129598c2b0c82f13053dba432b94e45e68253b09bb1f0f6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">88857060b690a57d2ea8569bca58758143c8faa4639fb17d745ce60ff84c867e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4eb74d44776b0fb0782560ea84d986dffec8ddd94947f383eba2284b0f32e35e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f62581d7e884dd01ee1707b7c21148f61f2febb7de092ae2f108743fcbef5985</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6f5dcb658d597410bb7c967c1d24eaf9377b0d621358cbe9d2ff804e5dd12e81</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9bf9acce44e967a5103fcd820fc7580c7b0ab8583eec4e2051aec560f7b31a63</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">240687b5be0f91fbde4936a329c9b7589d9259742766f74de575e1b2046575e4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">25740fb56e8bd37692ed380e15ec734be44d7c71974d8993f452b4527814601e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a54917b7e9cd3a67e429a630e237a90b096e0ba18897bfb99ee8bd1068a5fea0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b92aafcfab3d41580d54aca35a8057341f1cfc7c9af9e8bdfc652f83a20ced31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd316dbcc74c76266ba94eb021b0cc090b97cca122f50bd7a845f587ff4bf03f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0853da3d5e9bc6a07b2486054a410b7b03f34046c123c6561b535bb48cc509e1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cb41ad20064e18a900dd427d7cf41cfaec83bcd1184001f3d91a1f76b3fcea4e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b710bf7e7ae61957d5c4026b486be593ed3ec3dca3e5be15e0f6d8cf5d0a4990</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a952ae3eb460c6712388ac2ec706d24b0e651b9396d90c9a9e0a69eb27737fdc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0bedd91ae1dd142a4dc15970ed2c729ff6c73f33a40fa84ed0cdbf55de87c777</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">761531076df51309075133a6bc1db02d98ec7f66e22b064b1d513bc909f29743</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a2baa6be130e8a00b6cbb9f18a33611ec150b4537f8563bddadb54c1b74b8193</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f05450fa1cd7c525c0b9d1a7916e595d3041ac0afbed2ff6926e5afb6a781b7f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">81c4d1a3a564775c44732b94135d06e33417e829ff25226c164664f4a1046213</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e888be685fa42d8b8a3d3911d5604d14db87538aa7d0b29b1a7ea80d354c732d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6f8d7fe73d1816eeb5378409adc658f9525ecbfaf9e1ede1e2d67a338b0c7348</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0831d3ecdea22e4559cc1793f22e77067c9d8c451d55ae6a75bf1d116a8e7f42</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">513ccbf7420c30e283c25c82d5a8f439d625a838d3ba69e79a110c260c46813f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">301bd744a1adaa2f6a5e06c98f1ac2b6f8dc31a5c23b838f862d65e32fca0d4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f8832a4f83d4782a8f5a7b831c47e8ffe164e43c2c148c8160ed9a6d630bc02a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4b2416ed743ec5debcf61e1242e012652a4348de14ecc7df3512da072b074440</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">35585a8cb5917161f42c2104567bb83a1d96194095fc54a543113ed5df9fa436</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d389ff1e95b6e46ebedccf7fd1fadd10559add595ac6a7c2ea730268325f832c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9b007c2444705a2dc4a525964fd4dd28c3320b19b3410da6517cab28716f27d3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">188912b22b6c8225f4c4ffa020a2baa6ad8fabb3c141a12dbe6edbb34e7f1425</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1b4cf9ab9a0ae0cb122685209806d3f1dcb63b9fccdf1424fb42a129dc8c2faa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2d34a5450a402b00d20aeb7632489ffa2556ca7b26f4a63c35f6fccae1977427</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">466030a42724780794dea71eb32db83cc51214d66ab3fb3156edd88b9c8f0d78</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">68172622a5a57deb079a2c78511c40f91193548e8ab342c31e8cb0764d362459</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">54cdfcda59251b9c2f87a05d038c2ae02121219a04d4a1e6fc345794295bdc07</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b75b912a0baa033350367a8a07a8b2d44fd5b90c890bfbd063a8a5f945f644b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">47aeceb4363851d17f63069318ba5721ae695d9da55d599b4d6fb31508595278</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0525847f83f506aa1e28eb2057b696fe38217e12931c8b1b02198cfe6975e142</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efbe0b5e0fd078ed7b005faa0170da4f72666360f66f0bb2d7f73526ecfd99f9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0fadfdda275c838cba5102c7f90a20f2abd7727bf8f4a2b654a5b617529c5c18</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">56dd500411d03c5e9927a1eb55621e906837a83b02350a9dc401247d0353717c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6915fc9fa6b3ec3569566832e1bb03bd801c12cea030200e68663b9a87974e76</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5f1519b080d8ce0a814f17ad9fb49fb3a1d4d7ce5891f5c85fc38631ca3a8dc4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7036316cc26b93e401cedd781a579be606dad174829e6ad9e9c5a0da6e036f80</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="sortedcontainers@2.4.0">
+      <name>sortedcontainers</name>
+      <version>2.4.0</version>
+      <description>Sorted Containers -- Sorted List, Sorted Dict, Sorted Set</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/sortedcontainers@2.4.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="uri-template@1.3.0">
+      <name>uri-template</name>
+      <version>1.3.0</version>
+      <description>RFC 6570 URI Template Processor</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/uri-template@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uri-template/#uri-template-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uri-template/#uri_template-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="webcolors@1.13">
+      <name>webcolors</name>
+      <version>1.13</version>
+      <description>A library for working with the color formats defined by HTML and CSS.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/webcolors@1.13</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/webcolors/#webcolors-1.13-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/webcolors/#webcolors-1.13.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="zipp@3.17.0">
+      <name>zipp</name>
+      <version>3.17.0</version>
+      <description>Backport of pathlib-compatible object wrapper for zip files</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/zipp@3.17.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/zipp/#zipp-3.17.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/zipp/#zipp-3.17.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="attrs@23.1.0"/>
+    <dependency ref="boolean.py@4.0"/>
+    <dependency ref="cyclonedx-python-lib@5.1.1">
+      <dependency ref="jsonschema@4.19.2"/>
+      <dependency ref="license-expression@30.1.1"/>
+      <dependency ref="lxml@4.9.3"/>
+      <dependency ref="packageurl-python@0.11.2"/>
+      <dependency ref="py-serializable@0.15.0"/>
+      <dependency ref="sortedcontainers@2.4.0"/>
+    </dependency>
+    <dependency ref="defusedxml@0.7.1"/>
+    <dependency ref="fqdn@1.5.1"/>
+    <dependency ref="idna@3.4"/>
+    <dependency ref="importlib-resources@6.1.1">
+      <dependency ref="zipp@3.17.0"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="jsonpointer@2.4"/>
+    <dependency ref="jsonschema-specifications@2023.7.1">
+      <dependency ref="importlib-resources@6.1.1"/>
+      <dependency ref="referencing@0.30.2"/>
+    </dependency>
+    <dependency ref="jsonschema@4.19.2">
+      <dependency ref="attrs@23.1.0"/>
+      <dependency ref="fqdn@1.5.1"/>
+      <dependency ref="idna@3.4"/>
+      <dependency ref="importlib-resources@6.1.1"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="jsonpointer@2.4"/>
+      <dependency ref="jsonschema-specifications@2023.7.1"/>
+      <dependency ref="pkgutil-resolve-name@1.3.10"/>
+      <dependency ref="referencing@0.30.2"/>
+      <dependency ref="rfc3339-validator@0.1.4"/>
+      <dependency ref="rfc3987@1.3.8"/>
+      <dependency ref="rpds-py@0.12.0"/>
+      <dependency ref="uri-template@1.3.0"/>
+      <dependency ref="webcolors@1.13"/>
+    </dependency>
+    <dependency ref="license-expression@30.1.1">
+      <dependency ref="boolean.py@4.0"/>
+    </dependency>
+    <dependency ref="lxml@4.9.3"/>
+    <dependency ref="packageurl-python@0.11.2"/>
+    <dependency ref="pkgutil-resolve-name@1.3.10"/>
+    <dependency ref="py-serializable@0.15.0">
+      <dependency ref="defusedxml@0.7.1"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="referencing@0.30.2">
+      <dependency ref="attrs@23.1.0"/>
+      <dependency ref="rpds-py@0.12.0"/>
+    </dependency>
+    <dependency ref="rfc3339-validator@0.1.4">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="rfc3987@1.3.8"/>
+    <dependency ref="rpds-py@0.12.0"/>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="sortedcontainers@2.4.0"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+    <dependency ref="uri-template@1.3.0"/>
+    <dependency ref="webcolors@1.13"/>
+    <dependency ref="with-extras">
+      <dependency ref="cyclonedx-python-lib@5.1.1"/>
+    </dependency>
+    <dependency ref="zipp@3.17.0"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/some-extras-lock20-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/some-extras-lock20-1.5.json.bin
@@ -1,0 +1,3179 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "attrs@23.1.0",
+      "description": "Classes Without Boilerplate",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/#attrs-23.1.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/#attrs-23.1.0.tar.gz"
+        }
+      ],
+      "name": "attrs",
+      "purl": "pkg:pypi/attrs@23.1.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "23.1.0"
+    },
+    {
+      "bom-ref": "boolean-py@4.0",
+      "description": "Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2876f2051d7d6394a531d82dc6eb407faa0b01a0a0b3083817ccd7323b8d96bd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/boolean-py/#boolean.py-4.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "17b9a181630e43dde1851d42bef546d616d5d9b4480357514597e78b203d06e4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/boolean-py/#boolean.py-4.0.tar.gz"
+        }
+      ],
+      "name": "boolean-py",
+      "purl": "pkg:pypi/boolean-py@4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.0"
+    },
+    {
+      "bom-ref": "cyclonedx-python-lib@5.1.1",
+      "description": "Python library for CycloneDX",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2989db0cd8bb4c0c442423d71ed7a84ae059e16a2d0f932cc4bf92da7385cdb3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/cyclonedx-python-lib/#cyclonedx_python_lib-5.1.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "215a636a4e77385d2cf4c6c9801c9bad4791849634f2c6daa45ab2c6cb0a85f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/cyclonedx-python-lib/#cyclonedx_python_lib-5.1.1.tar.gz"
+        }
+      ],
+      "name": "cyclonedx-python-lib",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:extra",
+          "value": "json-validation"
+        },
+        {
+          "name": "cdx:python:package:extra",
+          "value": "xml-validation"
+        }
+      ],
+      "purl": "pkg:pypi/cyclonedx-python-lib@5.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "5.1.1"
+    },
+    {
+      "bom-ref": "defusedxml@0.7.1",
+      "description": "XML bomb protection for Python stdlib modules",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/defusedxml/#defusedxml-0.7.1-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/defusedxml/#defusedxml-0.7.1.tar.gz"
+        }
+      ],
+      "name": "defusedxml",
+      "purl": "pkg:pypi/defusedxml@0.7.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.7.1"
+    },
+    {
+      "bom-ref": "fqdn@1.5.1",
+      "description": "Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fqdn/#fqdn-1.5.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fqdn/#fqdn-1.5.1.tar.gz"
+        }
+      ],
+      "name": "fqdn",
+      "purl": "pkg:pypi/fqdn@1.5.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.5.1"
+    },
+    {
+      "bom-ref": "idna@3.4",
+      "description": "Internationalized Domain Names in Applications (IDNA)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/#idna-3.4-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/#idna-3.4.tar.gz"
+        }
+      ],
+      "name": "idna",
+      "purl": "pkg:pypi/idna@3.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "3.4"
+    },
+    {
+      "bom-ref": "importlib-resources@6.1.1",
+      "description": "Read resources from Python packages",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e8bf90d8213b486f428c9c39714b920041cb02c184686a3dee24905aaa8105d6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1.tar.gz"
+        }
+      ],
+      "name": "importlib-resources",
+      "purl": "pkg:pypi/importlib-resources@6.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "6.1.1"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "jsonpointer@2.4",
+      "description": "Identify specific nodes in a JSON document (RFC 6901)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonpointer/#jsonpointer-2.4-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonpointer/#jsonpointer-2.4.tar.gz"
+        }
+      ],
+      "name": "jsonpointer",
+      "purl": "pkg:pypi/jsonpointer@2.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.4"
+    },
+    {
+      "bom-ref": "jsonschema@4.19.2",
+      "description": "An implementation of JSON Schema validation for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eee9e502c788e89cb166d4d37f43084e3b64ab405c795c03d343a4dbc2c810fc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema/#jsonschema-4.19.2-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c9ff4d7447eed9592c23a12ccee508baf0dd0d59650615e847feb6cdca74f392"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema/#jsonschema-4.19.2.tar.gz"
+        }
+      ],
+      "name": "jsonschema",
+      "properties": [
+        {
+          "name": "cdx:python:package:extra",
+          "value": "format"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema@4.19.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.19.2"
+    },
+    {
+      "bom-ref": "jsonschema-specifications@2023.7.1",
+      "description": "The JSON Schema meta-schemas and vocabularies, exposed as a Registry",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05adf340b659828a004220a9613be00fa3f223f2b82002e273dee62fd50524b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c91a50404e88a1f6ba40636778e2ee08f6e24c5613fe4c53ac24578a5a7f72bb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1.tar.gz"
+        }
+      ],
+      "name": "jsonschema-specifications",
+      "purl": "pkg:pypi/jsonschema-specifications@2023.7.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "2023.7.1"
+    },
+    {
+      "bom-ref": "license-expression@30.1.1",
+      "description": "license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "42375df653ad85e6f5b4b0385138b2dbea1f5d66360783d8625c3e4f97f11f0c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/license-expression/#license-expression-30.1.1.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d7e5e2de0d04fc104a4f952c440e8f08a5ba63480a0dad015b294770b7e58ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/license-expression/#license_expression-30.1.1-py3-none-any.whl"
+        }
+      ],
+      "name": "license-expression",
+      "purl": "pkg:pypi/license-expression@30.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "30.1.1"
+    },
+    {
+      "bom-ref": "lxml@4.9.3",
+      "description": "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b0a545b46b526d418eb91754565ba5b63b1c0b12f9bd2f808c852d9b4b2f9b5c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "075b731ddd9e7f68ad24c635374211376aa05a281673ede86cbe1d1b3455279d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e224d5755dba2f4a9498e150c43792392ac9b5380aa1b845f98a1618c94eeef"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2c74524e179f2ad6d2a4f7caf70e2d96639c0954c943ad601a9e146c76408ed7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1026bc732b6a7f96369f7bfe1a4f2290fb34dce00d8644bc3036fb351a4ca1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c0781a98ff5e6586926293e59480b64ddd46282953203c76ae15dbbbf302e8bb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cef2502e7e8a96fe5ad686d60b49e1ab03e438bd9123987994528febd569868e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b86164d2cff4d3aaa1f04a14685cbc072efd0b4f99ca5708b2ad1b9b5988a991"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "42871176e7896d5d45138f6d28751053c711ed4d48d8e30b498da155af39aebd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ae8b9c6deb1e634ba4f1930eb67ef6e6bf6a44b6eb5ad605642b2d6d5ed9ce3c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "411007c0d88188d9f621b11d252cce90c4a2d1a49db6c068e3c16422f306eab8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd47b4a0d41d2afa3e58e5bf1f62069255aa2fd6ff5ee41604418ca925911d76"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e2cb47860da1f7e9a5256254b74ae331687b9672dfa780eed355c4c9c3dbd23"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1247694b26342a7bf47c02e513d32225ededd18045264d40758abeb3c838a51f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cdb650fc86227eba20de1a29d4b2c1bfe139dc75a0669270033cb2ea3d391b85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "97047f0d25cd4bcae81f9ec9dc290ca3e15927c192df17331b53bebe0e3ff96d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f447ea5429b54f9582d4b955f5f1985f278ce5cf169f72eea8afd9502973dd5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-macosx_11_0_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "57d6ba0ca2b0c462f339640d22882acc711de224d769edf29962b09f77129cbf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9767e79108424fb6c3edf8f81e6730666a50feb01a328f4a016464a5893f835a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "71c52db65e4b56b8ddc5bb89fb2e66c558ed9d1a74a45ceb7dcb20c191c3df2f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d73d8ecf8ecf10a3bd007f2192725a34bd62898e8da27eb9d32a58084f93962b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0a3d3487f07c1d7f150894c238299934a2a074ef590b583103a45002035be120"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9e28c51fa0ce5674be9f560c6761c1b441631901993f76700b1b30ca6c8378d6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0bfd0767c5c1de2551a120673b72e5d4b628737cb05414f03c3277bf9bed3305"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25f32acefac14ef7bd53e4218fe93b804ef6f6b92ffdb4322bb6d49d94cad2bc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d3ff32724f98fbbbfa9f49d82852b159e9784d6094983d9a8b7f2ddaebb063d4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-macosx_11_0_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48d6ed886b343d11493129e019da91d4039826794a3e3027321c56d9e71505be"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9a92d3faef50658dd2c5470af249985782bf754c4e18e15afb67d3ab06233f13"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b4e4bc18382088514ebde9328da057775055940a1f2e18f6ad2d78aa0f3ec5b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fc9b106a1bf918db68619fdcd6d5ad4f972fdd19c01d19bdb6bf63f3589a9ec5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d37017287a7adb6ab77e1c5bee9bcf9660f90ff445042b790402a654d2ad81d8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "56dc1f1ebccc656d1b3ed288f11e27172a01503fc016bcabdcbc0978b19352b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "578695735c5a3f51569810dfebd05dd6f888147a34f0f98d4bb27e92b76e05c2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "704f61ba8c1283c71b16135caf697557f5ecf3e74d9e453233e4771d68a1f42d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c41bfca0bd3532d53d16fd34d20806d5c2b1ace22a2f2e4c0008570bf2c58833"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "64f479d719dc9f4c813ad9bb6b28f8390360660b73b2e4beb4cb0ae7104f1c12"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dd708cf4ee4408cf46a48b108fb9427bfa00b9b85812a9262b5c668af2533ea5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c31c7462abdf8f2ac0577d9f05279727e698f97ecbb02f17939ea99ae8daa98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e3cd95e10c2610c360154afdc2f1480aea394f4a4f1ea0a5eacce49640c9b190"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4930be26af26ac545c3dffb662521d4e6268352866956672231887d18f0eaab2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4aec80cde9197340bc353d2768e2a75f5f60bacda2bab72ab1dc499589b3878c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "14e019fd83b831b2e61baed40cab76222139926b1fb5ed0e79225bc0cae14584"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0c0850c8b02c298d3c7006b23e98249515ac57430e16a166873fc47a5d549287"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aca086dc5f9ef98c512bac8efea4483eb84abbf926eaeedf7b91479feb092458"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "50baa9c1c47efcaef189f31e3d00d697c6d4afda5c3cde0302d063492ff9b477"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bef4e656f7d98aaa3486d2627e7d2df1157d7e88e7efd43a65aa5dd4714916cf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "46f409a2d60f634fe550f7133ed30ad5321ae2e6630f13657fb9479506b00601"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4c28a9144688aef80d6ea666c809b4b0e50010a2aca784c97f5e6bf143d9f129"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "141f1d1a9b663c679dc524af3ea1773e618907e96075262726c7612c02b149a4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "53ace1c1fd5a74ef662f844a0413446c0629d151055340e9893da958a374f70d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "17a753023436a18e27dd7769e798ce302963c236bc4114ceee5b25c18c52c693"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7d298a1bd60c067ea75d9f684f5f3992c9d6766fadbc0bcedd39750bf344c2f4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "081d32421db5df44c41b7f08a334a090a545c54ba977e47fd7cc2deece78809a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "23eed6d7b1a3336ad92d8e39d4bfe09073c31bfe502f20ca5116b2a334f8ec02"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1509dd12b773c02acd154582088820893109f6ca27ef7291b003d0e81666109f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "120fa9349a24c7043854c53cae8cec227e1f79195a7493e09e0c12e29f918e52"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d2d1edbca80b510443f51afd8496be95529db04a509bc8faee49c7b0fb6d2cc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d7e43bd40f65f7d97ad8ef5c9b1778943d02f04febef12def25f7583d19baac"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "71d66ee82e7417828af6ecd7db817913cb0cf9d4e61aa0ac1fde0583d84358db"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6fc3c450eaa0b56f815c7b62f2b7fba7266c4779adcf1cece9e6deb1de7305ce"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "65299ea57d82fb91c7f019300d24050c4ddeb7c5a190e076b5f48a2b43d19c42"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eadfbbbfb41b44034a4c757fd5d70baccd43296fb894dba0295606a7cf3124aa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e9bdd30efde2b9ccfa9cb5768ba04fe71b018a25ea093379c857c9dad262c40"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fcdd00edfd0a3001e0181eab3e63bd5c74ad3e67152c84f93f13769a40e073a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "57aba1bbdf450b726d58b2aea5fe47c7875f5afb2c4a23784ed78f19a0462574"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "92af161ecbdb2883c4593d5ed4815ea71b31fafd7fd05789b23100d081ecac96"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9bb6ad405121241e99a86efff22d3ef469024ce22875a7ae045896ad23ba2340"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8ed74706b26ad100433da4b9d807eae371efaa266ffc3e9191ea436087a9d6a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fbf521479bcac1e25a663df882c46a641a9bff6b56dc8b0fafaebd2f66fb231b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "303bf1edce6ced16bf67a18a1cf8339d0db79577eec5d9a6d4a80f0fb10aa2da"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5515edd2a6d1a5a70bfcdee23b42ec33425e405c5b351478ab7dc9347228f96e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "690dafd0b187ed38583a648076865d8c229661ed20e48f2335d68e2cf7dc829d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b6420a005548ad52154c8ceab4a1290ff78d757f9e5cbc68f8c77089acd3c432"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bb3bb49c7a6ad9d981d734ef7c7193bc349ac338776a0360cc671eaee89bcf69"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d27be7405547d1f958b60837dc4c1007da90b8b23f54ba1f8b728c78fdb19d50"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8df133a2ea5e74eef5e8fc6f19b9e085f758768a16e9877a60aec455ed2609b2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4dd9a263e845a72eacb60d12401e37c616438ea2e5442885f65082c276dfb2b2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6689a3d7fd13dc687e9102a27e98ef33730ac4fe37795d5036d18b4d527abd35"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f6bdac493b949141b733c5345b6ba8f87a226029cbabc7e9e121a413e49441e0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05186a0f1346ae12553d66df1cfce6f251589fea3ad3da4f3ef4e34b2d58c6a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c2006f5c8d28dee289f7020f721354362fa304acbaaf9745751ac4006650254b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c245b783db29c4e4fbbbfc9c5a78be496c9fea25517f90606aa1f6b2b3d5f7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4fb960a632a49f2f089d522f70496640fdf1218f1243889da3822e0a9f5f3ba7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "50670615eaf97227d5dc60de2dc99fb134a7130d310d783314e7724bf163f75d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9719fe17307a9e814580af1f5c6e05ca593b12fb7e44fe62450a5384dbf61b4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3331bece23c9ee066e0fb3f96c61322b9e0f54d775fccefff4c38ca488de283a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ed667f49b11360951e201453fc3967344d0d0263aa415e1619e85ae7fd17b4e0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8b77946fd508cbf0fccd8e400a7f71d4ac0e1595812e66025bac475a8e811694"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e4da8ca0c0c0aea88fd46be8e44bd49716772358d648cce45fe387f7b92374a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fe4bda6bd4340caa6e5cf95e73f8fea5c4bfc55763dd42f1b50a94c1b4a2fbd4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f3df3db1d336b9356dd3112eae5f5c2b8b377f3bc826848567f10bfddfee77e9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48628bd53a426c9eb9bc066a923acaa0878d1e86129fd5359aee99285f4eed9c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3.tar.gz"
+        }
+      ],
+      "name": "lxml",
+      "purl": "pkg:pypi/lxml@4.9.3",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.9.3"
+    },
+    {
+      "bom-ref": "packageurl-python@0.11.2",
+      "description": "A purl aka. Package URL parser and builder",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "01fbf74a41ef85cf413f1ede529a1411f658bda66ed22d45d27280ad9ceba471"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/packageurl-python/#packageurl-python-0.11.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "799acfe8d9e6e3534bbc19660be97d5b66754bc033e62c39f1e2f16323fcfa84"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/packageurl-python/#packageurl_python-0.11.2-py3-none-any.whl"
+        }
+      ],
+      "name": "packageurl-python",
+      "purl": "pkg:pypi/packageurl-python@0.11.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.11.2"
+    },
+    {
+      "bom-ref": "pkgutil-resolve-name@1.3.10",
+      "description": "Resolve a name to an object.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10.tar.gz"
+        }
+      ],
+      "name": "pkgutil-resolve-name",
+      "purl": "pkg:pypi/pkgutil-resolve-name@1.3.10",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.10"
+    },
+    {
+      "bom-ref": "py-serializable@0.15.0",
+      "description": "Library for serializing and deserializing Python Objects to and from JSON and XML.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8fc41457d8ee5f5c5a12f41fd87bf1a4f2ecf9da39fee92059b728e78f320771"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-serializable/#py-serializable-0.15.0.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d3f1201b33420c481aa83f7860c7bf2c2f036ba3ea82b6e15a96696457c36cd2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-serializable/#py_serializable-0.15.0-py3-none-any.whl"
+        }
+      ],
+      "name": "py-serializable",
+      "purl": "pkg:pypi/py-serializable@0.15.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.15.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "referencing@0.30.2",
+      "description": "JSON Referencing + Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "449b6669b6121a9e96a7f9e410b245d471e8d48964c67113ce9afe50c8dd7bdf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/#referencing-0.30.2-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "794ad8003c65938edcdbc027f1933215e0d0ccc0291e3ce20a4d87432b59efc0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/#referencing-0.30.2.tar.gz"
+        }
+      ],
+      "name": "referencing",
+      "purl": "pkg:pypi/referencing@0.30.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.30.2"
+    },
+    {
+      "bom-ref": "rfc3339-validator@0.1.4",
+      "description": "A pure python RFC3339 validator",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4.tar.gz"
+        }
+      ],
+      "name": "rfc3339-validator",
+      "purl": "pkg:pypi/rfc3339-validator@0.1.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.1.4"
+    },
+    {
+      "bom-ref": "rfc3987@1.3.8",
+      "description": "Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3987/#rfc3987-1.3.8-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3987/#rfc3987-1.3.8.tar.gz"
+        }
+      ],
+      "name": "rfc3987",
+      "purl": "pkg:pypi/rfc3987@1.3.8",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.8"
+    },
+    {
+      "bom-ref": "rpds-py@0.12.0",
+      "description": "Python bindings to Rust's persistent data structures (rpds)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c694bee70ece3b232df4678448fdda245fd3b1bb4ba481fb6cd20e13bb784c46"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "30e5ce9f501fb1f970e4a59098028cf20676dee64fc496d55c33e04bbbee097d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d72a4315514e5a0b9837a086cb433b004eea630afb0cc129de76d77654a9606f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eebaf8c76c39604d52852366249ab807fe6f7a3ffb0dd5484b9944917244cdbe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a239303acb0315091d54c7ff36712dba24554993b9a93941cf301391d8a997ee"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ced40cdbb6dd47a032725a038896cceae9ce267d340f59508b23537f05455431"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3c8c0226c71bd0ce9892eaf6afa77ae8f43a3d9313124a03df0b389c01f832de"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b8e11715178f3608874508f08e990d3771e0b8c66c73eb4e183038d600a9b274"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5210a0018c7e09c75fa788648617ebba861ae242944111d3079034e14498223f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "171d9a159f1b2f42a42a64a985e4ba46fc7268c78299272ceba970743a67ee50"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "57ec6baec231bb19bb5fd5fc7bae21231860a1605174b11585660236627e390e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7188ddc1a8887194f984fa4110d5a3d5b9b5cd35f6bafdff1b649049cbc0ce29"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e04581c6117ad9479b6cfae313e212fe0dfa226ac727755f0d539cd54792963"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0a38612d07a36138507d69646c470aedbfe2b75b43a4643f7bd8e51e52779624"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f12d69d568f5647ec503b64932874dade5a20255736c89936bf690951a5e79f5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f8a1d990dc198a6c68ec3d9a637ba1ce489b38cbfb65440a27901afbc5df575"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8c567c664fc2f44130a20edac73e0a867f8e012bf7370276f15c6adc3586c37c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e9e976e0dbed4f51c56db10831c9623d0fd67aac02853fe5476262e5a22acb7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efddca2d02254a52078c35cadad34762adbae3ff01c6b0c7787b59d038b63e0d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d9e7f29c00577aff6b318681e730a519b235af292732a149337f6aaa4d1c5e31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "389c0e38358fdc4e38e9995e7291269a3aead7acfcf8942010ee7bc5baee091c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "33ab498f9ac30598b6406e2be1b45fd231195b83d948ebd4bd77f337cb6a2bff"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d56b1cd606ba4cedd64bb43479d56580e147c6ef3f5d1c5e64203a1adab784a2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1fa73ed22c40a1bec98d7c93b5659cd35abcfa5a0a95ce876b91adbda170537c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dbc25baa6abb205766fb8606f8263b02c3503a55957fcb4576a6bb0a59d37d10"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c6b52b7028b547866c2413f614ee306c2d4eafdd444b1ff656bf3295bf1484aa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9620650c364c01ed5b497dcae7c3d4b948daeae6e1883ae185fef1c927b6b534"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2124f9e645a94ab7c853bc0a3644e0ca8ffbe5bb2d72db49aef8f9ec1c285733"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "281c8b219d4f4b3581b918b816764098d04964915b2f272d1476654143801aa2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27ccc93c7457ef890b0dd31564d2a05e1aca330623c942b7e818e9e7c2669ee4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d1c562a9bb72244fa767d1c1ab55ca1d92dd5f7c4d77878fee5483a22ffac808"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e57919c32ee295a2fca458bb73e4b20b05c115627f96f95a10f9f5acbd61172d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fa35ad36440aaf1ac8332b4a4a433d4acd28f1613f0d480995f5cfd3580e90b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e6aea5c0eb5b0faf52c7b5c4a47c8bb64437173be97227c819ffa31801fa4e34"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81cf9d306c04df1b45971c13167dc3bad625808aa01281d55f3cf852dde0e206"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08e6e7ff286254016b945e1ab632ee843e43d45e40683b66dd12b73791366dd1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d0a675a7acbbc16179188d8c6d0afb8628604fc1241faf41007255957335a0b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2287c09482949e0ca0c0eb68b2aca6cf57f8af8c6dfd29dcd3bc45f17b57978"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8015835494b21aa7abd3b43fdea0614ee35ef6b03db7ecba9beb58eadf01c24f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6174d6ad6b58a6bcf67afbbf1723420a53d06c4b89f4c50763d6fa0a6ac9afd2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a689e1ded7137552bea36305a7a16ad2b40be511740b80748d3140614993db98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f45321224144c25a62052035ce96cbcf264667bcb0d81823b1bbc22c4addd194"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aa32205358a76bf578854bf31698a86dc8b2cb591fd1d79a833283f4a403f04b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "91bd2b7cf0f4d252eec8b7046fa6a43cee17e8acdfc00eaa8b3dbf2f9a59d061"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3acadbab8b59f63b87b518e09c4c64b142e7286b9ca7a208107d6f9f4c393c5c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "429349a510da82c85431f0f3e66212d83efe9fd2850f50f339341b6532c62fe4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05942656cb2cb4989cd50ced52df16be94d344eae5097e8583966a1d27da73a5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0c5441b7626c29dbd54a3f6f3713ec8e956b009f419ffdaaa3c80eaf98ddb523"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b6b0e17d39d21698185097652c611f9cf30f7c56ccec189789920e3e7f1cee56"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3b7a64d43e2a1fa2dd46b678e00cabd9a49ebb123b339ce799204c44a593ae1c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e5bbe011a2cea9060fef1bb3d668a2fd8432b8888e6d92e74c9c794d3c101595"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bec29b801b4adbf388314c0d050e851d53762ab424af22657021ce4b6eb41543"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1096ca0bf2d3426cbe79d4ccc91dc5aaa73629b08ea2d8467375fad8447ce11a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48aa98987d54a46e13e6954880056c204700c65616af4395d1f0639eba11764b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7979d90ee2190d000129598c2b0c82f13053dba432b94e45e68253b09bb1f0f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "88857060b690a57d2ea8569bca58758143c8faa4639fb17d745ce60ff84c867e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4eb74d44776b0fb0782560ea84d986dffec8ddd94947f383eba2284b0f32e35e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f62581d7e884dd01ee1707b7c21148f61f2febb7de092ae2f108743fcbef5985"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6f5dcb658d597410bb7c967c1d24eaf9377b0d621358cbe9d2ff804e5dd12e81"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9bf9acce44e967a5103fcd820fc7580c7b0ab8583eec4e2051aec560f7b31a63"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "240687b5be0f91fbde4936a329c9b7589d9259742766f74de575e1b2046575e4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25740fb56e8bd37692ed380e15ec734be44d7c71974d8993f452b4527814601e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a54917b7e9cd3a67e429a630e237a90b096e0ba18897bfb99ee8bd1068a5fea0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b92aafcfab3d41580d54aca35a8057341f1cfc7c9af9e8bdfc652f83a20ced31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd316dbcc74c76266ba94eb021b0cc090b97cca122f50bd7a845f587ff4bf03f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0853da3d5e9bc6a07b2486054a410b7b03f34046c123c6561b535bb48cc509e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cb41ad20064e18a900dd427d7cf41cfaec83bcd1184001f3d91a1f76b3fcea4e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b710bf7e7ae61957d5c4026b486be593ed3ec3dca3e5be15e0f6d8cf5d0a4990"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a952ae3eb460c6712388ac2ec706d24b0e651b9396d90c9a9e0a69eb27737fdc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0bedd91ae1dd142a4dc15970ed2c729ff6c73f33a40fa84ed0cdbf55de87c777"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "761531076df51309075133a6bc1db02d98ec7f66e22b064b1d513bc909f29743"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a2baa6be130e8a00b6cbb9f18a33611ec150b4537f8563bddadb54c1b74b8193"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f05450fa1cd7c525c0b9d1a7916e595d3041ac0afbed2ff6926e5afb6a781b7f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81c4d1a3a564775c44732b94135d06e33417e829ff25226c164664f4a1046213"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e888be685fa42d8b8a3d3911d5604d14db87538aa7d0b29b1a7ea80d354c732d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6f8d7fe73d1816eeb5378409adc658f9525ecbfaf9e1ede1e2d67a338b0c7348"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0831d3ecdea22e4559cc1793f22e77067c9d8c451d55ae6a75bf1d116a8e7f42"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "513ccbf7420c30e283c25c82d5a8f439d625a838d3ba69e79a110c260c46813f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "301bd744a1adaa2f6a5e06c98f1ac2b6f8dc31a5c23b838f862d65e32fca0d4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f8832a4f83d4782a8f5a7b831c47e8ffe164e43c2c148c8160ed9a6d630bc02a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b2416ed743ec5debcf61e1242e012652a4348de14ecc7df3512da072b074440"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "35585a8cb5917161f42c2104567bb83a1d96194095fc54a543113ed5df9fa436"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d389ff1e95b6e46ebedccf7fd1fadd10559add595ac6a7c2ea730268325f832c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9b007c2444705a2dc4a525964fd4dd28c3320b19b3410da6517cab28716f27d3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "188912b22b6c8225f4c4ffa020a2baa6ad8fabb3c141a12dbe6edbb34e7f1425"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b4cf9ab9a0ae0cb122685209806d3f1dcb63b9fccdf1424fb42a129dc8c2faa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2d34a5450a402b00d20aeb7632489ffa2556ca7b26f4a63c35f6fccae1977427"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "466030a42724780794dea71eb32db83cc51214d66ab3fb3156edd88b9c8f0d78"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "68172622a5a57deb079a2c78511c40f91193548e8ab342c31e8cb0764d362459"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54cdfcda59251b9c2f87a05d038c2ae02121219a04d4a1e6fc345794295bdc07"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b75b912a0baa033350367a8a07a8b2d44fd5b90c890bfbd063a8a5f945f644b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "47aeceb4363851d17f63069318ba5721ae695d9da55d599b4d6fb31508595278"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0525847f83f506aa1e28eb2057b696fe38217e12931c8b1b02198cfe6975e142"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efbe0b5e0fd078ed7b005faa0170da4f72666360f66f0bb2d7f73526ecfd99f9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0fadfdda275c838cba5102c7f90a20f2abd7727bf8f4a2b654a5b617529c5c18"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "56dd500411d03c5e9927a1eb55621e906837a83b02350a9dc401247d0353717c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6915fc9fa6b3ec3569566832e1bb03bd801c12cea030200e68663b9a87974e76"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5f1519b080d8ce0a814f17ad9fb49fb3a1d4d7ce5891f5c85fc38631ca3a8dc4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7036316cc26b93e401cedd781a579be606dad174829e6ad9e9c5a0da6e036f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0.tar.gz"
+        }
+      ],
+      "name": "rpds-py",
+      "purl": "pkg:pypi/rpds-py@0.12.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.12.0"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "sortedcontainers@2.4.0",
+      "description": "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/sortedcontainers/#sortedcontainers-2.4.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/sortedcontainers/#sortedcontainers-2.4.0.tar.gz"
+        }
+      ],
+      "name": "sortedcontainers",
+      "purl": "pkg:pypi/sortedcontainers@2.4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.4.0"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.8.19.14"
+    },
+    {
+      "bom-ref": "uri-template@1.3.0",
+      "description": "RFC 6570 URI Template Processor",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uri-template/#uri-template-1.3.0.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uri-template/#uri_template-1.3.0-py3-none-any.whl"
+        }
+      ],
+      "name": "uri-template",
+      "purl": "pkg:pypi/uri-template@1.3.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "webcolors@1.13",
+      "description": "A library for working with the color formats defined by HTML and CSS.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/webcolors/#webcolors-1.13-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/webcolors/#webcolors-1.13.tar.gz"
+        }
+      ],
+      "name": "webcolors",
+      "purl": "pkg:pypi/webcolors@1.13",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.13"
+    },
+    {
+      "bom-ref": "zipp@3.17.0",
+      "description": "Backport of pathlib-compatible object wrapper for zip files",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/zipp/#zipp-3.17.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/zipp/#zipp-3.17.0.tar.gz"
+        }
+      ],
+      "name": "zipp",
+      "purl": "pkg:pypi/zipp@3.17.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "3.17.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "attrs@23.1.0"
+    },
+    {
+      "ref": "boolean-py@4.0"
+    },
+    {
+      "dependsOn": [
+        "jsonschema@4.19.2",
+        "license-expression@30.1.1",
+        "lxml@4.9.3",
+        "packageurl-python@0.11.2",
+        "py-serializable@0.15.0",
+        "sortedcontainers@2.4.0"
+      ],
+      "ref": "cyclonedx-python-lib@5.1.1"
+    },
+    {
+      "ref": "defusedxml@0.7.1"
+    },
+    {
+      "ref": "fqdn@1.5.1"
+    },
+    {
+      "ref": "idna@3.4"
+    },
+    {
+      "dependsOn": [
+        "zipp@3.17.0"
+      ],
+      "ref": "importlib-resources@6.1.1"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "ref": "jsonpointer@2.4"
+    },
+    {
+      "dependsOn": [
+        "importlib-resources@6.1.1",
+        "referencing@0.30.2"
+      ],
+      "ref": "jsonschema-specifications@2023.7.1"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.1.0",
+        "fqdn@1.5.1",
+        "idna@3.4",
+        "importlib-resources@6.1.1",
+        "isoduration@20.11.0",
+        "jsonpointer@2.4",
+        "jsonschema-specifications@2023.7.1",
+        "pkgutil-resolve-name@1.3.10",
+        "referencing@0.30.2",
+        "rfc3339-validator@0.1.4",
+        "rfc3987@1.3.8",
+        "rpds-py@0.12.0",
+        "uri-template@1.3.0",
+        "webcolors@1.13"
+      ],
+      "ref": "jsonschema@4.19.2"
+    },
+    {
+      "dependsOn": [
+        "boolean-py@4.0"
+      ],
+      "ref": "license-expression@30.1.1"
+    },
+    {
+      "ref": "lxml@4.9.3"
+    },
+    {
+      "ref": "packageurl-python@0.11.2"
+    },
+    {
+      "ref": "pkgutil-resolve-name@1.3.10"
+    },
+    {
+      "dependsOn": [
+        "defusedxml@0.7.1"
+      ],
+      "ref": "py-serializable@0.15.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.1.0",
+        "rpds-py@0.12.0"
+      ],
+      "ref": "referencing@0.30.2"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "rfc3339-validator@0.1.4"
+    },
+    {
+      "ref": "rfc3987@1.3.8"
+    },
+    {
+      "ref": "rpds-py@0.12.0"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "sortedcontainers@2.4.0"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    },
+    {
+      "ref": "uri-template@1.3.0"
+    },
+    {
+      "ref": "webcolors@1.13"
+    },
+    {
+      "dependsOn": [
+        "cyclonedx-python-lib@5.1.1"
+      ],
+      "ref": "with-extras"
+    },
+    {
+      "ref": "zipp@3.17.0"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "with-extras",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "properties": [
+        {
+          "name": "cdx:python:package:extra",
+          "value": "my-extra"
+        }
+      ],
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/some-extras-lock20-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/some-extras-lock20-1.5.xml.bin
@@ -1,0 +1,2092 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-extras">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+      <properties>
+        <property name="cdx:python:package:extra">my-extra</property>
+      </properties>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="attrs@23.1.0">
+      <name>attrs</name>
+      <version>23.1.0</version>
+      <description>Classes Without Boilerplate</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/attrs@23.1.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/#attrs-23.1.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/#attrs-23.1.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="boolean-py@4.0">
+      <name>boolean-py</name>
+      <version>4.0</version>
+      <description>Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/boolean-py@4.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/boolean-py/#boolean.py-4.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2876f2051d7d6394a531d82dc6eb407faa0b01a0a0b3083817ccd7323b8d96bd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/boolean-py/#boolean.py-4.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">17b9a181630e43dde1851d42bef546d616d5d9b4480357514597e78b203d06e4</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="cyclonedx-python-lib@5.1.1">
+      <name>cyclonedx-python-lib</name>
+      <version>5.1.1</version>
+      <description>Python library for CycloneDX</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/cyclonedx-python-lib@5.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/cyclonedx-python-lib/#cyclonedx_python_lib-5.1.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2989db0cd8bb4c0c442423d71ed7a84ae059e16a2d0f932cc4bf92da7385cdb3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/cyclonedx-python-lib/#cyclonedx_python_lib-5.1.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">215a636a4e77385d2cf4c6c9801c9bad4791849634f2c6daa45ab2c6cb0a85f6</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:extra">json-validation</property>
+        <property name="cdx:python:package:extra">xml-validation</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="defusedxml@0.7.1">
+      <name>defusedxml</name>
+      <version>0.7.1</version>
+      <description>XML bomb protection for Python stdlib modules</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/defusedxml@0.7.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/defusedxml/#defusedxml-0.7.1-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/defusedxml/#defusedxml-0.7.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="fqdn@1.5.1">
+      <name>fqdn</name>
+      <version>1.5.1</version>
+      <description>Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/fqdn@1.5.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fqdn/#fqdn-1.5.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fqdn/#fqdn-1.5.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="idna@3.4">
+      <name>idna</name>
+      <version>3.4</version>
+      <description>Internationalized Domain Names in Applications (IDNA)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/idna@3.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/#idna-3.4-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/#idna-3.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="importlib-resources@6.1.1">
+      <name>importlib-resources</name>
+      <version>6.1.1</version>
+      <description>Read resources from Python packages</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/importlib-resources@6.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e8bf90d8213b486f428c9c39714b920041cb02c184686a3dee24905aaa8105d6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="jsonpointer@2.4">
+      <name>jsonpointer</name>
+      <version>2.4</version>
+      <description>Identify specific nodes in a JSON document (RFC 6901)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonpointer@2.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonpointer/#jsonpointer-2.4-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonpointer/#jsonpointer-2.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="jsonschema@4.19.2">
+      <name>jsonschema</name>
+      <version>4.19.2</version>
+      <description>An implementation of JSON Schema validation for Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonschema@4.19.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema/#jsonschema-4.19.2-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eee9e502c788e89cb166d4d37f43084e3b64ab405c795c03d343a4dbc2c810fc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema/#jsonschema-4.19.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c9ff4d7447eed9592c23a12ccee508baf0dd0d59650615e847feb6cdca74f392</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:python:package:extra">format</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema-specifications@2023.7.1">
+      <name>jsonschema-specifications</name>
+      <version>2023.7.1</version>
+      <description>The JSON Schema meta-schemas and vocabularies, exposed as a Registry</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonschema-specifications@2023.7.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">05adf340b659828a004220a9613be00fa3f223f2b82002e273dee62fd50524b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c91a50404e88a1f6ba40636778e2ee08f6e24c5613fe4c53ac24578a5a7f72bb</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="license-expression@30.1.1">
+      <name>license-expression</name>
+      <version>30.1.1</version>
+      <description>license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/license-expression@30.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/license-expression/#license-expression-30.1.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">42375df653ad85e6f5b4b0385138b2dbea1f5d66360783d8625c3e4f97f11f0c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/license-expression/#license_expression-30.1.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8d7e5e2de0d04fc104a4f952c440e8f08a5ba63480a0dad015b294770b7e58ec</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="lxml@4.9.3">
+      <name>lxml</name>
+      <version>4.9.3</version>
+      <description>Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/lxml@4.9.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b0a545b46b526d418eb91754565ba5b63b1c0b12f9bd2f808c852d9b4b2f9b5c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">075b731ddd9e7f68ad24c635374211376aa05a281673ede86cbe1d1b3455279d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e224d5755dba2f4a9498e150c43792392ac9b5380aa1b845f98a1618c94eeef</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2c74524e179f2ad6d2a4f7caf70e2d96639c0954c943ad601a9e146c76408ed7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1026bc732b6a7f96369f7bfe1a4f2290fb34dce00d8644bc3036fb351a4ca1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c0781a98ff5e6586926293e59480b64ddd46282953203c76ae15dbbbf302e8bb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cef2502e7e8a96fe5ad686d60b49e1ab03e438bd9123987994528febd569868e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b86164d2cff4d3aaa1f04a14685cbc072efd0b4f99ca5708b2ad1b9b5988a991</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">42871176e7896d5d45138f6d28751053c711ed4d48d8e30b498da155af39aebd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ae8b9c6deb1e634ba4f1930eb67ef6e6bf6a44b6eb5ad605642b2d6d5ed9ce3c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_28_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">411007c0d88188d9f621b11d252cce90c4a2d1a49db6c068e3c16422f306eab8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd47b4a0d41d2afa3e58e5bf1f62069255aa2fd6ff5ee41604418ca925911d76</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e2cb47860da1f7e9a5256254b74ae331687b9672dfa780eed355c4c9c3dbd23</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1247694b26342a7bf47c02e513d32225ededd18045264d40758abeb3c838a51f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cdb650fc86227eba20de1a29d4b2c1bfe139dc75a0669270033cb2ea3d391b85</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">97047f0d25cd4bcae81f9ec9dc290ca3e15927c192df17331b53bebe0e3ff96d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-macosx_11_0_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f447ea5429b54f9582d4b955f5f1985f278ce5cf169f72eea8afd9502973dd5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">57d6ba0ca2b0c462f339640d22882acc711de224d769edf29962b09f77129cbf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9767e79108424fb6c3edf8f81e6730666a50feb01a328f4a016464a5893f835a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_28_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">71c52db65e4b56b8ddc5bb89fb2e66c558ed9d1a74a45ceb7dcb20c191c3df2f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d73d8ecf8ecf10a3bd007f2192725a34bd62898e8da27eb9d32a58084f93962b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0a3d3487f07c1d7f150894c238299934a2a074ef590b583103a45002035be120</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9e28c51fa0ce5674be9f560c6761c1b441631901993f76700b1b30ca6c8378d6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0bfd0767c5c1de2551a120673b72e5d4b628737cb05414f03c3277bf9bed3305</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">25f32acefac14ef7bd53e4218fe93b804ef6f6b92ffdb4322bb6d49d94cad2bc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-macosx_11_0_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d3ff32724f98fbbbfa9f49d82852b159e9784d6094983d9a8b7f2ddaebb063d4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-manylinux_2_28_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48d6ed886b343d11493129e019da91d4039826794a3e3027321c56d9e71505be</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9a92d3faef50658dd2c5470af249985782bf754c4e18e15afb67d3ab06233f13</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b4e4bc18382088514ebde9328da057775055940a1f2e18f6ad2d78aa0f3ec5b9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fc9b106a1bf918db68619fdcd6d5ad4f972fdd19c01d19bdb6bf63f3589a9ec5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d37017287a7adb6ab77e1c5bee9bcf9660f90ff445042b790402a654d2ad81d8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">56dc1f1ebccc656d1b3ed288f11e27172a01503fc016bcabdcbc0978b19352b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">578695735c5a3f51569810dfebd05dd6f888147a34f0f98d4bb27e92b76e05c2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">704f61ba8c1283c71b16135caf697557f5ecf3e74d9e453233e4771d68a1f42d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c41bfca0bd3532d53d16fd34d20806d5c2b1ace22a2f2e4c0008570bf2c58833</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">64f479d719dc9f4c813ad9bb6b28f8390360660b73b2e4beb4cb0ae7104f1c12</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dd708cf4ee4408cf46a48b108fb9427bfa00b9b85812a9262b5c668af2533ea5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5c31c7462abdf8f2ac0577d9f05279727e698f97ecbb02f17939ea99ae8daa98</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e3cd95e10c2610c360154afdc2f1480aea394f4a4f1ea0a5eacce49640c9b190</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4930be26af26ac545c3dffb662521d4e6268352866956672231887d18f0eaab2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4aec80cde9197340bc353d2768e2a75f5f60bacda2bab72ab1dc499589b3878c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">14e019fd83b831b2e61baed40cab76222139926b1fb5ed0e79225bc0cae14584</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0c0850c8b02c298d3c7006b23e98249515ac57430e16a166873fc47a5d549287</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aca086dc5f9ef98c512bac8efea4483eb84abbf926eaeedf7b91479feb092458</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">50baa9c1c47efcaef189f31e3d00d697c6d4afda5c3cde0302d063492ff9b477</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bef4e656f7d98aaa3486d2627e7d2df1157d7e88e7efd43a65aa5dd4714916cf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">46f409a2d60f634fe550f7133ed30ad5321ae2e6630f13657fb9479506b00601</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4c28a9144688aef80d6ea666c809b4b0e50010a2aca784c97f5e6bf143d9f129</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">141f1d1a9b663c679dc524af3ea1773e618907e96075262726c7612c02b149a4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">53ace1c1fd5a74ef662f844a0413446c0629d151055340e9893da958a374f70d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">17a753023436a18e27dd7769e798ce302963c236bc4114ceee5b25c18c52c693</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7d298a1bd60c067ea75d9f684f5f3992c9d6766fadbc0bcedd39750bf344c2f4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">081d32421db5df44c41b7f08a334a090a545c54ba977e47fd7cc2deece78809a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">23eed6d7b1a3336ad92d8e39d4bfe09073c31bfe502f20ca5116b2a334f8ec02</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1509dd12b773c02acd154582088820893109f6ca27ef7291b003d0e81666109f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">120fa9349a24c7043854c53cae8cec227e1f79195a7493e09e0c12e29f918e52</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d2d1edbca80b510443f51afd8496be95529db04a509bc8faee49c7b0fb6d2cc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8d7e43bd40f65f7d97ad8ef5c9b1778943d02f04febef12def25f7583d19baac</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">71d66ee82e7417828af6ecd7db817913cb0cf9d4e61aa0ac1fde0583d84358db</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6fc3c450eaa0b56f815c7b62f2b7fba7266c4779adcf1cece9e6deb1de7305ce</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">65299ea57d82fb91c7f019300d24050c4ddeb7c5a190e076b5f48a2b43d19c42</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eadfbbbfb41b44034a4c757fd5d70baccd43296fb894dba0295606a7cf3124aa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3e9bdd30efde2b9ccfa9cb5768ba04fe71b018a25ea093379c857c9dad262c40</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fcdd00edfd0a3001e0181eab3e63bd5c74ad3e67152c84f93f13769a40e073a7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">57aba1bbdf450b726d58b2aea5fe47c7875f5afb2c4a23784ed78f19a0462574</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">92af161ecbdb2883c4593d5ed4815ea71b31fafd7fd05789b23100d081ecac96</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9bb6ad405121241e99a86efff22d3ef469024ce22875a7ae045896ad23ba2340</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8ed74706b26ad100433da4b9d807eae371efaa266ffc3e9191ea436087a9d6a7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fbf521479bcac1e25a663df882c46a641a9bff6b56dc8b0fafaebd2f66fb231b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_28_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">303bf1edce6ced16bf67a18a1cf8339d0db79577eec5d9a6d4a80f0fb10aa2da</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5515edd2a6d1a5a70bfcdee23b42ec33425e405c5b351478ab7dc9347228f96e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">690dafd0b187ed38583a648076865d8c229661ed20e48f2335d68e2cf7dc829d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b6420a005548ad52154c8ceab4a1290ff78d757f9e5cbc68f8c77089acd3c432</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bb3bb49c7a6ad9d981d734ef7c7193bc349ac338776a0360cc671eaee89bcf69</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d27be7405547d1f958b60837dc4c1007da90b8b23f54ba1f8b728c78fdb19d50</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8df133a2ea5e74eef5e8fc6f19b9e085f758768a16e9877a60aec455ed2609b2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4dd9a263e845a72eacb60d12401e37c616438ea2e5442885f65082c276dfb2b2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6689a3d7fd13dc687e9102a27e98ef33730ac4fe37795d5036d18b4d527abd35</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f6bdac493b949141b733c5345b6ba8f87a226029cbabc7e9e121a413e49441e0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">05186a0f1346ae12553d66df1cfce6f251589fea3ad3da4f3ef4e34b2d58c6a3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c2006f5c8d28dee289f7020f721354362fa304acbaaf9745751ac4006650254b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5c245b783db29c4e4fbbbfc9c5a78be496c9fea25517f90606aa1f6b2b3d5f7b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4fb960a632a49f2f089d522f70496640fdf1218f1243889da3822e0a9f5f3ba7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">50670615eaf97227d5dc60de2dc99fb134a7130d310d783314e7724bf163f75d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9719fe17307a9e814580af1f5c6e05ca593b12fb7e44fe62450a5384dbf61b4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3331bece23c9ee066e0fb3f96c61322b9e0f54d775fccefff4c38ca488de283a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ed667f49b11360951e201453fc3967344d0d0263aa415e1619e85ae7fd17b4e0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8b77946fd508cbf0fccd8e400a7f71d4ac0e1595812e66025bac475a8e811694</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e4da8ca0c0c0aea88fd46be8e44bd49716772358d648cce45fe387f7b92374a7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fe4bda6bd4340caa6e5cf95e73f8fea5c4bfc55763dd42f1b50a94c1b4a2fbd4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f3df3db1d336b9356dd3112eae5f5c2b8b377f3bc826848567f10bfddfee77e9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48628bd53a426c9eb9bc066a923acaa0878d1e86129fd5359aee99285f4eed9c</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="packageurl-python@0.11.2">
+      <name>packageurl-python</name>
+      <version>0.11.2</version>
+      <description>A purl aka. Package URL parser and builder</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/packageurl-python@0.11.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/packageurl-python/#packageurl-python-0.11.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">01fbf74a41ef85cf413f1ede529a1411f658bda66ed22d45d27280ad9ceba471</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/packageurl-python/#packageurl_python-0.11.2-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">799acfe8d9e6e3534bbc19660be97d5b66754bc033e62c39f1e2f16323fcfa84</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkgutil-resolve-name@1.3.10">
+      <name>pkgutil-resolve-name</name>
+      <version>1.3.10</version>
+      <description>Resolve a name to an object.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/pkgutil-resolve-name@1.3.10</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="py-serializable@0.15.0">
+      <name>py-serializable</name>
+      <version>0.15.0</version>
+      <description>Library for serializing and deserializing Python Objects to and from JSON and XML.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/py-serializable@0.15.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-serializable/#py-serializable-0.15.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8fc41457d8ee5f5c5a12f41fd87bf1a4f2ecf9da39fee92059b728e78f320771</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-serializable/#py_serializable-0.15.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d3f1201b33420c481aa83f7860c7bf2c2f036ba3ea82b6e15a96696457c36cd2</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="referencing@0.30.2">
+      <name>referencing</name>
+      <version>0.30.2</version>
+      <description>JSON Referencing + Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/referencing@0.30.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/#referencing-0.30.2-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">449b6669b6121a9e96a7f9e410b245d471e8d48964c67113ce9afe50c8dd7bdf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/#referencing-0.30.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">794ad8003c65938edcdbc027f1933215e0d0ccc0291e3ce20a4d87432b59efc0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="rfc3339-validator@0.1.4">
+      <name>rfc3339-validator</name>
+      <version>0.1.4</version>
+      <description>A pure python RFC3339 validator</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rfc3339-validator@0.1.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="rfc3987@1.3.8">
+      <name>rfc3987</name>
+      <version>1.3.8</version>
+      <description>Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rfc3987@1.3.8</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3987/#rfc3987-1.3.8-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3987/#rfc3987-1.3.8.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="rpds-py@0.12.0">
+      <name>rpds-py</name>
+      <version>0.12.0</version>
+      <description>Python bindings to Rust's persistent data structures (rpds)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rpds-py@0.12.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c694bee70ece3b232df4678448fdda245fd3b1bb4ba481fb6cd20e13bb784c46</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">30e5ce9f501fb1f970e4a59098028cf20676dee64fc496d55c33e04bbbee097d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d72a4315514e5a0b9837a086cb433b004eea630afb0cc129de76d77654a9606f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eebaf8c76c39604d52852366249ab807fe6f7a3ffb0dd5484b9944917244cdbe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a239303acb0315091d54c7ff36712dba24554993b9a93941cf301391d8a997ee</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ced40cdbb6dd47a032725a038896cceae9ce267d340f59508b23537f05455431</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3c8c0226c71bd0ce9892eaf6afa77ae8f43a3d9313124a03df0b389c01f832de</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b8e11715178f3608874508f08e990d3771e0b8c66c73eb4e183038d600a9b274</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5210a0018c7e09c75fa788648617ebba861ae242944111d3079034e14498223f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">171d9a159f1b2f42a42a64a985e4ba46fc7268c78299272ceba970743a67ee50</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">57ec6baec231bb19bb5fd5fc7bae21231860a1605174b11585660236627e390e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7188ddc1a8887194f984fa4110d5a3d5b9b5cd35f6bafdff1b649049cbc0ce29</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e04581c6117ad9479b6cfae313e212fe0dfa226ac727755f0d539cd54792963</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0a38612d07a36138507d69646c470aedbfe2b75b43a4643f7bd8e51e52779624</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f12d69d568f5647ec503b64932874dade5a20255736c89936bf690951a5e79f5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f8a1d990dc198a6c68ec3d9a637ba1ce489b38cbfb65440a27901afbc5df575</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8c567c664fc2f44130a20edac73e0a867f8e012bf7370276f15c6adc3586c37c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e9e976e0dbed4f51c56db10831c9623d0fd67aac02853fe5476262e5a22acb7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efddca2d02254a52078c35cadad34762adbae3ff01c6b0c7787b59d038b63e0d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d9e7f29c00577aff6b318681e730a519b235af292732a149337f6aaa4d1c5e31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">389c0e38358fdc4e38e9995e7291269a3aead7acfcf8942010ee7bc5baee091c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">33ab498f9ac30598b6406e2be1b45fd231195b83d948ebd4bd77f337cb6a2bff</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d56b1cd606ba4cedd64bb43479d56580e147c6ef3f5d1c5e64203a1adab784a2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1fa73ed22c40a1bec98d7c93b5659cd35abcfa5a0a95ce876b91adbda170537c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dbc25baa6abb205766fb8606f8263b02c3503a55957fcb4576a6bb0a59d37d10</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c6b52b7028b547866c2413f614ee306c2d4eafdd444b1ff656bf3295bf1484aa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9620650c364c01ed5b497dcae7c3d4b948daeae6e1883ae185fef1c927b6b534</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2124f9e645a94ab7c853bc0a3644e0ca8ffbe5bb2d72db49aef8f9ec1c285733</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">281c8b219d4f4b3581b918b816764098d04964915b2f272d1476654143801aa2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">27ccc93c7457ef890b0dd31564d2a05e1aca330623c942b7e818e9e7c2669ee4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d1c562a9bb72244fa767d1c1ab55ca1d92dd5f7c4d77878fee5483a22ffac808</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e57919c32ee295a2fca458bb73e4b20b05c115627f96f95a10f9f5acbd61172d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fa35ad36440aaf1ac8332b4a4a433d4acd28f1613f0d480995f5cfd3580e90b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e6aea5c0eb5b0faf52c7b5c4a47c8bb64437173be97227c819ffa31801fa4e34</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">81cf9d306c04df1b45971c13167dc3bad625808aa01281d55f3cf852dde0e206</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08e6e7ff286254016b945e1ab632ee843e43d45e40683b66dd12b73791366dd1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d0a675a7acbbc16179188d8c6d0afb8628604fc1241faf41007255957335a0b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2287c09482949e0ca0c0eb68b2aca6cf57f8af8c6dfd29dcd3bc45f17b57978</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8015835494b21aa7abd3b43fdea0614ee35ef6b03db7ecba9beb58eadf01c24f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6174d6ad6b58a6bcf67afbbf1723420a53d06c4b89f4c50763d6fa0a6ac9afd2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a689e1ded7137552bea36305a7a16ad2b40be511740b80748d3140614993db98</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f45321224144c25a62052035ce96cbcf264667bcb0d81823b1bbc22c4addd194</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aa32205358a76bf578854bf31698a86dc8b2cb591fd1d79a833283f4a403f04b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">91bd2b7cf0f4d252eec8b7046fa6a43cee17e8acdfc00eaa8b3dbf2f9a59d061</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3acadbab8b59f63b87b518e09c4c64b142e7286b9ca7a208107d6f9f4c393c5c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">429349a510da82c85431f0f3e66212d83efe9fd2850f50f339341b6532c62fe4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">05942656cb2cb4989cd50ced52df16be94d344eae5097e8583966a1d27da73a5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0c5441b7626c29dbd54a3f6f3713ec8e956b009f419ffdaaa3c80eaf98ddb523</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b6b0e17d39d21698185097652c611f9cf30f7c56ccec189789920e3e7f1cee56</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3b7a64d43e2a1fa2dd46b678e00cabd9a49ebb123b339ce799204c44a593ae1c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e5bbe011a2cea9060fef1bb3d668a2fd8432b8888e6d92e74c9c794d3c101595</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bec29b801b4adbf388314c0d050e851d53762ab424af22657021ce4b6eb41543</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1096ca0bf2d3426cbe79d4ccc91dc5aaa73629b08ea2d8467375fad8447ce11a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48aa98987d54a46e13e6954880056c204700c65616af4395d1f0639eba11764b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7979d90ee2190d000129598c2b0c82f13053dba432b94e45e68253b09bb1f0f6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">88857060b690a57d2ea8569bca58758143c8faa4639fb17d745ce60ff84c867e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4eb74d44776b0fb0782560ea84d986dffec8ddd94947f383eba2284b0f32e35e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f62581d7e884dd01ee1707b7c21148f61f2febb7de092ae2f108743fcbef5985</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6f5dcb658d597410bb7c967c1d24eaf9377b0d621358cbe9d2ff804e5dd12e81</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9bf9acce44e967a5103fcd820fc7580c7b0ab8583eec4e2051aec560f7b31a63</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">240687b5be0f91fbde4936a329c9b7589d9259742766f74de575e1b2046575e4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">25740fb56e8bd37692ed380e15ec734be44d7c71974d8993f452b4527814601e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a54917b7e9cd3a67e429a630e237a90b096e0ba18897bfb99ee8bd1068a5fea0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b92aafcfab3d41580d54aca35a8057341f1cfc7c9af9e8bdfc652f83a20ced31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd316dbcc74c76266ba94eb021b0cc090b97cca122f50bd7a845f587ff4bf03f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0853da3d5e9bc6a07b2486054a410b7b03f34046c123c6561b535bb48cc509e1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cb41ad20064e18a900dd427d7cf41cfaec83bcd1184001f3d91a1f76b3fcea4e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b710bf7e7ae61957d5c4026b486be593ed3ec3dca3e5be15e0f6d8cf5d0a4990</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a952ae3eb460c6712388ac2ec706d24b0e651b9396d90c9a9e0a69eb27737fdc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0bedd91ae1dd142a4dc15970ed2c729ff6c73f33a40fa84ed0cdbf55de87c777</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">761531076df51309075133a6bc1db02d98ec7f66e22b064b1d513bc909f29743</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a2baa6be130e8a00b6cbb9f18a33611ec150b4537f8563bddadb54c1b74b8193</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f05450fa1cd7c525c0b9d1a7916e595d3041ac0afbed2ff6926e5afb6a781b7f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">81c4d1a3a564775c44732b94135d06e33417e829ff25226c164664f4a1046213</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e888be685fa42d8b8a3d3911d5604d14db87538aa7d0b29b1a7ea80d354c732d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6f8d7fe73d1816eeb5378409adc658f9525ecbfaf9e1ede1e2d67a338b0c7348</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0831d3ecdea22e4559cc1793f22e77067c9d8c451d55ae6a75bf1d116a8e7f42</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">513ccbf7420c30e283c25c82d5a8f439d625a838d3ba69e79a110c260c46813f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">301bd744a1adaa2f6a5e06c98f1ac2b6f8dc31a5c23b838f862d65e32fca0d4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f8832a4f83d4782a8f5a7b831c47e8ffe164e43c2c148c8160ed9a6d630bc02a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4b2416ed743ec5debcf61e1242e012652a4348de14ecc7df3512da072b074440</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">35585a8cb5917161f42c2104567bb83a1d96194095fc54a543113ed5df9fa436</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d389ff1e95b6e46ebedccf7fd1fadd10559add595ac6a7c2ea730268325f832c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9b007c2444705a2dc4a525964fd4dd28c3320b19b3410da6517cab28716f27d3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">188912b22b6c8225f4c4ffa020a2baa6ad8fabb3c141a12dbe6edbb34e7f1425</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1b4cf9ab9a0ae0cb122685209806d3f1dcb63b9fccdf1424fb42a129dc8c2faa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2d34a5450a402b00d20aeb7632489ffa2556ca7b26f4a63c35f6fccae1977427</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">466030a42724780794dea71eb32db83cc51214d66ab3fb3156edd88b9c8f0d78</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">68172622a5a57deb079a2c78511c40f91193548e8ab342c31e8cb0764d362459</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">54cdfcda59251b9c2f87a05d038c2ae02121219a04d4a1e6fc345794295bdc07</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b75b912a0baa033350367a8a07a8b2d44fd5b90c890bfbd063a8a5f945f644b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">47aeceb4363851d17f63069318ba5721ae695d9da55d599b4d6fb31508595278</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0525847f83f506aa1e28eb2057b696fe38217e12931c8b1b02198cfe6975e142</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efbe0b5e0fd078ed7b005faa0170da4f72666360f66f0bb2d7f73526ecfd99f9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0fadfdda275c838cba5102c7f90a20f2abd7727bf8f4a2b654a5b617529c5c18</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">56dd500411d03c5e9927a1eb55621e906837a83b02350a9dc401247d0353717c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6915fc9fa6b3ec3569566832e1bb03bd801c12cea030200e68663b9a87974e76</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5f1519b080d8ce0a814f17ad9fb49fb3a1d4d7ce5891f5c85fc38631ca3a8dc4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7036316cc26b93e401cedd781a579be606dad174829e6ad9e9c5a0da6e036f80</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="sortedcontainers@2.4.0">
+      <name>sortedcontainers</name>
+      <version>2.4.0</version>
+      <description>Sorted Containers -- Sorted List, Sorted Dict, Sorted Set</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/sortedcontainers@2.4.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/sortedcontainers/#sortedcontainers-2.4.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/sortedcontainers/#sortedcontainers-2.4.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="uri-template@1.3.0">
+      <name>uri-template</name>
+      <version>1.3.0</version>
+      <description>RFC 6570 URI Template Processor</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/uri-template@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uri-template/#uri-template-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uri-template/#uri_template-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="webcolors@1.13">
+      <name>webcolors</name>
+      <version>1.13</version>
+      <description>A library for working with the color formats defined by HTML and CSS.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/webcolors@1.13</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/webcolors/#webcolors-1.13-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/webcolors/#webcolors-1.13.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="zipp@3.17.0">
+      <name>zipp</name>
+      <version>3.17.0</version>
+      <description>Backport of pathlib-compatible object wrapper for zip files</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/zipp@3.17.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/zipp/#zipp-3.17.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/zipp/#zipp-3.17.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="attrs@23.1.0"/>
+    <dependency ref="boolean-py@4.0"/>
+    <dependency ref="cyclonedx-python-lib@5.1.1">
+      <dependency ref="jsonschema@4.19.2"/>
+      <dependency ref="license-expression@30.1.1"/>
+      <dependency ref="lxml@4.9.3"/>
+      <dependency ref="packageurl-python@0.11.2"/>
+      <dependency ref="py-serializable@0.15.0"/>
+      <dependency ref="sortedcontainers@2.4.0"/>
+    </dependency>
+    <dependency ref="defusedxml@0.7.1"/>
+    <dependency ref="fqdn@1.5.1"/>
+    <dependency ref="idna@3.4"/>
+    <dependency ref="importlib-resources@6.1.1">
+      <dependency ref="zipp@3.17.0"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="jsonpointer@2.4"/>
+    <dependency ref="jsonschema-specifications@2023.7.1">
+      <dependency ref="importlib-resources@6.1.1"/>
+      <dependency ref="referencing@0.30.2"/>
+    </dependency>
+    <dependency ref="jsonschema@4.19.2">
+      <dependency ref="attrs@23.1.0"/>
+      <dependency ref="fqdn@1.5.1"/>
+      <dependency ref="idna@3.4"/>
+      <dependency ref="importlib-resources@6.1.1"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="jsonpointer@2.4"/>
+      <dependency ref="jsonschema-specifications@2023.7.1"/>
+      <dependency ref="pkgutil-resolve-name@1.3.10"/>
+      <dependency ref="referencing@0.30.2"/>
+      <dependency ref="rfc3339-validator@0.1.4"/>
+      <dependency ref="rfc3987@1.3.8"/>
+      <dependency ref="rpds-py@0.12.0"/>
+      <dependency ref="uri-template@1.3.0"/>
+      <dependency ref="webcolors@1.13"/>
+    </dependency>
+    <dependency ref="license-expression@30.1.1">
+      <dependency ref="boolean-py@4.0"/>
+    </dependency>
+    <dependency ref="lxml@4.9.3"/>
+    <dependency ref="packageurl-python@0.11.2"/>
+    <dependency ref="pkgutil-resolve-name@1.3.10"/>
+    <dependency ref="py-serializable@0.15.0">
+      <dependency ref="defusedxml@0.7.1"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="referencing@0.30.2">
+      <dependency ref="attrs@23.1.0"/>
+      <dependency ref="rpds-py@0.12.0"/>
+    </dependency>
+    <dependency ref="rfc3339-validator@0.1.4">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="rfc3987@1.3.8"/>
+    <dependency ref="rpds-py@0.12.0"/>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="sortedcontainers@2.4.0"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+    <dependency ref="uri-template@1.3.0"/>
+    <dependency ref="webcolors@1.13"/>
+    <dependency ref="with-extras">
+      <dependency ref="cyclonedx-python-lib@5.1.1"/>
+    </dependency>
+    <dependency ref="zipp@3.17.0"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/some-groups-lock11-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/some-groups-lock11-1.5.json.bin
@@ -1,0 +1,341 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        },
+        {
+          "name": "cdx:poetry:group",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        },
+        {
+          "name": "cdx:poetry:group",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6",
+        "isoduration@20.11.0",
+        "toml@0.10.2"
+      ],
+      "ref": "group-deps"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "group-deps",
+      "description": "dependencies organized in groups",
+      "name": "group-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/some-groups-lock11-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/some-groups-lock11-1.5.xml.bin
@@ -1,0 +1,250 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="group-deps">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>group-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+        <property name="cdx:poetry:group">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+        <property name="cdx:poetry:group">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="group-deps">
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/some-groups-lock20-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/some-groups-lock20-1.5.json.bin
@@ -1,0 +1,309 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6",
+        "isoduration@20.11.0",
+        "toml@0.10.2"
+      ],
+      "ref": "group-deps"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "group-deps",
+      "description": "dependencies organized in groups",
+      "name": "group-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/some-groups-lock20-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/some-groups-lock20-1.5.xml.bin
@@ -1,0 +1,236 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="group-deps">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>group-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="group-deps">
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/with-extras-lock10-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/with-extras-lock10-1.5.json.bin
@@ -1,0 +1,29 @@
+{
+  "dependencies": [
+    {
+      "ref": "with-extras"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "with-extras",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/with-extras-lock10-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/with-extras-lock10-1.5.xml.bin
@@ -1,0 +1,53 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-extras">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+    </component>
+  </metadata>
+  <dependencies>
+    <dependency ref="with-extras"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/with-extras-lock11-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/with-extras-lock11-1.5.json.bin
@@ -1,0 +1,29 @@
+{
+  "dependencies": [
+    {
+      "ref": "with-extras"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "with-extras",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/with-extras-lock11-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/with-extras-lock11-1.5.xml.bin
@@ -1,0 +1,53 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-extras">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+    </component>
+  </metadata>
+  <dependencies>
+    <dependency ref="with-extras"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/with-extras-lock20-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/with-extras-lock20-1.5.json.bin
@@ -1,0 +1,29 @@
+{
+  "dependencies": [
+    {
+      "ref": "with-extras"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "with-extras",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/with-extras-lock20-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/with-extras-lock20-1.5.xml.bin
@@ -1,0 +1,53 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-extras">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+    </component>
+  </metadata>
+  <dependencies>
+    <dependency ref="with-extras"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/with-urls-lock10-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/with-urls-lock10-1.5.json.bin
@@ -1,0 +1,146 @@
+{
+  "components": [
+    {
+      "bom-ref": "Pillow@10.1.0",
+      "description": "Python Imaging Library (Fork)",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+https://github.com/python-pillow/Pillow.git#da59ad000d1405eaecd557175e29083a87d19f7c"
+        }
+      ],
+      "name": "Pillow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:poetry:source:package:reference",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        }
+      ],
+      "purl": "pkg:pypi/pillow@10.1.0?vcs_url=git%2Bhttps://github.com/python-pillow/Pillow.git%40da59ad000d1405eaecd557175e29083a87d19f7c",
+      "type": "library",
+      "version": "10.1.0"
+    },
+    {
+      "bom-ref": "numpy@1.24.4",
+      "description": "Fundamental package for array computing in Python",
+      "externalReferences": [
+        {
+          "comment": "from url",
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/a4/9b/027bec52c633f6556dba6b722d9a0befb40498b9ceddd29cbe67a45a127c/numpy-1.24.4.tar.gz"
+        }
+      ],
+      "name": "numpy",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/numpy@1.24.4",
+      "type": "library",
+      "version": "1.24.4"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+ssh://git@github.com/benjaminp/six.git#65486e4383f9f411da95937451205d3c7b61b9e1"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:poetry:source:package:reference",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0?vcs_url=git%2Bssh://git%40github.com/benjaminp/six.git%4065486e4383f9f411da95937451205d3c7b61b9e1",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "wxPython@4.2.2a1.dev5618+1f82021f",
+      "description": "Cross platform GUI toolkit for Python, \"Phoenix\" version",
+      "externalReferences": [
+        {
+          "comment": "from url",
+          "type": "distribution",
+          "url": "https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618+1f82021f-cp38-cp38-win32.whl"
+        }
+      ],
+      "name": "wxPython",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/wxpython@4.2.2a1.dev5618%2B1f82021f?download_url=https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618%2B1f82021f-cp38-cp38-win32.whl",
+      "type": "library",
+      "version": "4.2.2a1.dev5618+1f82021f"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "Pillow@10.1.0"
+    },
+    {
+      "ref": "numpy@1.24.4"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "dependsOn": [
+        "Pillow@10.1.0",
+        "numpy@1.24.4",
+        "six@1.16.0",
+        "wxPython@4.2.2a1.dev5618+1f82021f"
+      ],
+      "ref": "with-urls"
+    },
+    {
+      "dependsOn": [
+        "Pillow@10.1.0",
+        "numpy@1.24.4",
+        "six@1.16.0"
+      ],
+      "ref": "wxPython@4.2.2a1.dev5618+1f82021f"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "with-urls",
+      "description": "packages from direct urls",
+      "name": "with-urls",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/with-urls-lock10-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/with-urls-lock10-1.5.xml.bin
@@ -1,0 +1,130 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-urls">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>with-urls</name>
+      <version>0.1.0</version>
+      <description>packages from direct urls</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="Pillow@10.1.0">
+      <name>Pillow</name>
+      <version>10.1.0</version>
+      <description>Python Imaging Library (Fork)</description>
+      <purl>pkg:pypi/pillow@10.1.0?vcs_url=git%2Bhttps://github.com/python-pillow/Pillow.git%40da59ad000d1405eaecd557175e29083a87d19f7c</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/python-pillow/Pillow.git#da59ad000d1405eaecd557175e29083a87d19f7c</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:source:package:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="numpy@1.24.4">
+      <name>numpy</name>
+      <version>1.24.4</version>
+      <description>Fundamental package for array computing in Python</description>
+      <purl>pkg:pypi/numpy@1.24.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/a4/9b/027bec52c633f6556dba6b722d9a0befb40498b9ceddd29cbe67a45a127c/numpy-1.24.4.tar.gz</url>
+          <comment>from url</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0?vcs_url=git%2Bssh://git%40github.com/benjaminp/six.git%4065486e4383f9f411da95937451205d3c7b61b9e1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+ssh://git@github.com/benjaminp/six.git#65486e4383f9f411da95937451205d3c7b61b9e1</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:source:package:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">
+      <name>wxPython</name>
+      <version>4.2.2a1.dev5618+1f82021f</version>
+      <description>Cross platform GUI toolkit for Python, &quot;Phoenix&quot; version</description>
+      <purl>pkg:pypi/wxpython@4.2.2a1.dev5618%2B1f82021f?download_url=https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618%2B1f82021f-cp38-cp38-win32.whl</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618+1f82021f-cp38-cp38-win32.whl</url>
+          <comment>from url</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="Pillow@10.1.0"/>
+    <dependency ref="numpy@1.24.4"/>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="with-urls">
+      <dependency ref="Pillow@10.1.0"/>
+      <dependency ref="numpy@1.24.4"/>
+      <dependency ref="six@1.16.0"/>
+      <dependency ref="wxPython@4.2.2a1.dev5618+1f82021f"/>
+    </dependency>
+    <dependency ref="wxPython@4.2.2a1.dev5618+1f82021f">
+      <dependency ref="Pillow@10.1.0"/>
+      <dependency ref="numpy@1.24.4"/>
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/with-urls-lock11-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/with-urls-lock11-1.5.json.bin
@@ -1,0 +1,154 @@
+{
+  "components": [
+    {
+      "bom-ref": "Pillow@10.1.0",
+      "description": "Python Imaging Library (Fork)",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+https://github.com/python-pillow/Pillow.git#da59ad000d1405eaecd557175e29083a87d19f7c"
+        }
+      ],
+      "name": "Pillow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:poetry:package:source:resolved_reference",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
+          "name": "cdx:poetry:source:package:reference",
+          "value": "10.1.0"
+        }
+      ],
+      "purl": "pkg:pypi/pillow@10.1.0?vcs_url=git%2Bhttps://github.com/python-pillow/Pillow.git%40da59ad000d1405eaecd557175e29083a87d19f7c",
+      "type": "library",
+      "version": "10.1.0"
+    },
+    {
+      "bom-ref": "numpy@1.24.4",
+      "description": "Fundamental package for array computing in Python",
+      "externalReferences": [
+        {
+          "comment": "from url",
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/a4/9b/027bec52c633f6556dba6b722d9a0befb40498b9ceddd29cbe67a45a127c/numpy-1.24.4.tar.gz"
+        }
+      ],
+      "name": "numpy",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/numpy@1.24.4",
+      "type": "library",
+      "version": "1.24.4"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+ssh://git@github.com/benjaminp/six.git#65486e4383f9f411da95937451205d3c7b61b9e1"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:poetry:package:source:resolved_reference",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
+          "name": "cdx:poetry:source:package:reference",
+          "value": "1.16.0"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0?vcs_url=git%2Bssh://git%40github.com/benjaminp/six.git%4065486e4383f9f411da95937451205d3c7b61b9e1",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "wxPython@4.2.2a1.dev5618+1f82021f",
+      "description": "Cross platform GUI toolkit for Python, \"Phoenix\" version",
+      "externalReferences": [
+        {
+          "comment": "from url",
+          "type": "distribution",
+          "url": "https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618+1f82021f-cp38-cp38-win32.whl"
+        }
+      ],
+      "name": "wxPython",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/wxpython@4.2.2a1.dev5618%2B1f82021f?download_url=https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618%2B1f82021f-cp38-cp38-win32.whl",
+      "type": "library",
+      "version": "4.2.2a1.dev5618+1f82021f"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "Pillow@10.1.0"
+    },
+    {
+      "ref": "numpy@1.24.4"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "dependsOn": [
+        "Pillow@10.1.0",
+        "numpy@1.24.4",
+        "six@1.16.0",
+        "wxPython@4.2.2a1.dev5618+1f82021f"
+      ],
+      "ref": "with-urls"
+    },
+    {
+      "dependsOn": [
+        "Pillow@10.1.0",
+        "numpy@1.24.4",
+        "six@1.16.0"
+      ],
+      "ref": "wxPython@4.2.2a1.dev5618+1f82021f"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "with-urls",
+      "description": "packages from direct urls",
+      "name": "with-urls",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/with-urls-lock11-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/with-urls-lock11-1.5.xml.bin
@@ -1,0 +1,132 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-urls">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>with-urls</name>
+      <version>0.1.0</version>
+      <description>packages from direct urls</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="Pillow@10.1.0">
+      <name>Pillow</name>
+      <version>10.1.0</version>
+      <description>Python Imaging Library (Fork)</description>
+      <purl>pkg:pypi/pillow@10.1.0?vcs_url=git%2Bhttps://github.com/python-pillow/Pillow.git%40da59ad000d1405eaecd557175e29083a87d19f7c</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/python-pillow/Pillow.git#da59ad000d1405eaecd557175e29083a87d19f7c</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+        <property name="cdx:poetry:source:package:reference">10.1.0</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="numpy@1.24.4">
+      <name>numpy</name>
+      <version>1.24.4</version>
+      <description>Fundamental package for array computing in Python</description>
+      <purl>pkg:pypi/numpy@1.24.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/a4/9b/027bec52c633f6556dba6b722d9a0befb40498b9ceddd29cbe67a45a127c/numpy-1.24.4.tar.gz</url>
+          <comment>from url</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0?vcs_url=git%2Bssh://git%40github.com/benjaminp/six.git%4065486e4383f9f411da95937451205d3c7b61b9e1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+ssh://git@github.com/benjaminp/six.git#65486e4383f9f411da95937451205d3c7b61b9e1</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+        <property name="cdx:poetry:source:package:reference">1.16.0</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">
+      <name>wxPython</name>
+      <version>4.2.2a1.dev5618+1f82021f</version>
+      <description>Cross platform GUI toolkit for Python, &quot;Phoenix&quot; version</description>
+      <purl>pkg:pypi/wxpython@4.2.2a1.dev5618%2B1f82021f?download_url=https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618%2B1f82021f-cp38-cp38-win32.whl</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618+1f82021f-cp38-cp38-win32.whl</url>
+          <comment>from url</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="Pillow@10.1.0"/>
+    <dependency ref="numpy@1.24.4"/>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="with-urls">
+      <dependency ref="Pillow@10.1.0"/>
+      <dependency ref="numpy@1.24.4"/>
+      <dependency ref="six@1.16.0"/>
+      <dependency ref="wxPython@4.2.2a1.dev5618+1f82021f"/>
+    </dependency>
+    <dependency ref="wxPython@4.2.2a1.dev5618+1f82021f">
+      <dependency ref="Pillow@10.1.0"/>
+      <dependency ref="numpy@1.24.4"/>
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/with-urls-lock20-1.5.json.bin
+++ b/tests/_data/snapshots/poetry/with-urls-lock20-1.5.json.bin
@@ -1,0 +1,166 @@
+{
+  "components": [
+    {
+      "bom-ref": "Pillow@10.1.0",
+      "description": "Python Imaging Library (Fork)",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+https://github.com/python-pillow/Pillow.git#da59ad000d1405eaecd557175e29083a87d19f7c"
+        }
+      ],
+      "name": "Pillow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:poetry:package:source:resolved_reference",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
+          "name": "cdx:poetry:source:package:reference",
+          "value": "10.1.0"
+        }
+      ],
+      "purl": "pkg:pypi/pillow@10.1.0?vcs_url=git%2Bhttps://github.com/python-pillow/Pillow.git%40da59ad000d1405eaecd557175e29083a87d19f7c",
+      "type": "library",
+      "version": "10.1.0"
+    },
+    {
+      "bom-ref": "numpy@1.24.4",
+      "description": "Fundamental package for array computing in Python",
+      "externalReferences": [
+        {
+          "comment": "from url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "80f5e3a4e498641401868df4208b74581206afbee7cf7b8329daae82676d9463"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/a4/9b/027bec52c633f6556dba6b722d9a0befb40498b9ceddd29cbe67a45a127c/numpy-1.24.4.tar.gz"
+        }
+      ],
+      "name": "numpy",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/numpy@1.24.4",
+      "type": "library",
+      "version": "1.24.4"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+ssh://git@github.com/benjaminp/six.git#65486e4383f9f411da95937451205d3c7b61b9e1"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:poetry:package:source:resolved_reference",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
+          "name": "cdx:poetry:source:package:reference",
+          "value": "1.16.0"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0?vcs_url=git%2Bssh://git%40github.com/benjaminp/six.git%4065486e4383f9f411da95937451205d3c7b61b9e1",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "wxPython@4.2.2a1.dev5618+1f82021f",
+      "description": "Cross platform GUI toolkit for Python, \"Phoenix\" version",
+      "externalReferences": [
+        {
+          "comment": "from url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6ebb5019c6b999941a6cddd298dff7951d826239d663f6ce698b9547ae72d6b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618+1f82021f-cp38-cp38-win32.whl"
+        }
+      ],
+      "name": "wxPython",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/wxpython@4.2.2a1.dev5618%2B1f82021f?download_url=https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618%2B1f82021f-cp38-cp38-win32.whl",
+      "type": "library",
+      "version": "4.2.2a1.dev5618+1f82021f"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "Pillow@10.1.0"
+    },
+    {
+      "ref": "numpy@1.24.4"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "dependsOn": [
+        "Pillow@10.1.0",
+        "numpy@1.24.4",
+        "six@1.16.0",
+        "wxPython@4.2.2a1.dev5618+1f82021f"
+      ],
+      "ref": "with-urls"
+    },
+    {
+      "dependsOn": [
+        "Pillow@10.1.0",
+        "numpy@1.24.4",
+        "six@1.16.0"
+      ],
+      "ref": "wxPython@4.2.2a1.dev5618+1f82021f"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "author": "Your Name <you@example.com>",
+      "bom-ref": "with-urls",
+      "description": "packages from direct urls",
+      "name": "with-urls",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/poetry/with-urls-lock20-1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/with-urls-lock20-1.5.xml.bin
@@ -1,0 +1,138 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-urls">
+      <author>Your Name &lt;you@example.com&gt;</author>
+      <name>with-urls</name>
+      <version>0.1.0</version>
+      <description>packages from direct urls</description>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="Pillow@10.1.0">
+      <name>Pillow</name>
+      <version>10.1.0</version>
+      <description>Python Imaging Library (Fork)</description>
+      <purl>pkg:pypi/pillow@10.1.0?vcs_url=git%2Bhttps://github.com/python-pillow/Pillow.git%40da59ad000d1405eaecd557175e29083a87d19f7c</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/python-pillow/Pillow.git#da59ad000d1405eaecd557175e29083a87d19f7c</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+        <property name="cdx:poetry:source:package:reference">10.1.0</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="numpy@1.24.4">
+      <name>numpy</name>
+      <version>1.24.4</version>
+      <description>Fundamental package for array computing in Python</description>
+      <purl>pkg:pypi/numpy@1.24.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/a4/9b/027bec52c633f6556dba6b722d9a0befb40498b9ceddd29cbe67a45a127c/numpy-1.24.4.tar.gz</url>
+          <comment>from url</comment>
+          <hashes>
+            <hash alg="SHA-256">80f5e3a4e498641401868df4208b74581206afbee7cf7b8329daae82676d9463</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0?vcs_url=git%2Bssh://git%40github.com/benjaminp/six.git%4065486e4383f9f411da95937451205d3c7b61b9e1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+ssh://git@github.com/benjaminp/six.git#65486e4383f9f411da95937451205d3c7b61b9e1</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+        <property name="cdx:poetry:source:package:reference">1.16.0</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">
+      <name>wxPython</name>
+      <version>4.2.2a1.dev5618+1f82021f</version>
+      <description>Cross platform GUI toolkit for Python, &quot;Phoenix&quot; version</description>
+      <purl>pkg:pypi/wxpython@4.2.2a1.dev5618%2B1f82021f?download_url=https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618%2B1f82021f-cp38-cp38-win32.whl</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618+1f82021f-cp38-cp38-win32.whl</url>
+          <comment>from url</comment>
+          <hashes>
+            <hash alg="SHA-256">6ebb5019c6b999941a6cddd298dff7951d826239d663f6ce698b9547ae72d6b9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="Pillow@10.1.0"/>
+    <dependency ref="numpy@1.24.4"/>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="with-urls">
+      <dependency ref="Pillow@10.1.0"/>
+      <dependency ref="numpy@1.24.4"/>
+      <dependency ref="six@1.16.0"/>
+      <dependency ref="wxPython@4.2.2a1.dev5618+1f82021f"/>
+    </dependency>
+    <dependency ref="wxPython@4.2.2a1.dev5618+1f82021f">
+      <dependency ref="Pillow@10.1.0"/>
+      <dependency ref="numpy@1.24.4"/>
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/frozen.txt-1.5.json-file.bin
+++ b/tests/_data/snapshots/requirements/frozen.txt-1.5.json-file.bin
@@ -1,0 +1,81 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/FooProject/"
+        }
+      ],
+      "name": "FooProject",
+      "purl": "pkg:pypi/fooproject@1.2",
+      "type": "library",
+      "version": "1.2"
+    },
+    {
+      "bom-ref": "requirements-L4",
+      "description": "requirements line 4: colorama==0.4.6",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/"
+        }
+      ],
+      "name": "colorama",
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L4"
+    },
+    {
+      "ref": "requirements-L7"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/frozen.txt-1.5.json-stream.bin
+++ b/tests/_data/snapshots/requirements/frozen.txt-1.5.json-stream.bin
@@ -1,0 +1,66 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/FooProject/"
+        }
+      ],
+      "name": "FooProject",
+      "purl": "pkg:pypi/fooproject@1.2",
+      "type": "library",
+      "version": "1.2"
+    },
+    {
+      "bom-ref": "requirements-L4",
+      "description": "requirements line 4: colorama==0.4.6",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/"
+        }
+      ],
+      "name": "colorama",
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L4"
+    },
+    {
+      "ref": "requirements-L7"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/frozen.txt-1.5.xml-file.bin
+++ b/tests/_data/snapshots/requirements/frozen.txt-1.5.xml-file.bin
@@ -1,0 +1,87 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L7">
+      <name>FooProject</name>
+      <version>1.2</version>
+      <description>requirements line 7: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</description>
+      <purl>pkg:pypi/fooproject@1.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/FooProject/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824</hash>
+            <hash alg="SHA-256">486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L4">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>requirements line 4: colorama==0.4.6</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L4"/>
+    <dependency ref="requirements-L7"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/frozen.txt-1.5.xml-stream.bin
+++ b/tests/_data/snapshots/requirements/frozen.txt-1.5.xml-stream.bin
@@ -1,0 +1,78 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L7">
+      <name>FooProject</name>
+      <version>1.2</version>
+      <description>requirements line 7: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</description>
+      <purl>pkg:pypi/fooproject@1.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/FooProject/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824</hash>
+            <hash alg="SHA-256">486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L4">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>requirements line 4: colorama==0.4.6</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L4"/>
+    <dependency ref="requirements-L7"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/local.txt-1.5.json-file.bin
+++ b/tests/_data/snapshots/requirements/local.txt-1.5.json-file.bin
@@ -1,0 +1,138 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L11",
+      "description": "requirements line 11: foo @ file://../foo",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "file://../foo"
+        }
+      ],
+      "name": "foo",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L14",
+      "description": "requirements line 14: ./downloads/numpy-1.9.2-cp34-none-win32.whl",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "./downloads/numpy-1.9.2-cp34-none-win32.whl"
+        }
+      ],
+      "name": "numpy",
+      "type": "library",
+      "version": "1.9.2"
+    },
+    {
+      "bom-ref": "requirements-L2",
+      "description": "requirements line 2: ./myproject/chardet",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "./myproject/chardet"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L5",
+      "description": "requirements line 5: ./myproject/requests --hash=sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"
+            }
+          ],
+          "type": "other",
+          "url": "./myproject/requests"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L8",
+      "description": "requirements line 8: -e ./myproject/idna.whl",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "./myproject/idna.whl"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L17",
+      "description": "requirements line 17: ./downloads/numpy-1.26.1.tar.gz",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "./downloads/numpy-1.26.1.tar.gz"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L11"
+    },
+    {
+      "ref": "requirements-L14"
+    },
+    {
+      "ref": "requirements-L17"
+    },
+    {
+      "ref": "requirements-L2"
+    },
+    {
+      "ref": "requirements-L5"
+    },
+    {
+      "ref": "requirements-L8"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/local.txt-1.5.json-stream.bin
+++ b/tests/_data/snapshots/requirements/local.txt-1.5.json-stream.bin
@@ -1,0 +1,123 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L11",
+      "description": "requirements line 11: foo @ file://../foo",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "file://../foo"
+        }
+      ],
+      "name": "foo",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L14",
+      "description": "requirements line 14: ./downloads/numpy-1.9.2-cp34-none-win32.whl",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "./downloads/numpy-1.9.2-cp34-none-win32.whl"
+        }
+      ],
+      "name": "numpy",
+      "type": "library",
+      "version": "1.9.2"
+    },
+    {
+      "bom-ref": "requirements-L2",
+      "description": "requirements line 2: ./myproject/chardet",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "./myproject/chardet"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L5",
+      "description": "requirements line 5: ./myproject/requests --hash=sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"
+            }
+          ],
+          "type": "other",
+          "url": "./myproject/requests"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L8",
+      "description": "requirements line 8: -e ./myproject/idna.whl",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "./myproject/idna.whl"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L17",
+      "description": "requirements line 17: ./downloads/numpy-1.26.1.tar.gz",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "./downloads/numpy-1.26.1.tar.gz"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L11"
+    },
+    {
+      "ref": "requirements-L14"
+    },
+    {
+      "ref": "requirements-L17"
+    },
+    {
+      "ref": "requirements-L2"
+    },
+    {
+      "ref": "requirements-L5"
+    },
+    {
+      "ref": "requirements-L8"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/local.txt-1.5.xml-file.bin
+++ b/tests/_data/snapshots/requirements/local.txt-1.5.xml-file.bin
@@ -1,0 +1,127 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L11">
+      <name>foo</name>
+      <description>requirements line 11: foo @ file://../foo</description>
+      <externalReferences>
+        <reference type="other">
+          <url>file://../foo</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L14">
+      <name>numpy</name>
+      <version>1.9.2</version>
+      <description>requirements line 14: ./downloads/numpy-1.9.2-cp34-none-win32.whl</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./downloads/numpy-1.9.2-cp34-none-win32.whl</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L2">
+      <name>unknown</name>
+      <description>requirements line 2: ./myproject/chardet</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./myproject/chardet</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L5">
+      <name>unknown</name>
+      <description>requirements line 5: ./myproject/requests --hash=sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./myproject/requests</url>
+          <comment>explicit local path</comment>
+          <hashes>
+            <hash alg="SHA-256">27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L8">
+      <name>unknown</name>
+      <description>requirements line 8: -e ./myproject/idna.whl</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./myproject/idna.whl</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L17">
+      <name>unknown</name>
+      <description>requirements line 17: ./downloads/numpy-1.26.1.tar.gz</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./downloads/numpy-1.26.1.tar.gz</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L11"/>
+    <dependency ref="requirements-L14"/>
+    <dependency ref="requirements-L17"/>
+    <dependency ref="requirements-L2"/>
+    <dependency ref="requirements-L5"/>
+    <dependency ref="requirements-L8"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/local.txt-1.5.xml-stream.bin
+++ b/tests/_data/snapshots/requirements/local.txt-1.5.xml-stream.bin
@@ -1,0 +1,118 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L11">
+      <name>foo</name>
+      <description>requirements line 11: foo @ file://../foo</description>
+      <externalReferences>
+        <reference type="other">
+          <url>file://../foo</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L14">
+      <name>numpy</name>
+      <version>1.9.2</version>
+      <description>requirements line 14: ./downloads/numpy-1.9.2-cp34-none-win32.whl</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./downloads/numpy-1.9.2-cp34-none-win32.whl</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L2">
+      <name>unknown</name>
+      <description>requirements line 2: ./myproject/chardet</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./myproject/chardet</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L5">
+      <name>unknown</name>
+      <description>requirements line 5: ./myproject/requests --hash=sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./myproject/requests</url>
+          <comment>explicit local path</comment>
+          <hashes>
+            <hash alg="SHA-256">27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L8">
+      <name>unknown</name>
+      <description>requirements line 8: -e ./myproject/idna.whl</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./myproject/idna.whl</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L17">
+      <name>unknown</name>
+      <description>requirements line 17: ./downloads/numpy-1.26.1.tar.gz</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./downloads/numpy-1.26.1.tar.gz</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L11"/>
+    <dependency ref="requirements-L14"/>
+    <dependency ref="requirements-L17"/>
+    <dependency ref="requirements-L2"/>
+    <dependency ref="requirements-L5"/>
+    <dependency ref="requirements-L8"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/nested.txt-1.5.json-file.bin
+++ b/tests/_data/snapshots/requirements/nested.txt-1.5.json-file.bin
@@ -1,0 +1,81 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/FooProject/"
+        }
+      ],
+      "name": "FooProject",
+      "purl": "pkg:pypi/fooproject@1.2",
+      "type": "library",
+      "version": "1.2"
+    },
+    {
+      "bom-ref": "requirements-L4",
+      "description": "requirements line 4: colorama==0.4.6",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/"
+        }
+      ],
+      "name": "colorama",
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L4"
+    },
+    {
+      "ref": "requirements-L7"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/nested.txt-1.5.json-stream.bin
+++ b/tests/_data/snapshots/requirements/nested.txt-1.5.json-stream.bin
@@ -1,0 +1,16 @@
+{
+  "metadata": {
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/nested.txt-1.5.xml-file.bin
+++ b/tests/_data/snapshots/requirements/nested.txt-1.5.xml-file.bin
@@ -1,0 +1,87 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L7">
+      <name>FooProject</name>
+      <version>1.2</version>
+      <description>requirements line 7: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</description>
+      <purl>pkg:pypi/fooproject@1.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/FooProject/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824</hash>
+            <hash alg="SHA-256">486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L4">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>requirements line 4: colorama==0.4.6</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L4"/>
+    <dependency ref="requirements-L7"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/nested.txt-1.5.xml-stream.bin
+++ b/tests/_data/snapshots/requirements/nested.txt-1.5.xml-stream.bin
@@ -1,0 +1,44 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+  </metadata>
+</bom>

--- a/tests/_data/snapshots/requirements/private-packages.txt-1.5.json-file.bin
+++ b/tests/_data/snapshots/requirements/private-packages.txt-1.5.json-file.bin
@@ -1,0 +1,63 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: my-package==1.2.3",
+      "externalReferences": [
+        {
+          "comment": "implicit dist extra-url",
+          "type": "distribution",
+          "url": "https://legacy1.pypackages.acme.org/simple//my-package/"
+        },
+        {
+          "comment": "implicit dist extra-url",
+          "type": "distribution",
+          "url": "https://legacy2.pypackages.acme.org/simple//my-package/"
+        },
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypackages.acme.org/simple//my-package/"
+        }
+      ],
+      "name": "my-package",
+      "purl": "pkg:pypi/my-package@1.2.3",
+      "type": "library",
+      "version": "1.2.3"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L7"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/private-packages.txt-1.5.json-stream.bin
+++ b/tests/_data/snapshots/requirements/private-packages.txt-1.5.json-stream.bin
@@ -1,0 +1,48 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: my-package==1.2.3",
+      "externalReferences": [
+        {
+          "comment": "implicit dist extra-url",
+          "type": "distribution",
+          "url": "https://legacy1.pypackages.acme.org/simple//my-package/"
+        },
+        {
+          "comment": "implicit dist extra-url",
+          "type": "distribution",
+          "url": "https://legacy2.pypackages.acme.org/simple//my-package/"
+        },
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypackages.acme.org/simple//my-package/"
+        }
+      ],
+      "name": "my-package",
+      "purl": "pkg:pypi/my-package@1.2.3",
+      "type": "library",
+      "version": "1.2.3"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L7"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/private-packages.txt-1.5.xml-file.bin
+++ b/tests/_data/snapshots/requirements/private-packages.txt-1.5.xml-file.bin
@@ -1,0 +1,78 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L7">
+      <name>my-package</name>
+      <version>1.2.3</version>
+      <description>requirements line 7: my-package==1.2.3</description>
+      <purl>pkg:pypi/my-package@1.2.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://legacy1.pypackages.acme.org/simple//my-package/</url>
+          <comment>implicit dist extra-url</comment>
+        </reference>
+        <reference type="distribution">
+          <url>https://legacy2.pypackages.acme.org/simple//my-package/</url>
+          <comment>implicit dist extra-url</comment>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypackages.acme.org/simple//my-package/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L7"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/private-packages.txt-1.5.xml-stream.bin
+++ b/tests/_data/snapshots/requirements/private-packages.txt-1.5.xml-stream.bin
@@ -1,0 +1,69 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L7">
+      <name>my-package</name>
+      <version>1.2.3</version>
+      <description>requirements line 7: my-package==1.2.3</description>
+      <purl>pkg:pypi/my-package@1.2.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://legacy1.pypackages.acme.org/simple//my-package/</url>
+          <comment>implicit dist extra-url</comment>
+        </reference>
+        <reference type="distribution">
+          <url>https://legacy2.pypackages.acme.org/simple//my-package/</url>
+          <comment>implicit dist extra-url</comment>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypackages.acme.org/simple//my-package/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L7"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/regression-issue448.cp1252.txt.bin-1.5.json-stream.bin
+++ b/tests/_data/snapshots/requirements/regression-issue448.cp1252.txt.bin-1.5.json-stream.bin
@@ -1,0 +1,71 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L6",
+      "description": "requirements line 6: packageurl-python>=0.9.4",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/packageurl-python/"
+        }
+      ],
+      "name": "packageurl-python",
+      "purl": "pkg:pypi/packageurl-python",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: requirements_parser>=0.2.0",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/requirements_parser/"
+        }
+      ],
+      "name": "requirements_parser",
+      "purl": "pkg:pypi/requirements-parser",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L8",
+      "description": "requirements line 8: setuptools>=50.3.2",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/setuptools/"
+        }
+      ],
+      "name": "setuptools",
+      "purl": "pkg:pypi/setuptools",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L6"
+    },
+    {
+      "ref": "requirements-L7"
+    },
+    {
+      "ref": "requirements-L8"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/regression-issue448.cp1252.txt.bin-1.5.xml-stream.bin
+++ b/tests/_data/snapshots/requirements/regression-issue448.cp1252.txt.bin-1.5.xml-stream.bin
@@ -1,0 +1,84 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L6">
+      <name>packageurl-python</name>
+      <description>requirements line 6: packageurl-python&gt;=0.9.4</description>
+      <purl>pkg:pypi/packageurl-python</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/packageurl-python/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L7">
+      <name>requirements_parser</name>
+      <description>requirements line 7: requirements_parser&gt;=0.2.0</description>
+      <purl>pkg:pypi/requirements-parser</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/requirements_parser/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L8">
+      <name>setuptools</name>
+      <description>requirements line 8: setuptools&gt;=50.3.2</description>
+      <purl>pkg:pypi/setuptools</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/setuptools/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L6"/>
+    <dependency ref="requirements-L7"/>
+    <dependency ref="requirements-L8"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/with-comments.txt-1.5.json-file.bin
+++ b/tests/_data/snapshots/requirements/with-comments.txt-1.5.json-file.bin
@@ -1,0 +1,125 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L1",
+      "description": "requirements line 1: certifi==2021.5.30",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/"
+        }
+      ],
+      "name": "certifi",
+      "purl": "pkg:pypi/certifi@2021.5.30",
+      "type": "library",
+      "version": "2021.5.30"
+    },
+    {
+      "bom-ref": "requirements-L2",
+      "description": "requirements line 2: chardet==4.0.0",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/chardet/"
+        }
+      ],
+      "name": "chardet",
+      "purl": "pkg:pypi/chardet@4.0.0",
+      "type": "library",
+      "version": "4.0.0"
+    },
+    {
+      "bom-ref": "requirements-L3",
+      "description": "requirements line 3: idna==2.10",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/"
+        }
+      ],
+      "name": "idna",
+      "purl": "pkg:pypi/idna@2.10",
+      "type": "library",
+      "version": "2.10"
+    },
+    {
+      "bom-ref": "requirements-L4",
+      "description": "requirements line 4: requests==2.25.1",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/requests/"
+        }
+      ],
+      "name": "requests",
+      "purl": "pkg:pypi/requests@2.25.1",
+      "type": "library",
+      "version": "2.25.1"
+    },
+    {
+      "bom-ref": "requirements-L5",
+      "description": "requirements line 5: urllib3==1.26.5",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/urllib3/"
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3@1.26.5",
+      "type": "library",
+      "version": "1.26.5"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L1"
+    },
+    {
+      "ref": "requirements-L2"
+    },
+    {
+      "ref": "requirements-L3"
+    },
+    {
+      "ref": "requirements-L4"
+    },
+    {
+      "ref": "requirements-L5"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/with-comments.txt-1.5.json-stream.bin
+++ b/tests/_data/snapshots/requirements/with-comments.txt-1.5.json-stream.bin
@@ -1,0 +1,110 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L1",
+      "description": "requirements line 1: certifi==2021.5.30",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/"
+        }
+      ],
+      "name": "certifi",
+      "purl": "pkg:pypi/certifi@2021.5.30",
+      "type": "library",
+      "version": "2021.5.30"
+    },
+    {
+      "bom-ref": "requirements-L2",
+      "description": "requirements line 2: chardet==4.0.0",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/chardet/"
+        }
+      ],
+      "name": "chardet",
+      "purl": "pkg:pypi/chardet@4.0.0",
+      "type": "library",
+      "version": "4.0.0"
+    },
+    {
+      "bom-ref": "requirements-L3",
+      "description": "requirements line 3: idna==2.10",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/"
+        }
+      ],
+      "name": "idna",
+      "purl": "pkg:pypi/idna@2.10",
+      "type": "library",
+      "version": "2.10"
+    },
+    {
+      "bom-ref": "requirements-L4",
+      "description": "requirements line 4: requests==2.25.1",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/requests/"
+        }
+      ],
+      "name": "requests",
+      "purl": "pkg:pypi/requests@2.25.1",
+      "type": "library",
+      "version": "2.25.1"
+    },
+    {
+      "bom-ref": "requirements-L5",
+      "description": "requirements line 5: urllib3==1.26.5",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/urllib3/"
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3@1.26.5",
+      "type": "library",
+      "version": "1.26.5"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L1"
+    },
+    {
+      "ref": "requirements-L2"
+    },
+    {
+      "ref": "requirements-L3"
+    },
+    {
+      "ref": "requirements-L4"
+    },
+    {
+      "ref": "requirements-L5"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/with-comments.txt-1.5.xml-file.bin
+++ b/tests/_data/snapshots/requirements/with-comments.txt-1.5.xml-file.bin
@@ -1,0 +1,122 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L1">
+      <name>certifi</name>
+      <version>2021.5.30</version>
+      <description>requirements line 1: certifi==2021.5.30</description>
+      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L2">
+      <name>chardet</name>
+      <version>4.0.0</version>
+      <description>requirements line 2: chardet==4.0.0</description>
+      <purl>pkg:pypi/chardet@4.0.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/chardet/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L3">
+      <name>idna</name>
+      <version>2.10</version>
+      <description>requirements line 3: idna==2.10</description>
+      <purl>pkg:pypi/idna@2.10</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L4">
+      <name>requests</name>
+      <version>2.25.1</version>
+      <description>requirements line 4: requests==2.25.1</description>
+      <purl>pkg:pypi/requests@2.25.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/requests/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L5">
+      <name>urllib3</name>
+      <version>1.26.5</version>
+      <description>requirements line 5: urllib3==1.26.5</description>
+      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/urllib3/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L1"/>
+    <dependency ref="requirements-L2"/>
+    <dependency ref="requirements-L3"/>
+    <dependency ref="requirements-L4"/>
+    <dependency ref="requirements-L5"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/with-comments.txt-1.5.xml-stream.bin
+++ b/tests/_data/snapshots/requirements/with-comments.txt-1.5.xml-stream.bin
@@ -1,0 +1,113 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L1">
+      <name>certifi</name>
+      <version>2021.5.30</version>
+      <description>requirements line 1: certifi==2021.5.30</description>
+      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L2">
+      <name>chardet</name>
+      <version>4.0.0</version>
+      <description>requirements line 2: chardet==4.0.0</description>
+      <purl>pkg:pypi/chardet@4.0.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/chardet/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L3">
+      <name>idna</name>
+      <version>2.10</version>
+      <description>requirements line 3: idna==2.10</description>
+      <purl>pkg:pypi/idna@2.10</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L4">
+      <name>requests</name>
+      <version>2.25.1</version>
+      <description>requirements line 4: requests==2.25.1</description>
+      <purl>pkg:pypi/requests@2.25.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/requests/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L5">
+      <name>urllib3</name>
+      <version>1.26.5</version>
+      <description>requirements line 5: urllib3==1.26.5</description>
+      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/urllib3/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L1"/>
+    <dependency ref="requirements-L2"/>
+    <dependency ref="requirements-L3"/>
+    <dependency ref="requirements-L4"/>
+    <dependency ref="requirements-L5"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/with-extras.txt-1.5.json-file.bin
+++ b/tests/_data/snapshots/requirements/with-extras.txt-1.5.json-file.bin
@@ -1,0 +1,63 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L3",
+      "description": "requirements line 3: cyclonedx-python-lib[json-validation,xml-validation] == 5.1.1",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/cyclonedx-python-lib/"
+        }
+      ],
+      "name": "cyclonedx-python-lib",
+      "properties": [
+        {
+          "name": "cdx:python:package:extra",
+          "value": "json-validation"
+        },
+        {
+          "name": "cdx:python:package:extra",
+          "value": "xml-validation"
+        }
+      ],
+      "purl": "pkg:pypi/cyclonedx-python-lib@5.1.1",
+      "type": "library",
+      "version": "5.1.1"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L3"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/with-extras.txt-1.5.json-stream.bin
+++ b/tests/_data/snapshots/requirements/with-extras.txt-1.5.json-stream.bin
@@ -1,0 +1,48 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L3",
+      "description": "requirements line 3: cyclonedx-python-lib[json-validation,xml-validation] == 5.1.1",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/cyclonedx-python-lib/"
+        }
+      ],
+      "name": "cyclonedx-python-lib",
+      "properties": [
+        {
+          "name": "cdx:python:package:extra",
+          "value": "json-validation"
+        },
+        {
+          "name": "cdx:python:package:extra",
+          "value": "xml-validation"
+        }
+      ],
+      "purl": "pkg:pypi/cyclonedx-python-lib@5.1.1",
+      "type": "library",
+      "version": "5.1.1"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L3"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/with-extras.txt-1.5.xml-file.bin
+++ b/tests/_data/snapshots/requirements/with-extras.txt-1.5.xml-file.bin
@@ -1,0 +1,74 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L3">
+      <name>cyclonedx-python-lib</name>
+      <version>5.1.1</version>
+      <description>requirements line 3: cyclonedx-python-lib[json-validation,xml-validation] == 5.1.1</description>
+      <purl>pkg:pypi/cyclonedx-python-lib@5.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/cyclonedx-python-lib/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:python:package:extra">json-validation</property>
+        <property name="cdx:python:package:extra">xml-validation</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L3"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/with-extras.txt-1.5.xml-stream.bin
+++ b/tests/_data/snapshots/requirements/with-extras.txt-1.5.xml-stream.bin
@@ -1,0 +1,65 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L3">
+      <name>cyclonedx-python-lib</name>
+      <version>5.1.1</version>
+      <description>requirements line 3: cyclonedx-python-lib[json-validation,xml-validation] == 5.1.1</description>
+      <purl>pkg:pypi/cyclonedx-python-lib@5.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/cyclonedx-python-lib/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:python:package:extra">json-validation</property>
+        <property name="cdx:python:package:extra">xml-validation</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L3"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/with-hashes.txt-1.5.json-file.bin
+++ b/tests/_data/snapshots/requirements/with-hashes.txt-1.5.json-file.bin
@@ -1,0 +1,164 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L11",
+      "description": "requirements line 11: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/FooProject/"
+        }
+      ],
+      "name": "FooProject",
+      "purl": "pkg:pypi/fooproject@1.2",
+      "type": "library",
+      "version": "1.2"
+    },
+    {
+      "bom-ref": "requirements-L4",
+      "description": "requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/"
+        }
+      ],
+      "name": "certifi",
+      "purl": "pkg:pypi/certifi@2021.5.30",
+      "type": "library",
+      "version": "2021.5.30"
+    },
+    {
+      "bom-ref": "requirements-L16",
+      "description": "requirements line 16: colorama @ https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz     --hash=md5:9854316552d41419b678d39af443a75f     --hash=sha1:aa1fc7722b9128a3c945048de03f5b4e55157c6a",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "hashes": [
+            {
+              "alg": "MD5",
+              "content": "9854316552d41419b678d39af443a75f"
+            },
+            {
+              "alg": "SHA-1",
+              "content": "aa1fc7722b9128a3c945048de03f5b4e55157c6a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "purl": "pkg:pypi/colorama?download_url=https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L21",
+      "description": "requirements line 21: something == 1.33.7 --hash=foo:something-invalid",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/something/"
+        }
+      ],
+      "name": "something",
+      "purl": "pkg:pypi/something@1.33.7",
+      "type": "library",
+      "version": "1.33.7"
+    },
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/urllib3/"
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3@1.26.5",
+      "type": "library",
+      "version": "1.26.5"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L11"
+    },
+    {
+      "ref": "requirements-L16"
+    },
+    {
+      "ref": "requirements-L21"
+    },
+    {
+      "ref": "requirements-L4"
+    },
+    {
+      "ref": "requirements-L7"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/with-hashes.txt-1.5.json-stream.bin
+++ b/tests/_data/snapshots/requirements/with-hashes.txt-1.5.json-stream.bin
@@ -1,0 +1,149 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L11",
+      "description": "requirements line 11: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/FooProject/"
+        }
+      ],
+      "name": "FooProject",
+      "purl": "pkg:pypi/fooproject@1.2",
+      "type": "library",
+      "version": "1.2"
+    },
+    {
+      "bom-ref": "requirements-L4",
+      "description": "requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/"
+        }
+      ],
+      "name": "certifi",
+      "purl": "pkg:pypi/certifi@2021.5.30",
+      "type": "library",
+      "version": "2021.5.30"
+    },
+    {
+      "bom-ref": "requirements-L16",
+      "description": "requirements line 16: colorama @ https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz     --hash=md5:9854316552d41419b678d39af443a75f     --hash=sha1:aa1fc7722b9128a3c945048de03f5b4e55157c6a",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "hashes": [
+            {
+              "alg": "MD5",
+              "content": "9854316552d41419b678d39af443a75f"
+            },
+            {
+              "alg": "SHA-1",
+              "content": "aa1fc7722b9128a3c945048de03f5b4e55157c6a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "purl": "pkg:pypi/colorama?download_url=https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L21",
+      "description": "requirements line 21: something == 1.33.7 --hash=foo:something-invalid",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/something/"
+        }
+      ],
+      "name": "something",
+      "purl": "pkg:pypi/something@1.33.7",
+      "type": "library",
+      "version": "1.33.7"
+    },
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/urllib3/"
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3@1.26.5",
+      "type": "library",
+      "version": "1.26.5"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L11"
+    },
+    {
+      "ref": "requirements-L16"
+    },
+    {
+      "ref": "requirements-L21"
+    },
+    {
+      "ref": "requirements-L4"
+    },
+    {
+      "ref": "requirements-L7"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/with-hashes.txt-1.5.xml-file.bin
+++ b/tests/_data/snapshots/requirements/with-hashes.txt-1.5.xml-file.bin
@@ -1,0 +1,137 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L11">
+      <name>FooProject</name>
+      <version>1.2</version>
+      <description>requirements line 11: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</description>
+      <purl>pkg:pypi/fooproject@1.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/FooProject/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824</hash>
+            <hash alg="SHA-256">486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L4">
+      <name>certifi</name>
+      <version>2021.5.30</version>
+      <description>requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</description>
+      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee</hash>
+            <hash alg="SHA-256">50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L16">
+      <name>colorama</name>
+      <description>requirements line 16: colorama @ https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz     --hash=md5:9854316552d41419b678d39af443a75f     --hash=sha1:aa1fc7722b9128a3c945048de03f5b4e55157c6a</description>
+      <purl>pkg:pypi/colorama?download_url=https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz</url>
+          <comment>explicit dist url</comment>
+          <hashes>
+            <hash alg="MD5">9854316552d41419b678d39af443a75f</hash>
+            <hash alg="SHA-1">aa1fc7722b9128a3c945048de03f5b4e55157c6a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L21">
+      <name>something</name>
+      <version>1.33.7</version>
+      <description>requirements line 21: something == 1.33.7 --hash=foo:something-invalid</description>
+      <purl>pkg:pypi/something@1.33.7</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/something/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L7">
+      <name>urllib3</name>
+      <version>1.26.5</version>
+      <description>requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</description>
+      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/urllib3/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c</hash>
+            <hash alg="SHA-256">a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L11"/>
+    <dependency ref="requirements-L16"/>
+    <dependency ref="requirements-L21"/>
+    <dependency ref="requirements-L4"/>
+    <dependency ref="requirements-L7"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/with-hashes.txt-1.5.xml-stream.bin
+++ b/tests/_data/snapshots/requirements/with-hashes.txt-1.5.xml-stream.bin
@@ -1,0 +1,128 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L11">
+      <name>FooProject</name>
+      <version>1.2</version>
+      <description>requirements line 11: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</description>
+      <purl>pkg:pypi/fooproject@1.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/FooProject/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824</hash>
+            <hash alg="SHA-256">486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L4">
+      <name>certifi</name>
+      <version>2021.5.30</version>
+      <description>requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</description>
+      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee</hash>
+            <hash alg="SHA-256">50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L16">
+      <name>colorama</name>
+      <description>requirements line 16: colorama @ https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz     --hash=md5:9854316552d41419b678d39af443a75f     --hash=sha1:aa1fc7722b9128a3c945048de03f5b4e55157c6a</description>
+      <purl>pkg:pypi/colorama?download_url=https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz</url>
+          <comment>explicit dist url</comment>
+          <hashes>
+            <hash alg="MD5">9854316552d41419b678d39af443a75f</hash>
+            <hash alg="SHA-1">aa1fc7722b9128a3c945048de03f5b4e55157c6a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L21">
+      <name>something</name>
+      <version>1.33.7</version>
+      <description>requirements line 21: something == 1.33.7 --hash=foo:something-invalid</description>
+      <purl>pkg:pypi/something@1.33.7</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/something/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L7">
+      <name>urllib3</name>
+      <version>1.26.5</version>
+      <description>requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</description>
+      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/urllib3/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c</hash>
+            <hash alg="SHA-256">a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L11"/>
+    <dependency ref="requirements-L16"/>
+    <dependency ref="requirements-L21"/>
+    <dependency ref="requirements-L4"/>
+    <dependency ref="requirements-L7"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/with-urls.txt-1.5.json-file.bin
+++ b/tests/_data/snapshots/requirements/with-urls.txt-1.5.json-file.bin
@@ -1,0 +1,154 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L11",
+      "description": "requirements line 11: git+https://github.com/path/to/package-four@releases/tag/v3.7.1#egg=package-four",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "vcs",
+          "url": "git+https://github.com/path/to/package-four@releases/tag/v3.7.1#egg=package-four"
+        }
+      ],
+      "name": "package-four",
+      "purl": "pkg:pypi/package-four?vcs_url=git%2Bhttps://github.com/path/to/package-four%40releases/tag/v3.7.1%23egg%3Dpackage-four",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L5",
+      "description": "requirements line 5: git+https://github.com/path/to/package-one@41b95ec#egg=package-one",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "vcs",
+          "url": "git+https://github.com/path/to/package-one@41b95ec#egg=package-one"
+        }
+      ],
+      "name": "package-one",
+      "purl": "pkg:pypi/package-one?vcs_url=git%2Bhttps://github.com/path/to/package-one%4041b95ec%23egg%3Dpackage-one",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L9",
+      "description": "requirements line 9: git+https://github.com/path/to/package-three@0.1#egg=package-three",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "vcs",
+          "url": "git+https://github.com/path/to/package-three@0.1#egg=package-three"
+        }
+      ],
+      "name": "package-three",
+      "purl": "pkg:pypi/package-three?vcs_url=git%2Bhttps://github.com/path/to/package-three%400.1%23egg%3Dpackage-three",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: git+https://github.com/path/to/package-two@master#egg=package-two",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "vcs",
+          "url": "git+https://github.com/path/to/package-two@master#egg=package-two"
+        }
+      ],
+      "name": "package-two",
+      "purl": "pkg:pypi/package-two?vcs_url=git%2Bhttps://github.com/path/to/package-two%40master%23egg%3Dpackage-two",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L19",
+      "description": "requirements line 19: https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L23",
+      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "distribution",
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L15",
+      "description": "requirements line 15: http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "distribution",
+          "url": "http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl"
+        }
+      ],
+      "name": "wxPython-Phoenix",
+      "purl": "pkg:pypi/wxpython-phoenix@3.0.3.dev1820%2B49a8884?download_url=http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820%2B49a8884-cp34-none-win_amd64.whl",
+      "type": "library",
+      "version": "3.0.3.dev1820+49a8884"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L11"
+    },
+    {
+      "ref": "requirements-L15"
+    },
+    {
+      "ref": "requirements-L19"
+    },
+    {
+      "ref": "requirements-L23"
+    },
+    {
+      "ref": "requirements-L5"
+    },
+    {
+      "ref": "requirements-L7"
+    },
+    {
+      "ref": "requirements-L9"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/with-urls.txt-1.5.json-stream.bin
+++ b/tests/_data/snapshots/requirements/with-urls.txt-1.5.json-stream.bin
@@ -1,0 +1,139 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L11",
+      "description": "requirements line 11: git+https://github.com/path/to/package-four@releases/tag/v3.7.1#egg=package-four",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "vcs",
+          "url": "git+https://github.com/path/to/package-four@releases/tag/v3.7.1#egg=package-four"
+        }
+      ],
+      "name": "package-four",
+      "purl": "pkg:pypi/package-four?vcs_url=git%2Bhttps://github.com/path/to/package-four%40releases/tag/v3.7.1%23egg%3Dpackage-four",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L5",
+      "description": "requirements line 5: git+https://github.com/path/to/package-one@41b95ec#egg=package-one",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "vcs",
+          "url": "git+https://github.com/path/to/package-one@41b95ec#egg=package-one"
+        }
+      ],
+      "name": "package-one",
+      "purl": "pkg:pypi/package-one?vcs_url=git%2Bhttps://github.com/path/to/package-one%4041b95ec%23egg%3Dpackage-one",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L9",
+      "description": "requirements line 9: git+https://github.com/path/to/package-three@0.1#egg=package-three",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "vcs",
+          "url": "git+https://github.com/path/to/package-three@0.1#egg=package-three"
+        }
+      ],
+      "name": "package-three",
+      "purl": "pkg:pypi/package-three?vcs_url=git%2Bhttps://github.com/path/to/package-three%400.1%23egg%3Dpackage-three",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: git+https://github.com/path/to/package-two@master#egg=package-two",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "vcs",
+          "url": "git+https://github.com/path/to/package-two@master#egg=package-two"
+        }
+      ],
+      "name": "package-two",
+      "purl": "pkg:pypi/package-two?vcs_url=git%2Bhttps://github.com/path/to/package-two%40master%23egg%3Dpackage-two",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L19",
+      "description": "requirements line 19: https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L23",
+      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "distribution",
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L15",
+      "description": "requirements line 15: http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "distribution",
+          "url": "http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl"
+        }
+      ],
+      "name": "wxPython-Phoenix",
+      "purl": "pkg:pypi/wxpython-phoenix@3.0.3.dev1820%2B49a8884?download_url=http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820%2B49a8884-cp34-none-win_amd64.whl",
+      "type": "library",
+      "version": "3.0.3.dev1820+49a8884"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L11"
+    },
+    {
+      "ref": "requirements-L15"
+    },
+    {
+      "ref": "requirements-L19"
+    },
+    {
+      "ref": "requirements-L23"
+    },
+    {
+      "ref": "requirements-L5"
+    },
+    {
+      "ref": "requirements-L7"
+    },
+    {
+      "ref": "requirements-L9"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/with-urls.txt-1.5.xml-file.bin
+++ b/tests/_data/snapshots/requirements/with-urls.txt-1.5.xml-file.bin
@@ -1,0 +1,141 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L11">
+      <name>package-four</name>
+      <description>requirements line 11: git+https://github.com/path/to/package-four@releases/tag/v3.7.1#egg=package-four</description>
+      <purl>pkg:pypi/package-four?vcs_url=git%2Bhttps://github.com/path/to/package-four%40releases/tag/v3.7.1%23egg%3Dpackage-four</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/path/to/package-four@releases/tag/v3.7.1#egg=package-four</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L5">
+      <name>package-one</name>
+      <description>requirements line 5: git+https://github.com/path/to/package-one@41b95ec#egg=package-one</description>
+      <purl>pkg:pypi/package-one?vcs_url=git%2Bhttps://github.com/path/to/package-one%4041b95ec%23egg%3Dpackage-one</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/path/to/package-one@41b95ec#egg=package-one</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L9">
+      <name>package-three</name>
+      <description>requirements line 9: git+https://github.com/path/to/package-three@0.1#egg=package-three</description>
+      <purl>pkg:pypi/package-three?vcs_url=git%2Bhttps://github.com/path/to/package-three%400.1%23egg%3Dpackage-three</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/path/to/package-three@0.1#egg=package-three</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L7">
+      <name>package-two</name>
+      <description>requirements line 7: git+https://github.com/path/to/package-two@master#egg=package-two</description>
+      <purl>pkg:pypi/package-two?vcs_url=git%2Bhttps://github.com/path/to/package-two%40master%23egg%3Dpackage-two</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/path/to/package-two@master#egg=package-two</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L19">
+      <name>unknown</name>
+      <description>requirements line 19: https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L23">
+      <name>urllib3</name>
+      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</description>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L15">
+      <name>wxPython-Phoenix</name>
+      <version>3.0.3.dev1820+49a8884</version>
+      <description>requirements line 15: http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl</description>
+      <purl>pkg:pypi/wxpython-phoenix@3.0.3.dev1820%2B49a8884?download_url=http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820%2B49a8884-cp34-none-win_amd64.whl</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L11"/>
+    <dependency ref="requirements-L15"/>
+    <dependency ref="requirements-L19"/>
+    <dependency ref="requirements-L23"/>
+    <dependency ref="requirements-L5"/>
+    <dependency ref="requirements-L7"/>
+    <dependency ref="requirements-L9"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/with-urls.txt-1.5.xml-stream.bin
+++ b/tests/_data/snapshots/requirements/with-urls.txt-1.5.xml-stream.bin
@@ -1,0 +1,132 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L11">
+      <name>package-four</name>
+      <description>requirements line 11: git+https://github.com/path/to/package-four@releases/tag/v3.7.1#egg=package-four</description>
+      <purl>pkg:pypi/package-four?vcs_url=git%2Bhttps://github.com/path/to/package-four%40releases/tag/v3.7.1%23egg%3Dpackage-four</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/path/to/package-four@releases/tag/v3.7.1#egg=package-four</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L5">
+      <name>package-one</name>
+      <description>requirements line 5: git+https://github.com/path/to/package-one@41b95ec#egg=package-one</description>
+      <purl>pkg:pypi/package-one?vcs_url=git%2Bhttps://github.com/path/to/package-one%4041b95ec%23egg%3Dpackage-one</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/path/to/package-one@41b95ec#egg=package-one</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L9">
+      <name>package-three</name>
+      <description>requirements line 9: git+https://github.com/path/to/package-three@0.1#egg=package-three</description>
+      <purl>pkg:pypi/package-three?vcs_url=git%2Bhttps://github.com/path/to/package-three%400.1%23egg%3Dpackage-three</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/path/to/package-three@0.1#egg=package-three</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L7">
+      <name>package-two</name>
+      <description>requirements line 7: git+https://github.com/path/to/package-two@master#egg=package-two</description>
+      <purl>pkg:pypi/package-two?vcs_url=git%2Bhttps://github.com/path/to/package-two%40master%23egg%3Dpackage-two</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/path/to/package-two@master#egg=package-two</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L19">
+      <name>unknown</name>
+      <description>requirements line 19: https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L23">
+      <name>urllib3</name>
+      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</description>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L15">
+      <name>wxPython-Phoenix</name>
+      <version>3.0.3.dev1820+49a8884</version>
+      <description>requirements line 15: http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl</description>
+      <purl>pkg:pypi/wxpython-phoenix@3.0.3.dev1820%2B49a8884?download_url=http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820%2B49a8884-cp34-none-win_amd64.whl</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L11"/>
+    <dependency ref="requirements-L15"/>
+    <dependency ref="requirements-L19"/>
+    <dependency ref="requirements-L23"/>
+    <dependency ref="requirements-L5"/>
+    <dependency ref="requirements-L7"/>
+    <dependency ref="requirements-L9"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/without-pinned-versions.txt-1.5.json-file.bin
+++ b/tests/_data/snapshots/requirements/without-pinned-versions.txt-1.5.json-file.bin
@@ -1,0 +1,86 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L1",
+      "description": "requirements line 1: certifi>=2021.5.30",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/"
+        }
+      ],
+      "name": "certifi",
+      "purl": "pkg:pypi/certifi",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L2",
+      "description": "requirements line 2: chardet >= 4.0.0 , < 5",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/chardet/"
+        }
+      ],
+      "name": "chardet",
+      "purl": "pkg:pypi/chardet",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L3",
+      "description": "requirements line 3: urllib3",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/urllib3/"
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L1"
+    },
+    {
+      "ref": "requirements-L2"
+    },
+    {
+      "ref": "requirements-L3"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/without-pinned-versions.txt-1.5.json-stream.bin
+++ b/tests/_data/snapshots/requirements/without-pinned-versions.txt-1.5.json-stream.bin
@@ -1,0 +1,71 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L1",
+      "description": "requirements line 1: certifi>=2021.5.30",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/"
+        }
+      ],
+      "name": "certifi",
+      "purl": "pkg:pypi/certifi",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L2",
+      "description": "requirements line 2: chardet >= 4.0.0 , < 5",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/chardet/"
+        }
+      ],
+      "name": "chardet",
+      "purl": "pkg:pypi/chardet",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L3",
+      "description": "requirements line 3: urllib3",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/urllib3/"
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L1"
+    },
+    {
+      "ref": "requirements-L2"
+    },
+    {
+      "ref": "requirements-L3"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/requirements/without-pinned-versions.txt-1.5.xml-file.bin
+++ b/tests/_data/snapshots/requirements/without-pinned-versions.txt-1.5.xml-file.bin
@@ -1,0 +1,93 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L1">
+      <name>certifi</name>
+      <description>requirements line 1: certifi&gt;=2021.5.30</description>
+      <purl>pkg:pypi/certifi</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L2">
+      <name>chardet</name>
+      <description>requirements line 2: chardet &gt;= 4.0.0 , &lt; 5</description>
+      <purl>pkg:pypi/chardet</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/chardet/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L3">
+      <name>urllib3</name>
+      <description>requirements line 3: urllib3</description>
+      <purl>pkg:pypi/urllib3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/urllib3/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L1"/>
+    <dependency ref="requirements-L2"/>
+    <dependency ref="requirements-L3"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/without-pinned-versions.txt-1.5.xml-stream.bin
+++ b/tests/_data/snapshots/requirements/without-pinned-versions.txt-1.5.xml-stream.bin
@@ -1,0 +1,84 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L1">
+      <name>certifi</name>
+      <description>requirements line 1: certifi&gt;=2021.5.30</description>
+      <purl>pkg:pypi/certifi</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L2">
+      <name>chardet</name>
+      <description>requirements line 2: chardet &gt;= 4.0.0 , &lt; 5</description>
+      <purl>pkg:pypi/chardet</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/chardet/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L3">
+      <name>urllib3</name>
+      <description>requirements line 3: urllib3</description>
+      <purl>pkg:pypi/urllib3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/urllib3/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L1"/>
+    <dependency ref="requirements-L2"/>
+    <dependency ref="requirements-L3"/>
+  </dependencies>
+</bom>


### PR DESCRIPTION
upgrade cyclonedx-python-lib v6
the v5 of `cyclonedx-python-lib` dit not take care of enum constraints.
v6 does. need this feature for the future. 

also fixes #617
also sets default outputVersion to CDX1.5