### PR TITLE
support editable installed packages like '-e file:somepackage' (currently raising AttributeError)

### DIFF
--- a/cyclonedx_py/client.py
+++ b/cyclonedx_py/client.py
@@ -91,12 +91,13 @@ class CycloneDxCmd:
             exit(1)
 
         if parser and parser.has_warnings():
+            warning_packages = [str(warning.get_item()) for warning in parser.get_warnings()]
             print('',
                   '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!',
                   '!! Some of your dependencies do not have pinned version !!',
                   '!! numbers in your requirements.txt                     !!',
                   '!!                                                      !!',
-                  *('!! -> {} !!'.format(warning.get_item().ljust(49)) for warning in parser.get_warnings()),
+                  *('!! -> {} !!'.format(warn_package.ljust(49)) for warn_package in warning_packages),
                   '!!                                                      !!',
                   '!! The above will NOT be included in the generated      !!',
                   '!! CycloneDX as version is a mandatory field.           !!',

--- a/tests/fixtures/requirements-local-installed-package.txt
+++ b/tests/fixtures/requirements-local-installed-package.txt
@@ -1,0 +1,1 @@
+-e file:mylocalpackage

--- a/tests/test_parser_requirements.py
+++ b/tests/test_parser_requirements.py
@@ -100,6 +100,20 @@ class TestRequirementsParser(TestCase):
         self.assertEqual(HashAlgorithm.SHA_256, hash.alg)
         self.assertNotEqual(0, len(hash.content), f'{hash.content}')
 
+    def test_example_local_installed_packages(self) -> None:
+        with open(os.path.join(os.path.dirname(__file__),
+                               'fixtures/requirements-local-installed-package.txt')) as r:
+            parser = RequirementsParser(
+                requirements_content=r.read()
+            )
+        components = parser.get_components()
+
+        warnings = parser.get_warnings()
+        self.assertEqual(1, len(warnings), f'{parser.get_warnings()}')
+        warning = warnings[0]
+        self.assertIsNone(warning.get_item(), f'{warning.get_item()}')
+        self.assertEqual(0, len(components), f'{components}')
+
     def test_example_local_packages(self) -> None:
         with open(os.path.join(os.path.dirname(__file__),
                                'fixtures/requirements-local-and-remote-packages.txt')) as r:


### PR DESCRIPTION
lines like  `-e file:mylocalpackage`  are currently failing with following stacktrace

```
$ cyclonedx-py --requirements -i requirements.txt -o sbom.json --force

Traceback (most recent call last):
...
  File "/.../lib/python3.8/site-packages/cyclonedx_py/client.py", line 94, in get_output
    print('',
  File "/.../lib/python3.8/site-packages/cyclonedx_py/client.py", line 99, in <genexpr>
    *('!! -> {} !!'.format(warning.get_item().ljust(49)) for warning in parser.get_warnings()),
AttributeError: 'NoneType' object has no attribute 'ljust'
```

Such lines are [valid](https://stackoverflow.com/a/72258316/6203472) for requirements.txt and is what we get by running pip-compile with local packages installed in editable mode.

The PR allows cyclonedx to go through but reporting is currently not fantastic as it prints something like
```
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!! Some of your dependencies do not have pinned version !!
!! numbers in your requirements.txt                     !!
!!                                                      !!
!! -> None                                              !!
!!                                                      !!
!! The above will NOT be included in the generated      !!
!! CycloneDX as version is a mandatory field.           !!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```
because warning.get_item() is None --> because requirement.is_local_path is False on following line
`name = requirement.link.url if requirement.is_local_path else requirement.name` 

To get `requirement.is_local_path` to be True and get the link.url instead of None, I'll have to open a PR in `pip_requirements_parser`.

Still it would be great to get this merged