### PR TITLE
tests: modernize testbeds

### DIFF
--- a/tests/_data/infiles/environment/with-urls/init.py
+++ b/tests/_data/infiles/environment/with-urls/init.py
@@ -44,7 +44,7 @@ def main() -> None:
 
     pip_install(
         'git+https://github.com/pypa/packaging.git@23.2',
-        'urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip',
+        'urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip',
         'https://files.pythonhosted.org/packages/d9/5a/'
         'e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl',
     )

--- a/tests/_data/infiles/pipenv/with-urls/Pipfile
+++ b/tests/_data/infiles/pipenv/with-urls/Pipfile
@@ -6,7 +6,7 @@ sort_pipfile = true
 pillow = {ref = "10.1.0", git = "git+https://github.com/python-pillow/Pillow.git"}
 six = {ref = "1.16.0", git = "git+ssh://git@github.com/benjaminp/six.git"}
 # wxpython-phoenix = {file = "https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5624+e95b6c8b-cp311-cp311-win32.whl", markers="sys_platform == 'win32'"}
-urllib3 = {file = "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"}
+urllib3 = {file = "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"}
 requests = {git = "git+https://github.com/requests/requests.git#egg=requests"}
 
 [dev-packages]

--- a/tests/_data/infiles/pipenv/with-urls/Pipfile.lock
+++ b/tests/_data/infiles/pipenv/with-urls/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7da942b1b25618d83c715727e11e1bd3602acc0aff377dc95d80326e9d77fa5a"
+            "sha256": "77b820625225357a870010516abdd0e92f273af20af9908446833d8627ababe4"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -134,7 +134,7 @@
         "requests": {
             "git": "git+https://github.com/requests/requests.git#egg=requests",
             "markers": "python_version >= '3.7'",
-            "ref": "a25fde6989f8df5c3d823bc9f2e2fc24aa71f375"
+            "ref": "96b22fa18c00831656ee4b286bf1c9062459b00a"
         },
         "six": {
             "git": "git+ssh://git@github.com/benjaminp/six.git",
@@ -142,7 +142,7 @@
             "ref": "65486e4383f9f411da95937451205d3c7b61b9e1"
         },
         "urllib3": {
-            "file": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+            "file": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
             "markers": "python_version >= '3.8'"
         }
     },

--- a/tests/_data/infiles/requirements/with-comments.txt
+++ b/tests/_data/infiles/requirements/with-comments.txt
@@ -1,5 +1,5 @@
-certifi==2021.5.30 # via requests
+certifi==2023.11.17 # via requests
 chardet==4.0.0 # via requests
 idna==2.10 # via requests
-requests==2.25.1 # via -r requirements.in
-urllib3==1.26.5 # via requests
+requests==2.31.0  # via -r requirements.in
+urllib3==2.2.0 # via requests

--- a/tests/_data/infiles/requirements/with-hashes.txt
+++ b/tests/_data/infiles/requirements/with-hashes.txt
@@ -1,11 +1,11 @@
 # hash mode -- https://pip.pypa.io/en/stable/topics/secure-installs/#hash-checking-mode
 
 ## oneliner
-certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8
+certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1
 
 ## unorthodox line breaks
-urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c \
- --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098
+urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20 \
+ --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224
 
 ## typical line breaks
 FooProject == 1.2 \

--- a/tests/_data/infiles/requirements/with-urls.txt
+++ b/tests/_data/infiles/requirements/with-urls.txt
@@ -20,4 +20,4 @@ https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057
 
 
 ## named fetchable file
-urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip
+urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip

--- a/tests/_data/infiles/requirements/without-pinned-versions.txt
+++ b/tests/_data/infiles/requirements/without-pinned-versions.txt
@@ -1,3 +1,3 @@
-certifi>=2021.5.30
+certifi>=2023.11.17
 chardet >= 4.0.0 , < 5
 urllib3

--- a/tests/_data/snapshots/environment/plain_with-urls_1.0.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.0.xml.bin
@@ -17,9 +17,9 @@
     </component>
     <component type="library">
       <name>urllib3</name>
-      <version>1.26.8</version>
+      <version>2.2.0</version>
       <description>HTTP library with thread-safe connection pooling, file post, and more.</description>
-      <purl>pkg:pypi/urllib3@1.26.8?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <purl>pkg:pypi/urllib3@2.2.0?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <modified>false</modified>
     </component>
   </components>

--- a/tests/_data/snapshots/environment/plain_with-urls_1.1.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.1.xml.bin
@@ -42,23 +42,23 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="urllib3==1.26.8">
+    <component type="library" bom-ref="urllib3==2.2.0">
       <name>urllib3</name>
-      <version>1.26.8</version>
+      <version>2.2.0</version>
       <description>HTTP library with thread-safe connection pooling, file post, and more.</description>
       <licenses>
         <license>
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:pypi/urllib3@1.26.8?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <purl>pkg:pypi/urllib3@2.2.0?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>PackageSource: Archive</comment>
         </reference>
         <reference type="documentation">
-          <url>https://urllib3.readthedocs.io/</url>
+          <url>https://urllib3.readthedocs.io</url>
           <comment>from packaging metadata Project-URL: Documentation</comment>
         </reference>
         <reference type="issue-tracker">
@@ -69,9 +69,9 @@
           <url>https://github.com/urllib3/urllib3</url>
           <comment>from packaging metadata Project-URL: Code</comment>
         </reference>
-        <reference type="website">
-          <url>https://urllib3.readthedocs.io/</url>
-          <comment>from packaging metadata: Home-page</comment>
+        <reference type="other">
+          <url>https://github.com/urllib3/urllib3/blob/main/CHANGES.rst</url>
+          <comment>from packaging metadata Project-URL: Changelog</comment>
         </reference>
       </externalReferences>
     </component>

--- a/tests/_data/snapshots/environment/plain_with-urls_1.2.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.2.json.bin
@@ -53,18 +53,18 @@
       "version": "1.16.0"
     },
     {
-      "bom-ref": "urllib3==1.26.8",
+      "bom-ref": "urllib3==2.2.0",
       "description": "HTTP library with thread-safe connection pooling, file post, and more.",
       "externalReferences": [
         {
           "comment": "PackageSource: Archive",
           "type": "distribution",
-          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
         },
         {
           "comment": "from packaging metadata Project-URL: Documentation",
           "type": "documentation",
-          "url": "https://urllib3.readthedocs.io/"
+          "url": "https://urllib3.readthedocs.io"
         },
         {
           "comment": "from packaging metadata Project-URL: Issue tracker",
@@ -77,9 +77,9 @@
           "url": "https://github.com/urllib3/urllib3"
         },
         {
-          "comment": "from packaging metadata: Home-page",
-          "type": "website",
-          "url": "https://urllib3.readthedocs.io/"
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "other",
+          "url": "https://github.com/urllib3/urllib3/blob/main/CHANGES.rst"
         }
       ],
       "licenses": [
@@ -90,9 +90,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.8?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "purl": "pkg:pypi/urllib3@2.2.0?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "type": "library",
-      "version": "1.26.8"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [
@@ -109,7 +109,7 @@
       "ref": "six==1.16.0"
     },
     {
-      "ref": "urllib3==1.26.8"
+      "ref": "urllib3==2.2.0"
     }
   ],
   "metadata": {

--- a/tests/_data/snapshots/environment/plain_with-urls_1.2.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.2.xml.bin
@@ -61,23 +61,23 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="urllib3==1.26.8">
+    <component type="library" bom-ref="urllib3==2.2.0">
       <name>urllib3</name>
-      <version>1.26.8</version>
+      <version>2.2.0</version>
       <description>HTTP library with thread-safe connection pooling, file post, and more.</description>
       <licenses>
         <license>
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:pypi/urllib3@1.26.8?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <purl>pkg:pypi/urllib3@2.2.0?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>PackageSource: Archive</comment>
         </reference>
         <reference type="documentation">
-          <url>https://urllib3.readthedocs.io/</url>
+          <url>https://urllib3.readthedocs.io</url>
           <comment>from packaging metadata Project-URL: Documentation</comment>
         </reference>
         <reference type="issue-tracker">
@@ -88,9 +88,9 @@
           <url>https://github.com/urllib3/urllib3</url>
           <comment>from packaging metadata Project-URL: Code</comment>
         </reference>
-        <reference type="website">
-          <url>https://urllib3.readthedocs.io/</url>
-          <comment>from packaging metadata: Home-page</comment>
+        <reference type="other">
+          <url>https://github.com/urllib3/urllib3/blob/main/CHANGES.rst</url>
+          <comment>from packaging metadata Project-URL: Changelog</comment>
         </reference>
       </externalReferences>
     </component>
@@ -101,6 +101,6 @@
       <dependency ref="six==1.16.0"/>
     </dependency>
     <dependency ref="six==1.16.0"/>
-    <dependency ref="urllib3==1.26.8"/>
+    <dependency ref="urllib3==2.2.0"/>
   </dependencies>
 </bom>

--- a/tests/_data/snapshots/environment/plain_with-urls_1.3.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.3.json.bin
@@ -69,7 +69,7 @@
       "version": "1.16.0"
     },
     {
-      "bom-ref": "urllib3==1.26.8",
+      "bom-ref": "urllib3==2.2.0",
       "description": "HTTP library with thread-safe connection pooling, file post, and more.",
       "externalReferences": [
         {
@@ -77,16 +77,16 @@
           "hashes": [
             {
               "alg": "SHA-256",
-              "content": "335f26daa3f99cae180f477efaf8c45ccaab380e02fe54292e9b5e14b3b41977"
+              "content": "672a674765aba37fe6f3e3b05372bf13140ef501c4d79ae29e998e3910b6a8e9"
             }
           ],
           "type": "distribution",
-          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
         },
         {
           "comment": "from packaging metadata Project-URL: Documentation",
           "type": "documentation",
-          "url": "https://urllib3.readthedocs.io/"
+          "url": "https://urllib3.readthedocs.io"
         },
         {
           "comment": "from packaging metadata Project-URL: Issue tracker",
@@ -99,9 +99,9 @@
           "url": "https://github.com/urllib3/urllib3"
         },
         {
-          "comment": "from packaging metadata: Home-page",
-          "type": "website",
-          "url": "https://urllib3.readthedocs.io/"
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "other",
+          "url": "https://github.com/urllib3/urllib3/blob/main/CHANGES.rst"
         }
       ],
       "licenses": [
@@ -112,9 +112,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.8?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "purl": "pkg:pypi/urllib3@2.2.0?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "type": "library",
-      "version": "1.26.8"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [
@@ -131,7 +131,7 @@
       "ref": "six==1.16.0"
     },
     {
-      "ref": "urllib3==1.26.8"
+      "ref": "urllib3==2.2.0"
     }
   ],
   "metadata": {

--- a/tests/_data/snapshots/environment/plain_with-urls_1.3.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.3.xml.bin
@@ -71,26 +71,26 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="urllib3==1.26.8">
+    <component type="library" bom-ref="urllib3==2.2.0">
       <name>urllib3</name>
-      <version>1.26.8</version>
+      <version>2.2.0</version>
       <description>HTTP library with thread-safe connection pooling, file post, and more.</description>
       <licenses>
         <license>
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:pypi/urllib3@1.26.8?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <purl>pkg:pypi/urllib3@2.2.0?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>PackageSource: Archive</comment>
           <hashes>
-            <hash alg="SHA-256">335f26daa3f99cae180f477efaf8c45ccaab380e02fe54292e9b5e14b3b41977</hash>
+            <hash alg="SHA-256">672a674765aba37fe6f3e3b05372bf13140ef501c4d79ae29e998e3910b6a8e9</hash>
           </hashes>
         </reference>
         <reference type="documentation">
-          <url>https://urllib3.readthedocs.io/</url>
+          <url>https://urllib3.readthedocs.io</url>
           <comment>from packaging metadata Project-URL: Documentation</comment>
         </reference>
         <reference type="issue-tracker">
@@ -101,9 +101,9 @@
           <url>https://github.com/urllib3/urllib3</url>
           <comment>from packaging metadata Project-URL: Code</comment>
         </reference>
-        <reference type="website">
-          <url>https://urllib3.readthedocs.io/</url>
-          <comment>from packaging metadata: Home-page</comment>
+        <reference type="other">
+          <url>https://github.com/urllib3/urllib3/blob/main/CHANGES.rst</url>
+          <comment>from packaging metadata Project-URL: Changelog</comment>
         </reference>
       </externalReferences>
     </component>
@@ -114,6 +114,6 @@
       <dependency ref="six==1.16.0"/>
     </dependency>
     <dependency ref="six==1.16.0"/>
-    <dependency ref="urllib3==1.26.8"/>
+    <dependency ref="urllib3==2.2.0"/>
   </dependencies>
 </bom>

--- a/tests/_data/snapshots/environment/plain_with-urls_1.4.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.4.json.bin
@@ -69,7 +69,7 @@
       "version": "1.16.0"
     },
     {
-      "bom-ref": "urllib3==1.26.8",
+      "bom-ref": "urllib3==2.2.0",
       "description": "HTTP library with thread-safe connection pooling, file post, and more.",
       "externalReferences": [
         {
@@ -77,16 +77,16 @@
           "hashes": [
             {
               "alg": "SHA-256",
-              "content": "335f26daa3f99cae180f477efaf8c45ccaab380e02fe54292e9b5e14b3b41977"
+              "content": "672a674765aba37fe6f3e3b05372bf13140ef501c4d79ae29e998e3910b6a8e9"
             }
           ],
           "type": "distribution",
-          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
         },
         {
           "comment": "from packaging metadata Project-URL: Documentation",
           "type": "documentation",
-          "url": "https://urllib3.readthedocs.io/"
+          "url": "https://urllib3.readthedocs.io"
         },
         {
           "comment": "from packaging metadata Project-URL: Issue tracker",
@@ -99,9 +99,9 @@
           "url": "https://github.com/urllib3/urllib3"
         },
         {
-          "comment": "from packaging metadata: Home-page",
-          "type": "website",
-          "url": "https://urllib3.readthedocs.io/"
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "release-notes",
+          "url": "https://github.com/urllib3/urllib3/blob/main/CHANGES.rst"
         }
       ],
       "licenses": [
@@ -112,9 +112,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.8?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "purl": "pkg:pypi/urllib3@2.2.0?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "type": "library",
-      "version": "1.26.8"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [
@@ -131,7 +131,7 @@
       "ref": "six==1.16.0"
     },
     {
-      "ref": "urllib3==1.26.8"
+      "ref": "urllib3==2.2.0"
     }
   ],
   "metadata": {

--- a/tests/_data/snapshots/environment/plain_with-urls_1.4.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.4.xml.bin
@@ -98,26 +98,26 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="urllib3==1.26.8">
+    <component type="library" bom-ref="urllib3==2.2.0">
       <name>urllib3</name>
-      <version>1.26.8</version>
+      <version>2.2.0</version>
       <description>HTTP library with thread-safe connection pooling, file post, and more.</description>
       <licenses>
         <license>
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:pypi/urllib3@1.26.8?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <purl>pkg:pypi/urllib3@2.2.0?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>PackageSource: Archive</comment>
           <hashes>
-            <hash alg="SHA-256">335f26daa3f99cae180f477efaf8c45ccaab380e02fe54292e9b5e14b3b41977</hash>
+            <hash alg="SHA-256">672a674765aba37fe6f3e3b05372bf13140ef501c4d79ae29e998e3910b6a8e9</hash>
           </hashes>
         </reference>
         <reference type="documentation">
-          <url>https://urllib3.readthedocs.io/</url>
+          <url>https://urllib3.readthedocs.io</url>
           <comment>from packaging metadata Project-URL: Documentation</comment>
         </reference>
         <reference type="issue-tracker">
@@ -128,9 +128,9 @@
           <url>https://github.com/urllib3/urllib3</url>
           <comment>from packaging metadata Project-URL: Code</comment>
         </reference>
-        <reference type="website">
-          <url>https://urllib3.readthedocs.io/</url>
-          <comment>from packaging metadata: Home-page</comment>
+        <reference type="release-notes">
+          <url>https://github.com/urllib3/urllib3/blob/main/CHANGES.rst</url>
+          <comment>from packaging metadata Project-URL: Changelog</comment>
         </reference>
       </externalReferences>
     </component>
@@ -141,6 +141,6 @@
       <dependency ref="six==1.16.0"/>
     </dependency>
     <dependency ref="six==1.16.0"/>
-    <dependency ref="urllib3==1.26.8"/>
+    <dependency ref="urllib3==2.2.0"/>
   </dependencies>
 </bom>

--- a/tests/_data/snapshots/environment/plain_with-urls_1.5.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.5.json.bin
@@ -69,7 +69,7 @@
       "version": "1.16.0"
     },
     {
-      "bom-ref": "urllib3==1.26.8",
+      "bom-ref": "urllib3==2.2.0",
       "description": "HTTP library with thread-safe connection pooling, file post, and more.",
       "externalReferences": [
         {
@@ -77,16 +77,16 @@
           "hashes": [
             {
               "alg": "SHA-256",
-              "content": "335f26daa3f99cae180f477efaf8c45ccaab380e02fe54292e9b5e14b3b41977"
+              "content": "672a674765aba37fe6f3e3b05372bf13140ef501c4d79ae29e998e3910b6a8e9"
             }
           ],
           "type": "distribution",
-          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
         },
         {
           "comment": "from packaging metadata Project-URL: Documentation",
           "type": "documentation",
-          "url": "https://urllib3.readthedocs.io/"
+          "url": "https://urllib3.readthedocs.io"
         },
         {
           "comment": "from packaging metadata Project-URL: Issue tracker",
@@ -99,9 +99,9 @@
           "url": "https://github.com/urllib3/urllib3"
         },
         {
-          "comment": "from packaging metadata: Home-page",
-          "type": "website",
-          "url": "https://urllib3.readthedocs.io/"
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "release-notes",
+          "url": "https://github.com/urllib3/urllib3/blob/main/CHANGES.rst"
         }
       ],
       "licenses": [
@@ -112,9 +112,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.8?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "purl": "pkg:pypi/urllib3@2.2.0?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "type": "library",
-      "version": "1.26.8"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [
@@ -131,7 +131,7 @@
       "ref": "six==1.16.0"
     },
     {
-      "ref": "urllib3==1.26.8"
+      "ref": "urllib3==2.2.0"
     }
   ],
   "metadata": {

--- a/tests/_data/snapshots/environment/plain_with-urls_1.5.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.5.xml.bin
@@ -98,26 +98,26 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="urllib3==1.26.8">
+    <component type="library" bom-ref="urllib3==2.2.0">
       <name>urllib3</name>
-      <version>1.26.8</version>
+      <version>2.2.0</version>
       <description>HTTP library with thread-safe connection pooling, file post, and more.</description>
       <licenses>
         <license>
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:pypi/urllib3@1.26.8?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <purl>pkg:pypi/urllib3@2.2.0?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>PackageSource: Archive</comment>
           <hashes>
-            <hash alg="SHA-256">335f26daa3f99cae180f477efaf8c45ccaab380e02fe54292e9b5e14b3b41977</hash>
+            <hash alg="SHA-256">672a674765aba37fe6f3e3b05372bf13140ef501c4d79ae29e998e3910b6a8e9</hash>
           </hashes>
         </reference>
         <reference type="documentation">
-          <url>https://urllib3.readthedocs.io/</url>
+          <url>https://urllib3.readthedocs.io</url>
           <comment>from packaging metadata Project-URL: Documentation</comment>
         </reference>
         <reference type="issue-tracker">
@@ -128,9 +128,9 @@
           <url>https://github.com/urllib3/urllib3</url>
           <comment>from packaging metadata Project-URL: Code</comment>
         </reference>
-        <reference type="website">
-          <url>https://urllib3.readthedocs.io/</url>
-          <comment>from packaging metadata: Home-page</comment>
+        <reference type="release-notes">
+          <url>https://github.com/urllib3/urllib3/blob/main/CHANGES.rst</url>
+          <comment>from packaging metadata Project-URL: Changelog</comment>
         </reference>
       </externalReferences>
     </component>
@@ -141,6 +141,6 @@
       <dependency ref="six==1.16.0"/>
     </dependency>
     <dependency ref="six==1.16.0"/>
-    <dependency ref="urllib3==1.26.8"/>
+    <dependency ref="urllib3==2.2.0"/>
   </dependencies>
 </bom>

--- a/tests/_data/snapshots/pipenv/plain_with-urls_1.0.xml.bin
+++ b/tests/_data/snapshots/pipenv/plain_with-urls_1.0.xml.bin
@@ -28,7 +28,7 @@
     <component type="library">
       <name>requests</name>
       <version/>
-      <purl>pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%40a25fde6989f8df5c3d823bc9f2e2fc24aa71f375</purl>
+      <purl>pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%4096b22fa18c00831656ee4b286bf1c9062459b00a</purl>
       <modified>false</modified>
     </component>
     <component type="library">
@@ -40,7 +40,7 @@
     <component type="library">
       <name>urllib3</name>
       <version/>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <modified>false</modified>
     </component>
   </components>

--- a/tests/_data/snapshots/pipenv/plain_with-urls_1.1.xml.bin
+++ b/tests/_data/snapshots/pipenv/plain_with-urls_1.1.xml.bin
@@ -48,10 +48,10 @@
     <component type="library" bom-ref="requests">
       <name>requests</name>
       <version/>
-      <purl>pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%40a25fde6989f8df5c3d823bc9f2e2fc24aa71f375</purl>
+      <purl>pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%4096b22fa18c00831656ee4b286bf1c9062459b00a</purl>
       <externalReferences>
         <reference type="vcs">
-          <url>git+https://github.com/requests/requests.git#a25fde6989f8df5c3d823bc9f2e2fc24aa71f375</url>
+          <url>git+https://github.com/requests/requests.git#96b22fa18c00831656ee4b286bf1c9062459b00a</url>
           <comment>from git</comment>
         </reference>
       </externalReferences>
@@ -70,10 +70,10 @@
     <component type="library" bom-ref="urllib3">
       <name>urllib3</name>
       <version/>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>from file</comment>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/pipenv/plain_with-urls_1.2.json.bin
+++ b/tests/_data/snapshots/pipenv/plain_with-urls_1.2.json.bin
@@ -62,11 +62,11 @@
         {
           "comment": "from git",
           "type": "vcs",
-          "url": "git+https://github.com/requests/requests.git#a25fde6989f8df5c3d823bc9f2e2fc24aa71f375"
+          "url": "git+https://github.com/requests/requests.git#96b22fa18c00831656ee4b286bf1c9062459b00a"
         }
       ],
       "name": "requests",
-      "purl": "pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%40a25fde6989f8df5c3d823bc9f2e2fc24aa71f375",
+      "purl": "pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%4096b22fa18c00831656ee4b286bf1c9062459b00a",
       "type": "library",
       "version": ""
     },
@@ -90,11 +90,11 @@
         {
           "comment": "from file",
           "type": "distribution",
-          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "type": "library",
       "version": ""
     }

--- a/tests/_data/snapshots/pipenv/plain_with-urls_1.2.xml.bin
+++ b/tests/_data/snapshots/pipenv/plain_with-urls_1.2.xml.bin
@@ -67,10 +67,10 @@
     <component type="library" bom-ref="requests">
       <name>requests</name>
       <version/>
-      <purl>pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%40a25fde6989f8df5c3d823bc9f2e2fc24aa71f375</purl>
+      <purl>pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%4096b22fa18c00831656ee4b286bf1c9062459b00a</purl>
       <externalReferences>
         <reference type="vcs">
-          <url>git+https://github.com/requests/requests.git#a25fde6989f8df5c3d823bc9f2e2fc24aa71f375</url>
+          <url>git+https://github.com/requests/requests.git#96b22fa18c00831656ee4b286bf1c9062459b00a</url>
           <comment>from git</comment>
         </reference>
       </externalReferences>
@@ -89,10 +89,10 @@
     <component type="library" bom-ref="urllib3">
       <name>urllib3</name>
       <version/>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>from file</comment>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/pipenv/plain_with-urls_1.3.json.bin
+++ b/tests/_data/snapshots/pipenv/plain_with-urls_1.3.json.bin
@@ -468,7 +468,7 @@
         {
           "comment": "from git",
           "type": "vcs",
-          "url": "git+https://github.com/requests/requests.git#a25fde6989f8df5c3d823bc9f2e2fc24aa71f375"
+          "url": "git+https://github.com/requests/requests.git#96b22fa18c00831656ee4b286bf1c9062459b00a"
         }
       ],
       "name": "requests",
@@ -478,7 +478,7 @@
           "value": "default"
         }
       ],
-      "purl": "pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%40a25fde6989f8df5c3d823bc9f2e2fc24aa71f375",
+      "purl": "pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%4096b22fa18c00831656ee4b286bf1c9062459b00a",
       "type": "library",
       "version": ""
     },
@@ -508,7 +508,7 @@
         {
           "comment": "from file",
           "type": "distribution",
-          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
         }
       ],
       "name": "urllib3",
@@ -518,7 +518,7 @@
           "value": "default"
         }
       ],
-      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "type": "library",
       "version": ""
     }

--- a/tests/_data/snapshots/pipenv/plain_with-urls_1.3.xml.bin
+++ b/tests/_data/snapshots/pipenv/plain_with-urls_1.3.xml.bin
@@ -182,10 +182,10 @@
     <component type="library" bom-ref="requests">
       <name>requests</name>
       <version/>
-      <purl>pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%40a25fde6989f8df5c3d823bc9f2e2fc24aa71f375</purl>
+      <purl>pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%4096b22fa18c00831656ee4b286bf1c9062459b00a</purl>
       <externalReferences>
         <reference type="vcs">
-          <url>git+https://github.com/requests/requests.git#a25fde6989f8df5c3d823bc9f2e2fc24aa71f375</url>
+          <url>git+https://github.com/requests/requests.git#96b22fa18c00831656ee4b286bf1c9062459b00a</url>
           <comment>from git</comment>
         </reference>
       </externalReferences>
@@ -210,10 +210,10 @@
     <component type="library" bom-ref="urllib3">
       <name>urllib3</name>
       <version/>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>from file</comment>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/pipenv/plain_with-urls_1.4.json.bin
+++ b/tests/_data/snapshots/pipenv/plain_with-urls_1.4.json.bin
@@ -467,7 +467,7 @@
         {
           "comment": "from git",
           "type": "vcs",
-          "url": "git+https://github.com/requests/requests.git#a25fde6989f8df5c3d823bc9f2e2fc24aa71f375"
+          "url": "git+https://github.com/requests/requests.git#96b22fa18c00831656ee4b286bf1c9062459b00a"
         }
       ],
       "name": "requests",
@@ -477,7 +477,7 @@
           "value": "default"
         }
       ],
-      "purl": "pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%40a25fde6989f8df5c3d823bc9f2e2fc24aa71f375",
+      "purl": "pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%4096b22fa18c00831656ee4b286bf1c9062459b00a",
       "type": "library"
     },
     {
@@ -505,7 +505,7 @@
         {
           "comment": "from file",
           "type": "distribution",
-          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
         }
       ],
       "name": "urllib3",
@@ -515,7 +515,7 @@
           "value": "default"
         }
       ],
-      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "type": "library"
     }
   ],

--- a/tests/_data/snapshots/pipenv/plain_with-urls_1.4.xml.bin
+++ b/tests/_data/snapshots/pipenv/plain_with-urls_1.4.xml.bin
@@ -207,10 +207,10 @@
     </component>
     <component type="library" bom-ref="requests">
       <name>requests</name>
-      <purl>pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%40a25fde6989f8df5c3d823bc9f2e2fc24aa71f375</purl>
+      <purl>pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%4096b22fa18c00831656ee4b286bf1c9062459b00a</purl>
       <externalReferences>
         <reference type="vcs">
-          <url>git+https://github.com/requests/requests.git#a25fde6989f8df5c3d823bc9f2e2fc24aa71f375</url>
+          <url>git+https://github.com/requests/requests.git#96b22fa18c00831656ee4b286bf1c9062459b00a</url>
           <comment>from git</comment>
         </reference>
       </externalReferences>
@@ -233,10 +233,10 @@
     </component>
     <component type="library" bom-ref="urllib3">
       <name>urllib3</name>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>from file</comment>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/pipenv/plain_with-urls_1.5.json.bin
+++ b/tests/_data/snapshots/pipenv/plain_with-urls_1.5.json.bin
@@ -467,7 +467,7 @@
         {
           "comment": "from git",
           "type": "vcs",
-          "url": "git+https://github.com/requests/requests.git#a25fde6989f8df5c3d823bc9f2e2fc24aa71f375"
+          "url": "git+https://github.com/requests/requests.git#96b22fa18c00831656ee4b286bf1c9062459b00a"
         }
       ],
       "name": "requests",
@@ -477,7 +477,7 @@
           "value": "default"
         }
       ],
-      "purl": "pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%40a25fde6989f8df5c3d823bc9f2e2fc24aa71f375",
+      "purl": "pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%4096b22fa18c00831656ee4b286bf1c9062459b00a",
       "type": "library"
     },
     {
@@ -505,7 +505,7 @@
         {
           "comment": "from file",
           "type": "distribution",
-          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
         }
       ],
       "name": "urllib3",
@@ -515,7 +515,7 @@
           "value": "default"
         }
       ],
-      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "type": "library"
     }
   ],

--- a/tests/_data/snapshots/pipenv/plain_with-urls_1.5.xml.bin
+++ b/tests/_data/snapshots/pipenv/plain_with-urls_1.5.xml.bin
@@ -207,10 +207,10 @@
     </component>
     <component type="library" bom-ref="requests">
       <name>requests</name>
-      <purl>pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%40a25fde6989f8df5c3d823bc9f2e2fc24aa71f375</purl>
+      <purl>pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%4096b22fa18c00831656ee4b286bf1c9062459b00a</purl>
       <externalReferences>
         <reference type="vcs">
-          <url>git+https://github.com/requests/requests.git#a25fde6989f8df5c3d823bc9f2e2fc24aa71f375</url>
+          <url>git+https://github.com/requests/requests.git#96b22fa18c00831656ee4b286bf1c9062459b00a</url>
           <comment>from git</comment>
         </reference>
       </externalReferences>
@@ -233,10 +233,10 @@
     </component>
     <component type="library" bom-ref="urllib3">
       <name>urllib3</name>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>from file</comment>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/requirements/file_with-comments_1.0.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-comments_1.0.xml.bin
@@ -3,9 +3,9 @@
   <components>
     <component type="library">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 1: certifi==2021.5.30</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 1: certifi==2023.11.17</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <modified>false</modified>
     </component>
     <component type="library">
@@ -24,16 +24,16 @@
     </component>
     <component type="library">
       <name>requests</name>
-      <version>2.25.1</version>
-      <description>requirements line 4: requests==2.25.1</description>
-      <purl>pkg:pypi/requests@2.25.1</purl>
+      <version>2.31.0</version>
+      <description>requirements line 4: requests==2.31.0</description>
+      <purl>pkg:pypi/requests@2.31.0</purl>
       <modified>false</modified>
     </component>
     <component type="library">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 5: urllib3==1.26.5</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 5: urllib3==2.2.0</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <modified>false</modified>
     </component>
   </components>

--- a/tests/_data/snapshots/requirements/file_with-comments_1.1.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-comments_1.1.xml.bin
@@ -3,9 +3,9 @@
   <components>
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 1: certifi==2021.5.30</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 1: certifi==2023.11.17</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
@@ -39,9 +39,9 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>requests</name>
-      <version>2.25.1</version>
-      <description>requirements line 4: requests==2.25.1</description>
-      <purl>pkg:pypi/requests@2.25.1</purl>
+      <version>2.31.0</version>
+      <description>requirements line 4: requests==2.31.0</description>
+      <purl>pkg:pypi/requests@2.31.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/requests/</url>
@@ -51,9 +51,9 @@
     </component>
     <component type="library" bom-ref="requirements-L5">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 5: urllib3==1.26.5</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 5: urllib3==2.2.0</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>

--- a/tests/_data/snapshots/requirements/file_with-comments_1.2.json.bin
+++ b/tests/_data/snapshots/requirements/file_with-comments_1.2.json.bin
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "requirements-L1",
-      "description": "requirements line 1: certifi==2021.5.30",
+      "description": "requirements line 1: certifi==2023.11.17",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -11,9 +11,9 @@
         }
       ],
       "name": "certifi",
-      "purl": "pkg:pypi/certifi@2021.5.30",
+      "purl": "pkg:pypi/certifi@2023.11.17",
       "type": "library",
-      "version": "2021.5.30"
+      "version": "2023.11.17"
     },
     {
       "bom-ref": "requirements-L2",
@@ -47,7 +47,7 @@
     },
     {
       "bom-ref": "requirements-L4",
-      "description": "requirements line 4: requests==2.25.1",
+      "description": "requirements line 4: requests==2.31.0",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -56,13 +56,13 @@
         }
       ],
       "name": "requests",
-      "purl": "pkg:pypi/requests@2.25.1",
+      "purl": "pkg:pypi/requests@2.31.0",
       "type": "library",
-      "version": "2.25.1"
+      "version": "2.31.0"
     },
     {
       "bom-ref": "requirements-L5",
-      "description": "requirements line 5: urllib3==1.26.5",
+      "description": "requirements line 5: urllib3==2.2.0",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -71,9 +71,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.5",
+      "purl": "pkg:pypi/urllib3@2.2.0",
       "type": "library",
-      "version": "1.26.5"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [

--- a/tests/_data/snapshots/requirements/file_with-comments_1.2.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-comments_1.2.xml.bin
@@ -51,9 +51,9 @@
   <components>
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 1: certifi==2021.5.30</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 1: certifi==2023.11.17</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
@@ -87,9 +87,9 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>requests</name>
-      <version>2.25.1</version>
-      <description>requirements line 4: requests==2.25.1</description>
-      <purl>pkg:pypi/requests@2.25.1</purl>
+      <version>2.31.0</version>
+      <description>requirements line 4: requests==2.31.0</description>
+      <purl>pkg:pypi/requests@2.31.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/requests/</url>
@@ -99,9 +99,9 @@
     </component>
     <component type="library" bom-ref="requirements-L5">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 5: urllib3==1.26.5</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 5: urllib3==2.2.0</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>

--- a/tests/_data/snapshots/requirements/file_with-comments_1.3.json.bin
+++ b/tests/_data/snapshots/requirements/file_with-comments_1.3.json.bin
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "requirements-L1",
-      "description": "requirements line 1: certifi==2021.5.30",
+      "description": "requirements line 1: certifi==2023.11.17",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -11,9 +11,9 @@
         }
       ],
       "name": "certifi",
-      "purl": "pkg:pypi/certifi@2021.5.30",
+      "purl": "pkg:pypi/certifi@2023.11.17",
       "type": "library",
-      "version": "2021.5.30"
+      "version": "2023.11.17"
     },
     {
       "bom-ref": "requirements-L2",
@@ -47,7 +47,7 @@
     },
     {
       "bom-ref": "requirements-L4",
-      "description": "requirements line 4: requests==2.25.1",
+      "description": "requirements line 4: requests==2.31.0",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -56,13 +56,13 @@
         }
       ],
       "name": "requests",
-      "purl": "pkg:pypi/requests@2.25.1",
+      "purl": "pkg:pypi/requests@2.31.0",
       "type": "library",
-      "version": "2.25.1"
+      "version": "2.31.0"
     },
     {
       "bom-ref": "requirements-L5",
-      "description": "requirements line 5: urllib3==1.26.5",
+      "description": "requirements line 5: urllib3==2.2.0",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -71,9 +71,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.5",
+      "purl": "pkg:pypi/urllib3@2.2.0",
       "type": "library",
-      "version": "1.26.5"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [

--- a/tests/_data/snapshots/requirements/file_with-comments_1.3.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-comments_1.3.xml.bin
@@ -54,9 +54,9 @@
   <components>
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 1: certifi==2021.5.30</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 1: certifi==2023.11.17</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
@@ -90,9 +90,9 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>requests</name>
-      <version>2.25.1</version>
-      <description>requirements line 4: requests==2.25.1</description>
-      <purl>pkg:pypi/requests@2.25.1</purl>
+      <version>2.31.0</version>
+      <description>requirements line 4: requests==2.31.0</description>
+      <purl>pkg:pypi/requests@2.31.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/requests/</url>
@@ -102,9 +102,9 @@
     </component>
     <component type="library" bom-ref="requirements-L5">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 5: urllib3==1.26.5</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 5: urllib3==2.2.0</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>

--- a/tests/_data/snapshots/requirements/file_with-comments_1.4.json.bin
+++ b/tests/_data/snapshots/requirements/file_with-comments_1.4.json.bin
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "requirements-L1",
-      "description": "requirements line 1: certifi==2021.5.30",
+      "description": "requirements line 1: certifi==2023.11.17",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -11,9 +11,9 @@
         }
       ],
       "name": "certifi",
-      "purl": "pkg:pypi/certifi@2021.5.30",
+      "purl": "pkg:pypi/certifi@2023.11.17",
       "type": "library",
-      "version": "2021.5.30"
+      "version": "2023.11.17"
     },
     {
       "bom-ref": "requirements-L2",
@@ -47,7 +47,7 @@
     },
     {
       "bom-ref": "requirements-L4",
-      "description": "requirements line 4: requests==2.25.1",
+      "description": "requirements line 4: requests==2.31.0",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -56,13 +56,13 @@
         }
       ],
       "name": "requests",
-      "purl": "pkg:pypi/requests@2.25.1",
+      "purl": "pkg:pypi/requests@2.31.0",
       "type": "library",
-      "version": "2.25.1"
+      "version": "2.31.0"
     },
     {
       "bom-ref": "requirements-L5",
-      "description": "requirements line 5: urllib3==1.26.5",
+      "description": "requirements line 5: urllib3==2.2.0",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -71,9 +71,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.5",
+      "purl": "pkg:pypi/urllib3@2.2.0",
       "type": "library",
-      "version": "1.26.5"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [

--- a/tests/_data/snapshots/requirements/file_with-comments_1.4.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-comments_1.4.xml.bin
@@ -81,9 +81,9 @@
   <components>
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 1: certifi==2021.5.30</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 1: certifi==2023.11.17</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
@@ -117,9 +117,9 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>requests</name>
-      <version>2.25.1</version>
-      <description>requirements line 4: requests==2.25.1</description>
-      <purl>pkg:pypi/requests@2.25.1</purl>
+      <version>2.31.0</version>
+      <description>requirements line 4: requests==2.31.0</description>
+      <purl>pkg:pypi/requests@2.31.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/requests/</url>
@@ -129,9 +129,9 @@
     </component>
     <component type="library" bom-ref="requirements-L5">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 5: urllib3==1.26.5</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 5: urllib3==2.2.0</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>

--- a/tests/_data/snapshots/requirements/file_with-comments_1.5.json.bin
+++ b/tests/_data/snapshots/requirements/file_with-comments_1.5.json.bin
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "requirements-L1",
-      "description": "requirements line 1: certifi==2021.5.30",
+      "description": "requirements line 1: certifi==2023.11.17",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -11,9 +11,9 @@
         }
       ],
       "name": "certifi",
-      "purl": "pkg:pypi/certifi@2021.5.30",
+      "purl": "pkg:pypi/certifi@2023.11.17",
       "type": "library",
-      "version": "2021.5.30"
+      "version": "2023.11.17"
     },
     {
       "bom-ref": "requirements-L2",
@@ -47,7 +47,7 @@
     },
     {
       "bom-ref": "requirements-L4",
-      "description": "requirements line 4: requests==2.25.1",
+      "description": "requirements line 4: requests==2.31.0",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -56,13 +56,13 @@
         }
       ],
       "name": "requests",
-      "purl": "pkg:pypi/requests@2.25.1",
+      "purl": "pkg:pypi/requests@2.31.0",
       "type": "library",
-      "version": "2.25.1"
+      "version": "2.31.0"
     },
     {
       "bom-ref": "requirements-L5",
-      "description": "requirements line 5: urllib3==1.26.5",
+      "description": "requirements line 5: urllib3==2.2.0",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -71,9 +71,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.5",
+      "purl": "pkg:pypi/urllib3@2.2.0",
       "type": "library",
-      "version": "1.26.5"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [

--- a/tests/_data/snapshots/requirements/file_with-comments_1.5.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-comments_1.5.xml.bin
@@ -81,9 +81,9 @@
   <components>
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 1: certifi==2021.5.30</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 1: certifi==2023.11.17</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
@@ -117,9 +117,9 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>requests</name>
-      <version>2.25.1</version>
-      <description>requirements line 4: requests==2.25.1</description>
-      <purl>pkg:pypi/requests@2.25.1</purl>
+      <version>2.31.0</version>
+      <description>requirements line 4: requests==2.31.0</description>
+      <purl>pkg:pypi/requests@2.31.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/requests/</url>
@@ -129,9 +129,9 @@
     </component>
     <component type="library" bom-ref="requirements-L5">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 5: urllib3==1.26.5</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 5: urllib3==2.2.0</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>

--- a/tests/_data/snapshots/requirements/file_with-hashes_1.0.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-hashes_1.0.xml.bin
@@ -10,9 +10,9 @@
     </component>
     <component type="library">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <modified>false</modified>
     </component>
     <component type="library">
@@ -31,9 +31,9 @@
     </component>
     <component type="library">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <modified>false</modified>
     </component>
   </components>

--- a/tests/_data/snapshots/requirements/file_with-hashes_1.1.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-hashes_1.1.xml.bin
@@ -15,9 +15,9 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
@@ -51,9 +51,9 @@
     </component>
     <component type="library" bom-ref="requirements-L7">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>

--- a/tests/_data/snapshots/requirements/file_with-hashes_1.2.json.bin
+++ b/tests/_data/snapshots/requirements/file_with-hashes_1.2.json.bin
@@ -17,7 +17,7 @@
     },
     {
       "bom-ref": "requirements-L4",
-      "description": "requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8",
+      "description": "requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -26,9 +26,9 @@
         }
       ],
       "name": "certifi",
-      "purl": "pkg:pypi/certifi@2021.5.30",
+      "purl": "pkg:pypi/certifi@2023.11.17",
       "type": "library",
-      "version": "2021.5.30"
+      "version": "2023.11.17"
     },
     {
       "bom-ref": "requirements-L16",
@@ -62,7 +62,7 @@
     },
     {
       "bom-ref": "requirements-L7",
-      "description": "requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098",
+      "description": "requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -71,9 +71,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.5",
+      "purl": "pkg:pypi/urllib3@2.2.0",
       "type": "library",
-      "version": "1.26.5"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [

--- a/tests/_data/snapshots/requirements/file_with-hashes_1.2.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-hashes_1.2.xml.bin
@@ -63,9 +63,9 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
@@ -99,9 +99,9 @@
     </component>
     <component type="library" bom-ref="requirements-L7">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>

--- a/tests/_data/snapshots/requirements/file_with-hashes_1.3.json.bin
+++ b/tests/_data/snapshots/requirements/file_with-hashes_1.3.json.bin
@@ -27,18 +27,18 @@
     },
     {
       "bom-ref": "requirements-L4",
-      "description": "requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8",
+      "description": "requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1",
       "externalReferences": [
         {
           "comment": "implicit dist url",
           "hashes": [
             {
               "alg": "SHA-256",
-              "content": "2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"
+              "content": "9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1"
             },
             {
               "alg": "SHA-256",
-              "content": "50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
+              "content": "e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"
             }
           ],
           "type": "distribution",
@@ -46,9 +46,9 @@
         }
       ],
       "name": "certifi",
-      "purl": "pkg:pypi/certifi@2021.5.30",
+      "purl": "pkg:pypi/certifi@2023.11.17",
       "type": "library",
-      "version": "2021.5.30"
+      "version": "2023.11.17"
     },
     {
       "bom-ref": "requirements-L16",
@@ -92,18 +92,18 @@
     },
     {
       "bom-ref": "requirements-L7",
-      "description": "requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098",
+      "description": "requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224",
       "externalReferences": [
         {
           "comment": "implicit dist url",
           "hashes": [
             {
               "alg": "SHA-256",
-              "content": "753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c"
+              "content": "051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20"
             },
             {
               "alg": "SHA-256",
-              "content": "a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+              "content": "ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224"
             }
           ],
           "type": "distribution",
@@ -111,9 +111,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.5",
+      "purl": "pkg:pypi/urllib3@2.2.0",
       "type": "library",
-      "version": "1.26.5"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [

--- a/tests/_data/snapshots/requirements/file_with-hashes_1.3.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-hashes_1.3.xml.bin
@@ -70,16 +70,16 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
           <comment>implicit dist url</comment>
           <hashes>
-            <hash alg="SHA-256">2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee</hash>
-            <hash alg="SHA-256">50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</hash>
+            <hash alg="SHA-256">9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</hash>
+            <hash alg="SHA-256">e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474</hash>
           </hashes>
         </reference>
       </externalReferences>
@@ -114,16 +114,16 @@
     </component>
     <component type="library" bom-ref="requirements-L7">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>
           <comment>implicit dist url</comment>
           <hashes>
-            <hash alg="SHA-256">753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c</hash>
-            <hash alg="SHA-256">a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</hash>
+            <hash alg="SHA-256">051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20</hash>
+            <hash alg="SHA-256">ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</hash>
           </hashes>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/requirements/file_with-hashes_1.4.json.bin
+++ b/tests/_data/snapshots/requirements/file_with-hashes_1.4.json.bin
@@ -27,18 +27,18 @@
     },
     {
       "bom-ref": "requirements-L4",
-      "description": "requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8",
+      "description": "requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1",
       "externalReferences": [
         {
           "comment": "implicit dist url",
           "hashes": [
             {
               "alg": "SHA-256",
-              "content": "2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"
+              "content": "9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1"
             },
             {
               "alg": "SHA-256",
-              "content": "50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
+              "content": "e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"
             }
           ],
           "type": "distribution",
@@ -46,9 +46,9 @@
         }
       ],
       "name": "certifi",
-      "purl": "pkg:pypi/certifi@2021.5.30",
+      "purl": "pkg:pypi/certifi@2023.11.17",
       "type": "library",
-      "version": "2021.5.30"
+      "version": "2023.11.17"
     },
     {
       "bom-ref": "requirements-L16",
@@ -91,18 +91,18 @@
     },
     {
       "bom-ref": "requirements-L7",
-      "description": "requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098",
+      "description": "requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224",
       "externalReferences": [
         {
           "comment": "implicit dist url",
           "hashes": [
             {
               "alg": "SHA-256",
-              "content": "753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c"
+              "content": "051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20"
             },
             {
               "alg": "SHA-256",
-              "content": "a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+              "content": "ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224"
             }
           ],
           "type": "distribution",
@@ -110,9 +110,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.5",
+      "purl": "pkg:pypi/urllib3@2.2.0",
       "type": "library",
-      "version": "1.26.5"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [

--- a/tests/_data/snapshots/requirements/file_with-hashes_1.4.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-hashes_1.4.xml.bin
@@ -97,16 +97,16 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
           <comment>implicit dist url</comment>
           <hashes>
-            <hash alg="SHA-256">2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee</hash>
-            <hash alg="SHA-256">50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</hash>
+            <hash alg="SHA-256">9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</hash>
+            <hash alg="SHA-256">e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474</hash>
           </hashes>
         </reference>
       </externalReferences>
@@ -140,16 +140,16 @@
     </component>
     <component type="library" bom-ref="requirements-L7">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>
           <comment>implicit dist url</comment>
           <hashes>
-            <hash alg="SHA-256">753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c</hash>
-            <hash alg="SHA-256">a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</hash>
+            <hash alg="SHA-256">051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20</hash>
+            <hash alg="SHA-256">ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</hash>
           </hashes>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/requirements/file_with-hashes_1.5.json.bin
+++ b/tests/_data/snapshots/requirements/file_with-hashes_1.5.json.bin
@@ -27,18 +27,18 @@
     },
     {
       "bom-ref": "requirements-L4",
-      "description": "requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8",
+      "description": "requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1",
       "externalReferences": [
         {
           "comment": "implicit dist url",
           "hashes": [
             {
               "alg": "SHA-256",
-              "content": "2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"
+              "content": "9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1"
             },
             {
               "alg": "SHA-256",
-              "content": "50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
+              "content": "e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"
             }
           ],
           "type": "distribution",
@@ -46,9 +46,9 @@
         }
       ],
       "name": "certifi",
-      "purl": "pkg:pypi/certifi@2021.5.30",
+      "purl": "pkg:pypi/certifi@2023.11.17",
       "type": "library",
-      "version": "2021.5.30"
+      "version": "2023.11.17"
     },
     {
       "bom-ref": "requirements-L16",
@@ -91,18 +91,18 @@
     },
     {
       "bom-ref": "requirements-L7",
-      "description": "requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098",
+      "description": "requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224",
       "externalReferences": [
         {
           "comment": "implicit dist url",
           "hashes": [
             {
               "alg": "SHA-256",
-              "content": "753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c"
+              "content": "051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20"
             },
             {
               "alg": "SHA-256",
-              "content": "a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+              "content": "ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224"
             }
           ],
           "type": "distribution",
@@ -110,9 +110,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.5",
+      "purl": "pkg:pypi/urllib3@2.2.0",
       "type": "library",
-      "version": "1.26.5"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [

--- a/tests/_data/snapshots/requirements/file_with-hashes_1.5.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-hashes_1.5.xml.bin
@@ -97,16 +97,16 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
           <comment>implicit dist url</comment>
           <hashes>
-            <hash alg="SHA-256">2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee</hash>
-            <hash alg="SHA-256">50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</hash>
+            <hash alg="SHA-256">9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</hash>
+            <hash alg="SHA-256">e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474</hash>
           </hashes>
         </reference>
       </externalReferences>
@@ -140,16 +140,16 @@
     </component>
     <component type="library" bom-ref="requirements-L7">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>
           <comment>implicit dist url</comment>
           <hashes>
-            <hash alg="SHA-256">753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c</hash>
-            <hash alg="SHA-256">a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</hash>
+            <hash alg="SHA-256">051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20</hash>
+            <hash alg="SHA-256">ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</hash>
           </hashes>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/requirements/file_with-urls_1.0.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-urls_1.0.xml.bin
@@ -38,8 +38,8 @@
     <component type="library">
       <name>urllib3</name>
       <version/>
-      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</description>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</description>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <modified>false</modified>
     </component>
     <component type="library">

--- a/tests/_data/snapshots/requirements/file_with-urls_1.1.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-urls_1.1.xml.bin
@@ -63,11 +63,11 @@
     <component type="library" bom-ref="requirements-L23">
       <name>urllib3</name>
       <version/>
-      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</description>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</description>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>explicit dist url</comment>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/requirements/file_with-urls_1.2.json.bin
+++ b/tests/_data/snapshots/requirements/file_with-urls_1.2.json.bin
@@ -76,16 +76,16 @@
     },
     {
       "bom-ref": "requirements-L23",
-      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "externalReferences": [
         {
           "comment": "explicit dist url",
           "type": "distribution",
-          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "type": "library",
       "version": ""
     },

--- a/tests/_data/snapshots/requirements/file_with-urls_1.2.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-urls_1.2.xml.bin
@@ -111,11 +111,11 @@
     <component type="library" bom-ref="requirements-L23">
       <name>urllib3</name>
       <version/>
-      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</description>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</description>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>explicit dist url</comment>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/requirements/file_with-urls_1.3.json.bin
+++ b/tests/_data/snapshots/requirements/file_with-urls_1.3.json.bin
@@ -76,16 +76,16 @@
     },
     {
       "bom-ref": "requirements-L23",
-      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "externalReferences": [
         {
           "comment": "explicit dist url",
           "type": "distribution",
-          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "type": "library",
       "version": ""
     },

--- a/tests/_data/snapshots/requirements/file_with-urls_1.3.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-urls_1.3.xml.bin
@@ -114,11 +114,11 @@
     <component type="library" bom-ref="requirements-L23">
       <name>urllib3</name>
       <version/>
-      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</description>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</description>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>explicit dist url</comment>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/requirements/file_with-urls_1.4.json.bin
+++ b/tests/_data/snapshots/requirements/file_with-urls_1.4.json.bin
@@ -71,16 +71,16 @@
     },
     {
       "bom-ref": "requirements-L23",
-      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "externalReferences": [
         {
           "comment": "explicit dist url",
           "type": "distribution",
-          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "type": "library"
     },
     {

--- a/tests/_data/snapshots/requirements/file_with-urls_1.4.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-urls_1.4.xml.bin
@@ -135,11 +135,11 @@
     </component>
     <component type="library" bom-ref="requirements-L23">
       <name>urllib3</name>
-      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</description>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</description>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>explicit dist url</comment>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/requirements/file_with-urls_1.5.json.bin
+++ b/tests/_data/snapshots/requirements/file_with-urls_1.5.json.bin
@@ -71,16 +71,16 @@
     },
     {
       "bom-ref": "requirements-L23",
-      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "externalReferences": [
         {
           "comment": "explicit dist url",
           "type": "distribution",
-          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "type": "library"
     },
     {

--- a/tests/_data/snapshots/requirements/file_with-urls_1.5.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-urls_1.5.xml.bin
@@ -135,11 +135,11 @@
     </component>
     <component type="library" bom-ref="requirements-L23">
       <name>urllib3</name>
-      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</description>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</description>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>explicit dist url</comment>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/requirements/file_without-pinned-versions_1.0.xml.bin
+++ b/tests/_data/snapshots/requirements/file_without-pinned-versions_1.0.xml.bin
@@ -4,7 +4,7 @@
     <component type="library">
       <name>certifi</name>
       <version/>
-      <description>requirements line 1: certifi&gt;=2021.5.30</description>
+      <description>requirements line 1: certifi&gt;=2023.11.17</description>
       <purl>pkg:pypi/certifi</purl>
       <modified>false</modified>
     </component>

--- a/tests/_data/snapshots/requirements/file_without-pinned-versions_1.1.xml.bin
+++ b/tests/_data/snapshots/requirements/file_without-pinned-versions_1.1.xml.bin
@@ -4,7 +4,7 @@
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
       <version/>
-      <description>requirements line 1: certifi&gt;=2021.5.30</description>
+      <description>requirements line 1: certifi&gt;=2023.11.17</description>
       <purl>pkg:pypi/certifi</purl>
       <externalReferences>
         <reference type="distribution">

--- a/tests/_data/snapshots/requirements/file_without-pinned-versions_1.2.json.bin
+++ b/tests/_data/snapshots/requirements/file_without-pinned-versions_1.2.json.bin
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "requirements-L1",
-      "description": "requirements line 1: certifi>=2021.5.30",
+      "description": "requirements line 1: certifi>=2023.11.17",
       "externalReferences": [
         {
           "comment": "implicit dist url",

--- a/tests/_data/snapshots/requirements/file_without-pinned-versions_1.2.xml.bin
+++ b/tests/_data/snapshots/requirements/file_without-pinned-versions_1.2.xml.bin
@@ -52,7 +52,7 @@
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
       <version/>
-      <description>requirements line 1: certifi&gt;=2021.5.30</description>
+      <description>requirements line 1: certifi&gt;=2023.11.17</description>
       <purl>pkg:pypi/certifi</purl>
       <externalReferences>
         <reference type="distribution">

--- a/tests/_data/snapshots/requirements/file_without-pinned-versions_1.3.json.bin
+++ b/tests/_data/snapshots/requirements/file_without-pinned-versions_1.3.json.bin
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "requirements-L1",
-      "description": "requirements line 1: certifi>=2021.5.30",
+      "description": "requirements line 1: certifi>=2023.11.17",
       "externalReferences": [
         {
           "comment": "implicit dist url",

--- a/tests/_data/snapshots/requirements/file_without-pinned-versions_1.3.xml.bin
+++ b/tests/_data/snapshots/requirements/file_without-pinned-versions_1.3.xml.bin
@@ -55,7 +55,7 @@
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
       <version/>
-      <description>requirements line 1: certifi&gt;=2021.5.30</description>
+      <description>requirements line 1: certifi&gt;=2023.11.17</description>
       <purl>pkg:pypi/certifi</purl>
       <externalReferences>
         <reference type="distribution">

--- a/tests/_data/snapshots/requirements/file_without-pinned-versions_1.4.json.bin
+++ b/tests/_data/snapshots/requirements/file_without-pinned-versions_1.4.json.bin
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "requirements-L1",
-      "description": "requirements line 1: certifi>=2021.5.30",
+      "description": "requirements line 1: certifi>=2023.11.17",
       "externalReferences": [
         {
           "comment": "implicit dist url",

--- a/tests/_data/snapshots/requirements/file_without-pinned-versions_1.4.xml.bin
+++ b/tests/_data/snapshots/requirements/file_without-pinned-versions_1.4.xml.bin
@@ -81,7 +81,7 @@
   <components>
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
-      <description>requirements line 1: certifi&gt;=2021.5.30</description>
+      <description>requirements line 1: certifi&gt;=2023.11.17</description>
       <purl>pkg:pypi/certifi</purl>
       <externalReferences>
         <reference type="distribution">

--- a/tests/_data/snapshots/requirements/file_without-pinned-versions_1.5.json.bin
+++ b/tests/_data/snapshots/requirements/file_without-pinned-versions_1.5.json.bin
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "requirements-L1",
-      "description": "requirements line 1: certifi>=2021.5.30",
+      "description": "requirements line 1: certifi>=2023.11.17",
       "externalReferences": [
         {
           "comment": "implicit dist url",

--- a/tests/_data/snapshots/requirements/file_without-pinned-versions_1.5.xml.bin
+++ b/tests/_data/snapshots/requirements/file_without-pinned-versions_1.5.xml.bin
@@ -81,7 +81,7 @@
   <components>
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
-      <description>requirements line 1: certifi&gt;=2021.5.30</description>
+      <description>requirements line 1: certifi&gt;=2023.11.17</description>
       <purl>pkg:pypi/certifi</purl>
       <externalReferences>
         <reference type="distribution">

--- a/tests/_data/snapshots/requirements/stream_with-comments_1.0.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-comments_1.0.xml.bin
@@ -3,9 +3,9 @@
   <components>
     <component type="library">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 1: certifi==2021.5.30</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 1: certifi==2023.11.17</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <modified>false</modified>
     </component>
     <component type="library">
@@ -24,16 +24,16 @@
     </component>
     <component type="library">
       <name>requests</name>
-      <version>2.25.1</version>
-      <description>requirements line 4: requests==2.25.1</description>
-      <purl>pkg:pypi/requests@2.25.1</purl>
+      <version>2.31.0</version>
+      <description>requirements line 4: requests==2.31.0</description>
+      <purl>pkg:pypi/requests@2.31.0</purl>
       <modified>false</modified>
     </component>
     <component type="library">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 5: urllib3==1.26.5</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 5: urllib3==2.2.0</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <modified>false</modified>
     </component>
   </components>

--- a/tests/_data/snapshots/requirements/stream_with-comments_1.1.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-comments_1.1.xml.bin
@@ -3,9 +3,9 @@
   <components>
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 1: certifi==2021.5.30</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 1: certifi==2023.11.17</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
@@ -39,9 +39,9 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>requests</name>
-      <version>2.25.1</version>
-      <description>requirements line 4: requests==2.25.1</description>
-      <purl>pkg:pypi/requests@2.25.1</purl>
+      <version>2.31.0</version>
+      <description>requirements line 4: requests==2.31.0</description>
+      <purl>pkg:pypi/requests@2.31.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/requests/</url>
@@ -51,9 +51,9 @@
     </component>
     <component type="library" bom-ref="requirements-L5">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 5: urllib3==1.26.5</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 5: urllib3==2.2.0</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>

--- a/tests/_data/snapshots/requirements/stream_with-comments_1.2.json.bin
+++ b/tests/_data/snapshots/requirements/stream_with-comments_1.2.json.bin
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "requirements-L1",
-      "description": "requirements line 1: certifi==2021.5.30",
+      "description": "requirements line 1: certifi==2023.11.17",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -11,9 +11,9 @@
         }
       ],
       "name": "certifi",
-      "purl": "pkg:pypi/certifi@2021.5.30",
+      "purl": "pkg:pypi/certifi@2023.11.17",
       "type": "library",
-      "version": "2021.5.30"
+      "version": "2023.11.17"
     },
     {
       "bom-ref": "requirements-L2",
@@ -47,7 +47,7 @@
     },
     {
       "bom-ref": "requirements-L4",
-      "description": "requirements line 4: requests==2.25.1",
+      "description": "requirements line 4: requests==2.31.0",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -56,13 +56,13 @@
         }
       ],
       "name": "requests",
-      "purl": "pkg:pypi/requests@2.25.1",
+      "purl": "pkg:pypi/requests@2.31.0",
       "type": "library",
-      "version": "2.25.1"
+      "version": "2.31.0"
     },
     {
       "bom-ref": "requirements-L5",
-      "description": "requirements line 5: urllib3==1.26.5",
+      "description": "requirements line 5: urllib3==2.2.0",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -71,9 +71,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.5",
+      "purl": "pkg:pypi/urllib3@2.2.0",
       "type": "library",
-      "version": "1.26.5"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [

--- a/tests/_data/snapshots/requirements/stream_with-comments_1.2.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-comments_1.2.xml.bin
@@ -17,9 +17,9 @@
   <components>
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 1: certifi==2021.5.30</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 1: certifi==2023.11.17</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
@@ -53,9 +53,9 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>requests</name>
-      <version>2.25.1</version>
-      <description>requirements line 4: requests==2.25.1</description>
-      <purl>pkg:pypi/requests@2.25.1</purl>
+      <version>2.31.0</version>
+      <description>requirements line 4: requests==2.31.0</description>
+      <purl>pkg:pypi/requests@2.31.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/requests/</url>
@@ -65,9 +65,9 @@
     </component>
     <component type="library" bom-ref="requirements-L5">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 5: urllib3==1.26.5</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 5: urllib3==2.2.0</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>

--- a/tests/_data/snapshots/requirements/stream_with-comments_1.3.json.bin
+++ b/tests/_data/snapshots/requirements/stream_with-comments_1.3.json.bin
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "requirements-L1",
-      "description": "requirements line 1: certifi==2021.5.30",
+      "description": "requirements line 1: certifi==2023.11.17",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -11,9 +11,9 @@
         }
       ],
       "name": "certifi",
-      "purl": "pkg:pypi/certifi@2021.5.30",
+      "purl": "pkg:pypi/certifi@2023.11.17",
       "type": "library",
-      "version": "2021.5.30"
+      "version": "2023.11.17"
     },
     {
       "bom-ref": "requirements-L2",
@@ -47,7 +47,7 @@
     },
     {
       "bom-ref": "requirements-L4",
-      "description": "requirements line 4: requests==2.25.1",
+      "description": "requirements line 4: requests==2.31.0",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -56,13 +56,13 @@
         }
       ],
       "name": "requests",
-      "purl": "pkg:pypi/requests@2.25.1",
+      "purl": "pkg:pypi/requests@2.31.0",
       "type": "library",
-      "version": "2.25.1"
+      "version": "2.31.0"
     },
     {
       "bom-ref": "requirements-L5",
-      "description": "requirements line 5: urllib3==1.26.5",
+      "description": "requirements line 5: urllib3==2.2.0",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -71,9 +71,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.5",
+      "purl": "pkg:pypi/urllib3@2.2.0",
       "type": "library",
-      "version": "1.26.5"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [

--- a/tests/_data/snapshots/requirements/stream_with-comments_1.3.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-comments_1.3.xml.bin
@@ -20,9 +20,9 @@
   <components>
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 1: certifi==2021.5.30</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 1: certifi==2023.11.17</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
@@ -56,9 +56,9 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>requests</name>
-      <version>2.25.1</version>
-      <description>requirements line 4: requests==2.25.1</description>
-      <purl>pkg:pypi/requests@2.25.1</purl>
+      <version>2.31.0</version>
+      <description>requirements line 4: requests==2.31.0</description>
+      <purl>pkg:pypi/requests@2.31.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/requests/</url>
@@ -68,9 +68,9 @@
     </component>
     <component type="library" bom-ref="requirements-L5">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 5: urllib3==1.26.5</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 5: urllib3==2.2.0</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>

--- a/tests/_data/snapshots/requirements/stream_with-comments_1.4.json.bin
+++ b/tests/_data/snapshots/requirements/stream_with-comments_1.4.json.bin
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "requirements-L1",
-      "description": "requirements line 1: certifi==2021.5.30",
+      "description": "requirements line 1: certifi==2023.11.17",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -11,9 +11,9 @@
         }
       ],
       "name": "certifi",
-      "purl": "pkg:pypi/certifi@2021.5.30",
+      "purl": "pkg:pypi/certifi@2023.11.17",
       "type": "library",
-      "version": "2021.5.30"
+      "version": "2023.11.17"
     },
     {
       "bom-ref": "requirements-L2",
@@ -47,7 +47,7 @@
     },
     {
       "bom-ref": "requirements-L4",
-      "description": "requirements line 4: requests==2.25.1",
+      "description": "requirements line 4: requests==2.31.0",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -56,13 +56,13 @@
         }
       ],
       "name": "requests",
-      "purl": "pkg:pypi/requests@2.25.1",
+      "purl": "pkg:pypi/requests@2.31.0",
       "type": "library",
-      "version": "2.25.1"
+      "version": "2.31.0"
     },
     {
       "bom-ref": "requirements-L5",
-      "description": "requirements line 5: urllib3==1.26.5",
+      "description": "requirements line 5: urllib3==2.2.0",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -71,9 +71,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.5",
+      "purl": "pkg:pypi/urllib3@2.2.0",
       "type": "library",
-      "version": "1.26.5"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [

--- a/tests/_data/snapshots/requirements/stream_with-comments_1.4.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-comments_1.4.xml.bin
@@ -47,9 +47,9 @@
   <components>
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 1: certifi==2021.5.30</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 1: certifi==2023.11.17</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
@@ -83,9 +83,9 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>requests</name>
-      <version>2.25.1</version>
-      <description>requirements line 4: requests==2.25.1</description>
-      <purl>pkg:pypi/requests@2.25.1</purl>
+      <version>2.31.0</version>
+      <description>requirements line 4: requests==2.31.0</description>
+      <purl>pkg:pypi/requests@2.31.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/requests/</url>
@@ -95,9 +95,9 @@
     </component>
     <component type="library" bom-ref="requirements-L5">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 5: urllib3==1.26.5</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 5: urllib3==2.2.0</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>

--- a/tests/_data/snapshots/requirements/stream_with-comments_1.5.json.bin
+++ b/tests/_data/snapshots/requirements/stream_with-comments_1.5.json.bin
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "requirements-L1",
-      "description": "requirements line 1: certifi==2021.5.30",
+      "description": "requirements line 1: certifi==2023.11.17",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -11,9 +11,9 @@
         }
       ],
       "name": "certifi",
-      "purl": "pkg:pypi/certifi@2021.5.30",
+      "purl": "pkg:pypi/certifi@2023.11.17",
       "type": "library",
-      "version": "2021.5.30"
+      "version": "2023.11.17"
     },
     {
       "bom-ref": "requirements-L2",
@@ -47,7 +47,7 @@
     },
     {
       "bom-ref": "requirements-L4",
-      "description": "requirements line 4: requests==2.25.1",
+      "description": "requirements line 4: requests==2.31.0",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -56,13 +56,13 @@
         }
       ],
       "name": "requests",
-      "purl": "pkg:pypi/requests@2.25.1",
+      "purl": "pkg:pypi/requests@2.31.0",
       "type": "library",
-      "version": "2.25.1"
+      "version": "2.31.0"
     },
     {
       "bom-ref": "requirements-L5",
-      "description": "requirements line 5: urllib3==1.26.5",
+      "description": "requirements line 5: urllib3==2.2.0",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -71,9 +71,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.5",
+      "purl": "pkg:pypi/urllib3@2.2.0",
       "type": "library",
-      "version": "1.26.5"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [

--- a/tests/_data/snapshots/requirements/stream_with-comments_1.5.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-comments_1.5.xml.bin
@@ -47,9 +47,9 @@
   <components>
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 1: certifi==2021.5.30</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 1: certifi==2023.11.17</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
@@ -83,9 +83,9 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>requests</name>
-      <version>2.25.1</version>
-      <description>requirements line 4: requests==2.25.1</description>
-      <purl>pkg:pypi/requests@2.25.1</purl>
+      <version>2.31.0</version>
+      <description>requirements line 4: requests==2.31.0</description>
+      <purl>pkg:pypi/requests@2.31.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/requests/</url>
@@ -95,9 +95,9 @@
     </component>
     <component type="library" bom-ref="requirements-L5">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 5: urllib3==1.26.5</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 5: urllib3==2.2.0</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>

--- a/tests/_data/snapshots/requirements/stream_with-hashes_1.0.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-hashes_1.0.xml.bin
@@ -10,9 +10,9 @@
     </component>
     <component type="library">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <modified>false</modified>
     </component>
     <component type="library">
@@ -31,9 +31,9 @@
     </component>
     <component type="library">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <modified>false</modified>
     </component>
   </components>

--- a/tests/_data/snapshots/requirements/stream_with-hashes_1.1.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-hashes_1.1.xml.bin
@@ -15,9 +15,9 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
@@ -51,9 +51,9 @@
     </component>
     <component type="library" bom-ref="requirements-L7">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>

--- a/tests/_data/snapshots/requirements/stream_with-hashes_1.2.json.bin
+++ b/tests/_data/snapshots/requirements/stream_with-hashes_1.2.json.bin
@@ -17,7 +17,7 @@
     },
     {
       "bom-ref": "requirements-L4",
-      "description": "requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8",
+      "description": "requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -26,9 +26,9 @@
         }
       ],
       "name": "certifi",
-      "purl": "pkg:pypi/certifi@2021.5.30",
+      "purl": "pkg:pypi/certifi@2023.11.17",
       "type": "library",
-      "version": "2021.5.30"
+      "version": "2023.11.17"
     },
     {
       "bom-ref": "requirements-L16",
@@ -62,7 +62,7 @@
     },
     {
       "bom-ref": "requirements-L7",
-      "description": "requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098",
+      "description": "requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -71,9 +71,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.5",
+      "purl": "pkg:pypi/urllib3@2.2.0",
       "type": "library",
-      "version": "1.26.5"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [

--- a/tests/_data/snapshots/requirements/stream_with-hashes_1.2.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-hashes_1.2.xml.bin
@@ -29,9 +29,9 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
@@ -65,9 +65,9 @@
     </component>
     <component type="library" bom-ref="requirements-L7">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>

--- a/tests/_data/snapshots/requirements/stream_with-hashes_1.3.json.bin
+++ b/tests/_data/snapshots/requirements/stream_with-hashes_1.3.json.bin
@@ -27,18 +27,18 @@
     },
     {
       "bom-ref": "requirements-L4",
-      "description": "requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8",
+      "description": "requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1",
       "externalReferences": [
         {
           "comment": "implicit dist url",
           "hashes": [
             {
               "alg": "SHA-256",
-              "content": "2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"
+              "content": "9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1"
             },
             {
               "alg": "SHA-256",
-              "content": "50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
+              "content": "e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"
             }
           ],
           "type": "distribution",
@@ -46,9 +46,9 @@
         }
       ],
       "name": "certifi",
-      "purl": "pkg:pypi/certifi@2021.5.30",
+      "purl": "pkg:pypi/certifi@2023.11.17",
       "type": "library",
-      "version": "2021.5.30"
+      "version": "2023.11.17"
     },
     {
       "bom-ref": "requirements-L16",
@@ -92,18 +92,18 @@
     },
     {
       "bom-ref": "requirements-L7",
-      "description": "requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098",
+      "description": "requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224",
       "externalReferences": [
         {
           "comment": "implicit dist url",
           "hashes": [
             {
               "alg": "SHA-256",
-              "content": "753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c"
+              "content": "051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20"
             },
             {
               "alg": "SHA-256",
-              "content": "a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+              "content": "ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224"
             }
           ],
           "type": "distribution",
@@ -111,9 +111,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.5",
+      "purl": "pkg:pypi/urllib3@2.2.0",
       "type": "library",
-      "version": "1.26.5"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [

--- a/tests/_data/snapshots/requirements/stream_with-hashes_1.3.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-hashes_1.3.xml.bin
@@ -36,16 +36,16 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
           <comment>implicit dist url</comment>
           <hashes>
-            <hash alg="SHA-256">2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee</hash>
-            <hash alg="SHA-256">50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</hash>
+            <hash alg="SHA-256">9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</hash>
+            <hash alg="SHA-256">e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474</hash>
           </hashes>
         </reference>
       </externalReferences>
@@ -80,16 +80,16 @@
     </component>
     <component type="library" bom-ref="requirements-L7">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>
           <comment>implicit dist url</comment>
           <hashes>
-            <hash alg="SHA-256">753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c</hash>
-            <hash alg="SHA-256">a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</hash>
+            <hash alg="SHA-256">051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20</hash>
+            <hash alg="SHA-256">ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</hash>
           </hashes>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/requirements/stream_with-hashes_1.4.json.bin
+++ b/tests/_data/snapshots/requirements/stream_with-hashes_1.4.json.bin
@@ -27,18 +27,18 @@
     },
     {
       "bom-ref": "requirements-L4",
-      "description": "requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8",
+      "description": "requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1",
       "externalReferences": [
         {
           "comment": "implicit dist url",
           "hashes": [
             {
               "alg": "SHA-256",
-              "content": "2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"
+              "content": "9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1"
             },
             {
               "alg": "SHA-256",
-              "content": "50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
+              "content": "e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"
             }
           ],
           "type": "distribution",
@@ -46,9 +46,9 @@
         }
       ],
       "name": "certifi",
-      "purl": "pkg:pypi/certifi@2021.5.30",
+      "purl": "pkg:pypi/certifi@2023.11.17",
       "type": "library",
-      "version": "2021.5.30"
+      "version": "2023.11.17"
     },
     {
       "bom-ref": "requirements-L16",
@@ -91,18 +91,18 @@
     },
     {
       "bom-ref": "requirements-L7",
-      "description": "requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098",
+      "description": "requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224",
       "externalReferences": [
         {
           "comment": "implicit dist url",
           "hashes": [
             {
               "alg": "SHA-256",
-              "content": "753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c"
+              "content": "051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20"
             },
             {
               "alg": "SHA-256",
-              "content": "a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+              "content": "ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224"
             }
           ],
           "type": "distribution",
@@ -110,9 +110,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.5",
+      "purl": "pkg:pypi/urllib3@2.2.0",
       "type": "library",
-      "version": "1.26.5"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [

--- a/tests/_data/snapshots/requirements/stream_with-hashes_1.4.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-hashes_1.4.xml.bin
@@ -63,16 +63,16 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
           <comment>implicit dist url</comment>
           <hashes>
-            <hash alg="SHA-256">2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee</hash>
-            <hash alg="SHA-256">50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</hash>
+            <hash alg="SHA-256">9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</hash>
+            <hash alg="SHA-256">e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474</hash>
           </hashes>
         </reference>
       </externalReferences>
@@ -106,16 +106,16 @@
     </component>
     <component type="library" bom-ref="requirements-L7">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>
           <comment>implicit dist url</comment>
           <hashes>
-            <hash alg="SHA-256">753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c</hash>
-            <hash alg="SHA-256">a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</hash>
+            <hash alg="SHA-256">051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20</hash>
+            <hash alg="SHA-256">ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</hash>
           </hashes>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/requirements/stream_with-hashes_1.5.json.bin
+++ b/tests/_data/snapshots/requirements/stream_with-hashes_1.5.json.bin
@@ -27,18 +27,18 @@
     },
     {
       "bom-ref": "requirements-L4",
-      "description": "requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8",
+      "description": "requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1",
       "externalReferences": [
         {
           "comment": "implicit dist url",
           "hashes": [
             {
               "alg": "SHA-256",
-              "content": "2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"
+              "content": "9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1"
             },
             {
               "alg": "SHA-256",
-              "content": "50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
+              "content": "e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"
             }
           ],
           "type": "distribution",
@@ -46,9 +46,9 @@
         }
       ],
       "name": "certifi",
-      "purl": "pkg:pypi/certifi@2021.5.30",
+      "purl": "pkg:pypi/certifi@2023.11.17",
       "type": "library",
-      "version": "2021.5.30"
+      "version": "2023.11.17"
     },
     {
       "bom-ref": "requirements-L16",
@@ -91,18 +91,18 @@
     },
     {
       "bom-ref": "requirements-L7",
-      "description": "requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098",
+      "description": "requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224",
       "externalReferences": [
         {
           "comment": "implicit dist url",
           "hashes": [
             {
               "alg": "SHA-256",
-              "content": "753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c"
+              "content": "051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20"
             },
             {
               "alg": "SHA-256",
-              "content": "a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+              "content": "ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224"
             }
           ],
           "type": "distribution",
@@ -110,9 +110,9 @@
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3@1.26.5",
+      "purl": "pkg:pypi/urllib3@2.2.0",
       "type": "library",
-      "version": "1.26.5"
+      "version": "2.2.0"
     }
   ],
   "dependencies": [

--- a/tests/_data/snapshots/requirements/stream_with-hashes_1.5.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-hashes_1.5.xml.bin
@@ -63,16 +63,16 @@
     </component>
     <component type="library" bom-ref="requirements-L4">
       <name>certifi</name>
-      <version>2021.5.30</version>
-      <description>requirements line 4: certifi==2021.5.30 --hash=sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</description>
-      <purl>pkg:pypi/certifi@2021.5.30</purl>
+      <version>2023.11.17</version>
+      <description>requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/certifi/</url>
           <comment>implicit dist url</comment>
           <hashes>
-            <hash alg="SHA-256">2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee</hash>
-            <hash alg="SHA-256">50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8</hash>
+            <hash alg="SHA-256">9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</hash>
+            <hash alg="SHA-256">e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474</hash>
           </hashes>
         </reference>
       </externalReferences>
@@ -106,16 +106,16 @@
     </component>
     <component type="library" bom-ref="requirements-L7">
       <name>urllib3</name>
-      <version>1.26.5</version>
-      <description>requirements line 7: urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c  --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</description>
-      <purl>pkg:pypi/urllib3@1.26.5</purl>
+      <version>2.2.0</version>
+      <description>requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://pypi.org/simple/urllib3/</url>
           <comment>implicit dist url</comment>
           <hashes>
-            <hash alg="SHA-256">753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c</hash>
-            <hash alg="SHA-256">a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098</hash>
+            <hash alg="SHA-256">051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20</hash>
+            <hash alg="SHA-256">ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</hash>
           </hashes>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/requirements/stream_with-urls_1.0.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-urls_1.0.xml.bin
@@ -38,8 +38,8 @@
     <component type="library">
       <name>urllib3</name>
       <version/>
-      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</description>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</description>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <modified>false</modified>
     </component>
     <component type="library">

--- a/tests/_data/snapshots/requirements/stream_with-urls_1.1.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-urls_1.1.xml.bin
@@ -63,11 +63,11 @@
     <component type="library" bom-ref="requirements-L23">
       <name>urllib3</name>
       <version/>
-      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</description>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</description>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>explicit dist url</comment>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/requirements/stream_with-urls_1.2.json.bin
+++ b/tests/_data/snapshots/requirements/stream_with-urls_1.2.json.bin
@@ -76,16 +76,16 @@
     },
     {
       "bom-ref": "requirements-L23",
-      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "externalReferences": [
         {
           "comment": "explicit dist url",
           "type": "distribution",
-          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "type": "library",
       "version": ""
     },

--- a/tests/_data/snapshots/requirements/stream_with-urls_1.2.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-urls_1.2.xml.bin
@@ -77,11 +77,11 @@
     <component type="library" bom-ref="requirements-L23">
       <name>urllib3</name>
       <version/>
-      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</description>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</description>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>explicit dist url</comment>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/requirements/stream_with-urls_1.3.json.bin
+++ b/tests/_data/snapshots/requirements/stream_with-urls_1.3.json.bin
@@ -76,16 +76,16 @@
     },
     {
       "bom-ref": "requirements-L23",
-      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "externalReferences": [
         {
           "comment": "explicit dist url",
           "type": "distribution",
-          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "type": "library",
       "version": ""
     },

--- a/tests/_data/snapshots/requirements/stream_with-urls_1.3.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-urls_1.3.xml.bin
@@ -80,11 +80,11 @@
     <component type="library" bom-ref="requirements-L23">
       <name>urllib3</name>
       <version/>
-      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</description>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</description>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>explicit dist url</comment>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/requirements/stream_with-urls_1.4.json.bin
+++ b/tests/_data/snapshots/requirements/stream_with-urls_1.4.json.bin
@@ -71,16 +71,16 @@
     },
     {
       "bom-ref": "requirements-L23",
-      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "externalReferences": [
         {
           "comment": "explicit dist url",
           "type": "distribution",
-          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "type": "library"
     },
     {

--- a/tests/_data/snapshots/requirements/stream_with-urls_1.4.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-urls_1.4.xml.bin
@@ -101,11 +101,11 @@
     </component>
     <component type="library" bom-ref="requirements-L23">
       <name>urllib3</name>
-      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</description>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</description>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>explicit dist url</comment>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/requirements/stream_with-urls_1.5.json.bin
+++ b/tests/_data/snapshots/requirements/stream_with-urls_1.5.json.bin
@@ -71,16 +71,16 @@
     },
     {
       "bom-ref": "requirements-L23",
-      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "externalReferences": [
         {
           "comment": "explicit dist url",
           "type": "distribution",
-          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip"
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
         }
       ],
       "name": "urllib3",
-      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip",
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
       "type": "library"
     },
     {

--- a/tests/_data/snapshots/requirements/stream_with-urls_1.5.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-urls_1.5.xml.bin
@@ -101,11 +101,11 @@
     </component>
     <component type="library" bom-ref="requirements-L23">
       <name>urllib3</name>
-      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</description>
-      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</purl>
+      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</description>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
       <externalReferences>
         <reference type="distribution">
-          <url>https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip</url>
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
           <comment>explicit dist url</comment>
         </reference>
       </externalReferences>

--- a/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.0.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.0.xml.bin
@@ -4,7 +4,7 @@
     <component type="library">
       <name>certifi</name>
       <version/>
-      <description>requirements line 1: certifi&gt;=2021.5.30</description>
+      <description>requirements line 1: certifi&gt;=2023.11.17</description>
       <purl>pkg:pypi/certifi</purl>
       <modified>false</modified>
     </component>

--- a/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.1.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.1.xml.bin
@@ -4,7 +4,7 @@
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
       <version/>
-      <description>requirements line 1: certifi&gt;=2021.5.30</description>
+      <description>requirements line 1: certifi&gt;=2023.11.17</description>
       <purl>pkg:pypi/certifi</purl>
       <externalReferences>
         <reference type="distribution">

--- a/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.2.json.bin
+++ b/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.2.json.bin
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "requirements-L1",
-      "description": "requirements line 1: certifi>=2021.5.30",
+      "description": "requirements line 1: certifi>=2023.11.17",
       "externalReferences": [
         {
           "comment": "implicit dist url",

--- a/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.2.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.2.xml.bin
@@ -18,7 +18,7 @@
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
       <version/>
-      <description>requirements line 1: certifi&gt;=2021.5.30</description>
+      <description>requirements line 1: certifi&gt;=2023.11.17</description>
       <purl>pkg:pypi/certifi</purl>
       <externalReferences>
         <reference type="distribution">

--- a/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.3.json.bin
+++ b/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.3.json.bin
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "requirements-L1",
-      "description": "requirements line 1: certifi>=2021.5.30",
+      "description": "requirements line 1: certifi>=2023.11.17",
       "externalReferences": [
         {
           "comment": "implicit dist url",

--- a/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.3.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.3.xml.bin
@@ -21,7 +21,7 @@
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
       <version/>
-      <description>requirements line 1: certifi&gt;=2021.5.30</description>
+      <description>requirements line 1: certifi&gt;=2023.11.17</description>
       <purl>pkg:pypi/certifi</purl>
       <externalReferences>
         <reference type="distribution">

--- a/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.4.json.bin
+++ b/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.4.json.bin
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "requirements-L1",
-      "description": "requirements line 1: certifi>=2021.5.30",
+      "description": "requirements line 1: certifi>=2023.11.17",
       "externalReferences": [
         {
           "comment": "implicit dist url",

--- a/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.4.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.4.xml.bin
@@ -47,7 +47,7 @@
   <components>
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
-      <description>requirements line 1: certifi&gt;=2021.5.30</description>
+      <description>requirements line 1: certifi&gt;=2023.11.17</description>
       <purl>pkg:pypi/certifi</purl>
       <externalReferences>
         <reference type="distribution">

--- a/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.5.json.bin
+++ b/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.5.json.bin
@@ -2,7 +2,7 @@
   "components": [
     {
       "bom-ref": "requirements-L1",
-      "description": "requirements line 1: certifi>=2021.5.30",
+      "description": "requirements line 1: certifi>=2023.11.17",
       "externalReferences": [
         {
           "comment": "implicit dist url",

--- a/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.5.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.5.xml.bin
@@ -47,7 +47,7 @@
   <components>
     <component type="library" bom-ref="requirements-L1">
       <name>certifi</name>
-      <description>requirements line 1: certifi&gt;=2021.5.30</description>
+      <description>requirements line 1: certifi&gt;=2023.11.17</description>
       <purl>pkg:pypi/certifi</purl>
       <externalReferences>
         <reference type="distribution">


### PR DESCRIPTION
some test beds used outdated/vulnerable components.
even though they were never run, it is better to have them bumped to versions that dont have known vulnerabilities.