### PR TITLE
feat: support CycloneDX 1.6 output

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -29,11 +29,11 @@ The full documentation can be issued by running with ``--help``:
       -h, --help      show this help message and exit
       --version       show program's version number and exit
 
-Example usage: save SBOM in CycloneDX 1.5 XML format, generated from current python environment
+Example usage: save SBOM in CycloneDX 1.6 XML format, generated from current python environment
 
 .. code-block:: shell
 
-   cyclonedx-py environment --outfile my-sbom.xml --schema-version 1.5 --output-format XML
+   cyclonedx-py environment --outfile my-sbom.xml --schema-version 1.6 --output-format XML
 
 
 For Python (virtual) environment
@@ -78,7 +78,7 @@ The full documentation can be issued by running with ``environment --help``:
                             (default: -)
       --sv <version>, --schema-version <version>
                             The CycloneDX schema version for your SBOM
-                            {choices: 1.5, 1.4, 1.3, 1.2, 1.1, 1.0}
+                            {choices: 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0}
                             (default: 1.5)
       --of <format>, --output-format <format>
                             The output format for your SBOM
@@ -238,7 +238,7 @@ The full documentation can be issued by running with ``pipenv --help``:
                             (default: -)
       --sv <version>, --schema-version <version>
                             The CycloneDX schema version for your SBOM
-                            {choices: 1.5, 1.4, 1.3, 1.2, 1.1, 1.0}
+                            {choices: 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0}
                             (default: 1.5)
       --of <format>, --output-format <format>
                             The output format for your SBOM
@@ -313,7 +313,8 @@ The full documentation can be issued by running with ``poetry --help``:
                             (default: -)
       --sv <version>, --schema-version <version>
                             The CycloneDX schema version for your SBOM
-                            {choices: 1.5, 1.4, 1.3, 1.2, 1.1, 1.0} (default: 1.5)
+                            {choices: 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0}
+                            (default: 1.5)
       --of <format>, --output-format <format>
                             The output format for your SBOM
                             {choices: JSON, XML}
@@ -383,7 +384,7 @@ The full documentation can be issued by running with ``requirements --help``:
                             (default: -)
       --sv <version>, --schema-version <version>
                             The CycloneDX schema version for your SBOM
-                            {choices: 1.5, 1.4, 1.3, 1.2, 1.1, 1.0}
+                            {choices: 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0}
                             (default: 1.5)
       --of <format>, --output-format <format>
                             The output format for your SBOM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,10 +69,10 @@ cyclonedx-py = "cyclonedx_py._internal.cli:run"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-cyclonedx-python-lib = { version = "^6.1.0", extras = ["validation"] }
+cyclonedx-python-lib = { version = "^7.0.0", extras = ["validation"] }
 packageurl-python = ">=0.11, <2"  # keep in sync with same dep in `cyclonedx-python-lib`
 pip-requirements-parser = "^32.0"
-packaging = "^22||^23 || ^24"
+packaging = "^22 || ^23 || ^24"
 tomli = { version = "^2.0.1", python = "<3.11" }
 chardet = "^5.1"
 

--- a/tests/_data/snapshots/environment/plain_editable-self_1.6.json.bin
+++ b/tests/_data/snapshots/environment/plain_editable-self_1.6.json.bin
@@ -1,0 +1,64 @@
+{
+  "components": [
+    {
+      "bom-ref": "six==1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/benjaminp/six"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "six==1.16.0"
+      ],
+      "ref": "root-component"
+    },
+    {
+      "ref": "six==1.16.0"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "install the current project as an editable",
+      "name": "editable-self",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/environment/plain_editable-self_1.6.xml.bin
+++ b/tests/_data/snapshots/environment/plain_editable-self_1.6.xml.bin
@@ -1,0 +1,77 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>editable-self</name>
+      <version>0.1.0</version>
+      <description>install the current project as an editable</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="six==1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/benjaminp/six</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="root-component">
+      <dependency ref="six==1.16.0"/>
+    </dependency>
+    <dependency ref="six==1.16.0"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/environment/plain_local_1.6.json.bin
+++ b/tests/_data/snapshots/environment/plain_local_1.6.json.bin
@@ -1,0 +1,122 @@
+{
+  "components": [
+    {
+      "bom-ref": "package-a==23.42",
+      "description": "some package A",
+      "externalReferences": [
+        {
+          "comment": "PackageSource: Archive",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c8da28603857d4073c67e751ba3cd526a7ef414135faecfec164e7d01be24be"
+            }
+          ],
+          "type": "distribution",
+          "url": "file://.../tests/_data/infiles/_helpers/local_pckages/a/dist/package_a-23.42-py3-none-any.whl"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "declared license of 'package-a'",
+            "text": {
+              "content": "some license text",
+              "contentType": "text/plain"
+            }
+          }
+        }
+      ],
+      "name": "package-a",
+      "type": "library",
+      "version": "23.42"
+    },
+    {
+      "bom-ref": "package-b==23.42",
+      "description": "some package B",
+      "externalReferences": [
+        {
+          "comment": "PackageSource: Archive",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "20e983935a800046222a02674ed37baf3e7a4ef7cd40e6033d9c0efaeb73206f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file://.../tests/_data/infiles/_helpers/local_pckages/b/dist/package-b-23.42.tar.gz"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "package-b",
+      "type": "library",
+      "version": "23.42"
+    },
+    {
+      "bom-ref": "package-c==23.42",
+      "description": "some package C",
+      "externalReferences": [
+        {
+          "comment": "PackageSource: Local",
+          "type": "distribution",
+          "url": "file://.../tests/_data/infiles/_helpers/local_pckages/c"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "package-c",
+      "type": "library",
+      "version": "23.42"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "package-a==23.42"
+    },
+    {
+      "ref": "package-b==23.42"
+    },
+    {
+      "ref": "package-c==23.42"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "packages from local paths",
+      "name": "local",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/environment/plain_local_1.6.xml.bin
+++ b/tests/_data/snapshots/environment/plain_local_1.6.xml.bin
@@ -1,0 +1,113 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>local</name>
+      <version>0.1.0</version>
+      <description>packages from local paths</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="package-a==23.42">
+      <name>package-a</name>
+      <version>23.42</version>
+      <description>some package A</description>
+      <licenses>
+        <license>
+          <name>declared license of 'package-a'</name>
+          <text content-type="text/plain">some license text</text>
+        </license>
+      </licenses>
+      <externalReferences>
+        <reference type="distribution">
+          <url>file://.../tests/_data/infiles/_helpers/local_pckages/a/dist/package_a-23.42-py3-none-any.whl</url>
+          <comment>PackageSource: Archive</comment>
+          <hashes>
+            <hash alg="SHA-256">5c8da28603857d4073c67e751ba3cd526a7ef414135faecfec164e7d01be24be</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="package-b==23.42">
+      <name>package-b</name>
+      <version>23.42</version>
+      <description>some package B</description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <externalReferences>
+        <reference type="distribution">
+          <url>file://.../tests/_data/infiles/_helpers/local_pckages/b/dist/package-b-23.42.tar.gz</url>
+          <comment>PackageSource: Archive</comment>
+          <hashes>
+            <hash alg="SHA-256">20e983935a800046222a02674ed37baf3e7a4ef7cd40e6033d9c0efaeb73206f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="package-c==23.42">
+      <name>package-c</name>
+      <version>23.42</version>
+      <description>some package C</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="distribution">
+          <url>file://.../tests/_data/infiles/_helpers/local_pckages/c</url>
+          <comment>PackageSource: Local</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="package-a==23.42"/>
+    <dependency ref="package-b==23.42"/>
+    <dependency ref="package-c==23.42"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/environment/plain_no-deps_1.6.json.bin
+++ b/tests/_data/snapshots/environment/plain_no-deps_1.6.json.bin
@@ -1,0 +1,71 @@
+{
+  "dependencies": [
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "packages with all meta, but no deps",
+      "externalReferences": [
+        {
+          "comment": "from pyproject urls: documentation",
+          "type": "documentation",
+          "url": "https://oss.acme.org/my-project/docs/"
+        },
+        {
+          "comment": "from pyproject urls: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://oss.acme.org/my-project/bugs/"
+        },
+        {
+          "comment": "from pyproject urls: Funding",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/funding/"
+        },
+        {
+          "comment": "from pyproject urls: Change log",
+          "type": "release-notes",
+          "url": "https://oss.acme.org/my-project/changelog/"
+        },
+        {
+          "comment": "from pyproject urls: repository",
+          "type": "vcs",
+          "url": "https://oss.acme.org/my-project.git"
+        },
+        {
+          "comment": "from pyproject urls: homepage",
+          "type": "website",
+          "url": "https://oss.acme.org/my-project/"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "no-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/environment/plain_no-deps_1.6.xml.bin
+++ b/tests/_data/snapshots/environment/plain_no-deps_1.6.xml.bin
@@ -1,0 +1,84 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>no-deps</name>
+      <version>0.1.0</version>
+      <description>packages with all meta, but no deps</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://oss.acme.org/my-project/docs/</url>
+          <comment>from pyproject urls: documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://oss.acme.org/my-project/bugs/</url>
+          <comment>from pyproject urls: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/funding/</url>
+          <comment>from pyproject urls: Funding</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://oss.acme.org/my-project/changelog/</url>
+          <comment>from pyproject urls: Change log</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://oss.acme.org/my-project.git</url>
+          <comment>from pyproject urls: repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://oss.acme.org/my-project/</url>
+          <comment>from pyproject urls: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <dependencies>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/environment/plain_normalize-packagename_1.6.json.bin
+++ b/tests/_data/snapshots/environment/plain_normalize-packagename_1.6.json.bin
@@ -1,0 +1,151 @@
+{
+  "components": [
+    {
+      "bom-ref": "ruamel.yaml==0.18.5",
+      "description": "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://yaml.readthedocs.io/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Tracker",
+          "type": "issue-tracker",
+          "url": "https://sourceforge.net/p/ruamel-yaml/tickets/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://sourceforge.net/p/ruamel-yaml/code/ci/default/tree/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Home",
+          "type": "website",
+          "url": "https://sourceforge.net/p/ruamel-yaml/"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "name": "declared license of 'ruamel.yaml'",
+            "text": {
+              "content": "MIT license",
+              "contentType": "text/plain"
+            }
+          }
+        }
+      ],
+      "name": "ruamel.yaml",
+      "properties": [
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "jinja2"
+        }
+      ],
+      "purl": "pkg:pypi/ruamel.yaml@0.18.5",
+      "type": "library",
+      "version": "0.18.5"
+    },
+    {
+      "bom-ref": "ruamel.yaml.clib==0.2.8",
+      "description": "C version of reader, parser and emitter for ruamel.yaml derived from libyaml",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://sourceforge.net/p/ruamel-yaml-clib/code/ci/default/tree"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "ruamel.yaml.clib",
+      "purl": "pkg:pypi/ruamel.yaml.clib@0.2.8",
+      "type": "library",
+      "version": "0.2.8"
+    },
+    {
+      "bom-ref": "ruamel.yaml.jinja2==0.2.7",
+      "description": "jinja2 pre and post-processor to update with YAML",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://sourceforge.net/p/ruamel-yaml-jinja2/code/ci/default/tree"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "ruamel.yaml.jinja2",
+      "purl": "pkg:pypi/ruamel.yaml.jinja2@0.2.7",
+      "type": "library",
+      "version": "0.2.7"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "ruamel.yaml==0.18.5"
+      ],
+      "ref": "root-component"
+    },
+    {
+      "ref": "ruamel.yaml.clib==0.2.8"
+    },
+    {
+      "dependsOn": [
+        "ruamel.yaml==0.18.5"
+      ],
+      "ref": "ruamel.yaml.jinja2==0.2.7"
+    },
+    {
+      "dependsOn": [
+        "ruamel.yaml.clib==0.2.8",
+        "ruamel.yaml.jinja2==0.2.7"
+      ],
+      "ref": "ruamel.yaml==0.18.5"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "packages with non-normalized names",
+      "name": "normalize-packagename",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/environment/plain_normalize-packagename_1.6.xml.bin
+++ b/tests/_data/snapshots/environment/plain_normalize-packagename_1.6.xml.bin
@@ -1,0 +1,137 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>normalize-packagename</name>
+      <version>0.1.0</version>
+      <description>packages with non-normalized names</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="ruamel.yaml==0.18.5">
+      <name>ruamel.yaml</name>
+      <version>0.18.5</version>
+      <description>ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+        <license>
+          <name>declared license of 'ruamel.yaml'</name>
+          <text content-type="text/plain">MIT license</text>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/ruamel.yaml@0.18.5</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://yaml.readthedocs.io/</url>
+          <comment>from packaging metadata Project-URL: Documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://sourceforge.net/p/ruamel-yaml/tickets/</url>
+          <comment>from packaging metadata Project-URL: Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://sourceforge.net/p/ruamel-yaml/code/ci/default/tree/</url>
+          <comment>from packaging metadata Project-URL: Source</comment>
+        </reference>
+        <reference type="website">
+          <url>https://sourceforge.net/p/ruamel-yaml/</url>
+          <comment>from packaging metadata Project-URL: Home</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:python:package:required-extra">jinja2</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="ruamel.yaml.clib==0.2.8">
+      <name>ruamel.yaml.clib</name>
+      <version>0.2.8</version>
+      <description>C version of reader, parser and emitter for ruamel.yaml derived from libyaml</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/ruamel.yaml.clib@0.2.8</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://sourceforge.net/p/ruamel-yaml-clib/code/ci/default/tree</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="ruamel.yaml.jinja2==0.2.7">
+      <name>ruamel.yaml.jinja2</name>
+      <version>0.2.7</version>
+      <description>jinja2 pre and post-processor to update with YAML</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/ruamel.yaml.jinja2@0.2.7</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://sourceforge.net/p/ruamel-yaml-jinja2/code/ci/default/tree</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="root-component">
+      <dependency ref="ruamel.yaml==0.18.5"/>
+    </dependency>
+    <dependency ref="ruamel.yaml.clib==0.2.8"/>
+    <dependency ref="ruamel.yaml.jinja2==0.2.7">
+      <dependency ref="ruamel.yaml==0.18.5"/>
+    </dependency>
+    <dependency ref="ruamel.yaml==0.18.5">
+      <dependency ref="ruamel.yaml.clib==0.2.8"/>
+      <dependency ref="ruamel.yaml.jinja2==0.2.7"/>
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/environment/plain_private-packages_1.6.json.bin
+++ b/tests/_data/snapshots/environment/plain_private-packages_1.6.json.bin
@@ -1,0 +1,100 @@
+{
+  "components": [
+    {
+      "bom-ref": "six==1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "PackageSource: Archive",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/benjaminp/six"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml==0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/uiri/toml"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "toml",
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "six==1.16.0"
+      ],
+      "ref": "root-component"
+    },
+    {
+      "ref": "six==1.16.0"
+    },
+    {
+      "ref": "toml==0.10.2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "packages from direct urls",
+      "name": "with-urls",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/environment/plain_private-packages_1.6.xml.bin
+++ b/tests/_data/snapshots/environment/plain_private-packages_1.6.xml.bin
@@ -1,0 +1,102 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>with-urls</name>
+      <version>0.1.0</version>
+      <description>packages from direct urls</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="six==1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>PackageSource: Archive</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/benjaminp/six</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="toml==0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/uiri/toml</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="root-component">
+      <dependency ref="six==1.16.0"/>
+    </dependency>
+    <dependency ref="six==1.16.0"/>
+    <dependency ref="toml==0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/environment/plain_via-pdm_1.6.json.bin
+++ b/tests/_data/snapshots/environment/plain_via-pdm_1.6.json.bin
@@ -1,0 +1,69 @@
+{
+  "components": [
+    {
+      "bom-ref": "toml==0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/uiri/toml"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "toml",
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "toml==0.10.2"
+      ],
+      "ref": "root-component"
+    },
+    {
+      "ref": "toml==0.10.2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "environment via PDM",
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "via-pdm",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/environment/plain_via-pdm_1.6.xml.bin
+++ b/tests/_data/snapshots/environment/plain_via-pdm_1.6.xml.bin
@@ -1,0 +1,80 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>via-pdm</name>
+      <version>0.1.0</version>
+      <description>environment via PDM</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="toml==0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/uiri/toml</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="root-component">
+      <dependency ref="toml==0.10.2"/>
+    </dependency>
+    <dependency ref="toml==0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/environment/plain_via-pipenv_1.6.json.bin
+++ b/tests/_data/snapshots/environment/plain_via-pipenv_1.6.json.bin
@@ -1,0 +1,101 @@
+{
+  "components": [
+    {
+      "bom-ref": "toml==0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/uiri/toml"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "toml",
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "toml==0.10.2"
+      ],
+      "ref": "root-component"
+    },
+    {
+      "ref": "toml==0.10.2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "environment via Pipenv",
+      "externalReferences": [
+        {
+          "comment": "from pyproject urls: documentation",
+          "type": "documentation",
+          "url": "https://oss.acme.org/my-project/docs/"
+        },
+        {
+          "comment": "from pyproject urls: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://oss.acme.org/my-project/bugs/"
+        },
+        {
+          "comment": "from pyproject urls: Funding",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/funding/"
+        },
+        {
+          "comment": "from pyproject urls: Change log",
+          "type": "release-notes",
+          "url": "https://oss.acme.org/my-project/changelog/"
+        },
+        {
+          "comment": "from pyproject urls: repository",
+          "type": "vcs",
+          "url": "https://oss.acme.org/my-project.git"
+        },
+        {
+          "comment": "from pyproject urls: homepage",
+          "type": "website",
+          "url": "https://oss.acme.org/my-project/"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "via-pipenv",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/environment/plain_via-pipenv_1.6.xml.bin
+++ b/tests/_data/snapshots/environment/plain_via-pipenv_1.6.xml.bin
@@ -1,0 +1,106 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>via-pipenv</name>
+      <version>0.1.0</version>
+      <description>environment via Pipenv</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://oss.acme.org/my-project/docs/</url>
+          <comment>from pyproject urls: documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://oss.acme.org/my-project/bugs/</url>
+          <comment>from pyproject urls: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/funding/</url>
+          <comment>from pyproject urls: Funding</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://oss.acme.org/my-project/changelog/</url>
+          <comment>from pyproject urls: Change log</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://oss.acme.org/my-project.git</url>
+          <comment>from pyproject urls: repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://oss.acme.org/my-project/</url>
+          <comment>from pyproject urls: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="toml==0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/uiri/toml</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="root-component">
+      <dependency ref="toml==0.10.2"/>
+    </dependency>
+    <dependency ref="toml==0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/environment/plain_via-poetry_1.6.json.bin
+++ b/tests/_data/snapshots/environment/plain_via-poetry_1.6.json.bin
@@ -1,0 +1,101 @@
+{
+  "components": [
+    {
+      "bom-ref": "toml==0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/uiri/toml"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "toml",
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "toml==0.10.2"
+      ],
+      "ref": "root-component"
+    },
+    {
+      "ref": "toml==0.10.2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "environment via Poetry",
+      "externalReferences": [
+        {
+          "comment": "from poetry: documentation",
+          "type": "documentation",
+          "url": "https://oss.acme.org/my-project/docs/"
+        },
+        {
+          "comment": "from poetry url: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://oss.acme.org/my-project/bugs/"
+        },
+        {
+          "comment": "from poetry url: Funding",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/funding/"
+        },
+        {
+          "comment": "from poetry url: Change log",
+          "type": "release-notes",
+          "url": "https://oss.acme.org/my-project/changelog/"
+        },
+        {
+          "comment": "from poetry: repository",
+          "type": "vcs",
+          "url": "https://oss.acme.org/my-project.git"
+        },
+        {
+          "comment": "from poetry: homepage",
+          "type": "website",
+          "url": "https://oss.acme.org/my-project/"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "via-poetry",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/environment/plain_via-poetry_1.6.xml.bin
+++ b/tests/_data/snapshots/environment/plain_via-poetry_1.6.xml.bin
@@ -1,0 +1,106 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>via-poetry</name>
+      <version>0.1.0</version>
+      <description>environment via Poetry</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://oss.acme.org/my-project/docs/</url>
+          <comment>from poetry: documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://oss.acme.org/my-project/bugs/</url>
+          <comment>from poetry url: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/funding/</url>
+          <comment>from poetry url: Funding</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://oss.acme.org/my-project/changelog/</url>
+          <comment>from poetry url: Change log</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://oss.acme.org/my-project.git</url>
+          <comment>from poetry: repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://oss.acme.org/my-project/</url>
+          <comment>from poetry: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="toml==0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/uiri/toml</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="root-component">
+      <dependency ref="toml==0.10.2"/>
+    </dependency>
+    <dependency ref="toml==0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/environment/plain_with-extras_1.6.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-extras_1.6.json.bin
@@ -1,0 +1,1099 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow==1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://arrow.readthedocs.io"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Issues",
+          "type": "issue-tracker",
+          "url": "https://github.com/arrow-py/arrow/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/arrow-py/arrow"
+        }
+      ],
+      "name": "arrow",
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "attrs==23.1.0",
+      "description": "Classes Without Boilerplate",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://www.attrs.org/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://github.com/python-attrs/attrs/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Source Code",
+          "type": "other",
+          "url": "https://github.com/python-attrs/attrs"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Funding",
+          "type": "other",
+          "url": "https://github.com/sponsors/hynek"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Tidelift",
+          "type": "other",
+          "url": "https://tidelift.com/subscription/pkg/pypi-attrs?utm_source=pypi-attrs&utm_medium=pypi"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "release-notes",
+          "url": "https://www.attrs.org/en/stable/changelog.html"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "attrs",
+      "purl": "pkg:pypi/attrs@23.1.0",
+      "type": "library",
+      "version": "23.1.0"
+    },
+    {
+      "bom-ref": "boolean.py==4.0",
+      "description": "Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/bastikr/boolean.py"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause"
+          }
+        }
+      ],
+      "name": "boolean.py",
+      "purl": "pkg:pypi/boolean.py@4.0",
+      "type": "library",
+      "version": "4.0"
+    },
+    {
+      "bom-ref": "cyclonedx-python-lib==6.0.0",
+      "description": "Python library for CycloneDX",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://cyclonedx-python-library.readthedocs.io/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://github.com/CycloneDX/cyclonedx-python-lib/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Funding",
+          "type": "other",
+          "url": "https://owasp.org/donate/?reponame=www-project-cyclonedx&title=OWASP+CycloneDX"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Repository",
+          "type": "vcs",
+          "url": "https://github.com/CycloneDX/cyclonedx-python-lib"
+        },
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/CycloneDX/cyclonedx-python-lib/#readme"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "cyclonedx-python-lib",
+      "properties": [
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "xml-validation"
+        }
+      ],
+      "purl": "pkg:pypi/cyclonedx-python-lib@6.0.0",
+      "type": "library",
+      "version": "6.0.0"
+    },
+    {
+      "bom-ref": "defusedxml==0.7.1",
+      "description": "XML bomb protection for Python stdlib modules",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Download-URL",
+          "type": "distribution",
+          "url": "https://pypi.python.org/pypi/defusedxml"
+        },
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/tiran/defusedxml"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Python-2.0"
+          }
+        },
+        {
+          "license": {
+            "name": "declared license of 'defusedxml'",
+            "text": {
+              "content": "PSFL",
+              "contentType": "text/plain"
+            }
+          }
+        }
+      ],
+      "name": "defusedxml",
+      "purl": "pkg:pypi/defusedxml@0.7.1",
+      "type": "library",
+      "version": "0.7.1"
+    },
+    {
+      "bom-ref": "fqdn==1.5.1",
+      "description": "Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/ypcrts/fqdn"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "declared license of 'fqdn'",
+            "text": {
+              "content": "MPL 2.0",
+              "contentType": "text/plain"
+            }
+          }
+        }
+      ],
+      "name": "fqdn",
+      "purl": "pkg:pypi/fqdn@1.5.1",
+      "type": "library",
+      "version": "1.5.1"
+    },
+    {
+      "bom-ref": "idna==3.6",
+      "description": "Internationalized Domain Names in Applications (IDNA)",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Issue tracker",
+          "type": "issue-tracker",
+          "url": "https://github.com/kjd/idna/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/kjd/idna"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "release-notes",
+          "url": "https://github.com/kjd/idna/blob/master/HISTORY.rst"
+        }
+      ],
+      "name": "idna",
+      "purl": "pkg:pypi/idna@3.6",
+      "type": "library",
+      "version": "3.6"
+    },
+    {
+      "bom-ref": "importlib-resources==6.1.1",
+      "description": "Read resources from Python packages",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://importlib-resources.readthedocs.io/"
+        },
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/python/importlib_resources"
+        }
+      ],
+      "name": "importlib-resources",
+      "purl": "pkg:pypi/importlib-resources@6.1.1",
+      "type": "library",
+      "version": "6.1.1"
+    },
+    {
+      "bom-ref": "isoduration==20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Bug Reports",
+          "type": "issue-tracker",
+          "url": "https://github.com/bolsote/isoduration/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "release-notes",
+          "url": "https://github.com/bolsote/isoduration/blob/master/CHANGELOG"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Repository",
+          "type": "vcs",
+          "url": "https://github.com/bolsote/isoduration"
+        },
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/bolsote/isoduration"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "ISC"
+          }
+        },
+        {
+          "license": {
+            "name": "declared license of 'isoduration'",
+            "text": {
+              "content": "UNKNOWN",
+              "contentType": "text/plain"
+            }
+          }
+        }
+      ],
+      "name": "isoduration",
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "jsonpointer==2.4",
+      "description": "Identify specific nodes in a JSON document (RFC 6901) ",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/stefankoegl/python-json-pointer"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "declared license of 'jsonpointer'",
+            "text": {
+              "content": "Modified BSD License",
+              "contentType": "text/plain"
+            }
+          }
+        }
+      ],
+      "name": "jsonpointer",
+      "purl": "pkg:pypi/jsonpointer@2.4",
+      "type": "library",
+      "version": "2.4"
+    },
+    {
+      "bom-ref": "jsonschema==4.20.0",
+      "description": "An implementation of JSON Schema validation for Python",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://python-jsonschema.readthedocs.io/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Issues",
+          "type": "issue-tracker",
+          "url": "https://github.com/python-jsonschema/jsonschema/issues/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/python-jsonschema/jsonschema"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Funding",
+          "type": "other",
+          "url": "https://github.com/sponsors/Julian"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Tidelift",
+          "type": "other",
+          "url": "https://tidelift.com/subscription/pkg/pypi-jsonschema?utm_source=pypi-jsonschema&utm_medium=referral&utm_campaign=pypi-link"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "release-notes",
+          "url": "https://github.com/python-jsonschema/jsonschema/blob/main/CHANGELOG.rst"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://github.com/python-jsonschema/jsonschema"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "jsonschema",
+      "properties": [
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "format"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema@4.20.0",
+      "type": "library",
+      "version": "4.20.0"
+    },
+    {
+      "bom-ref": "jsonschema-specifications==2023.11.2",
+      "description": "The JSON Schema meta-schemas and vocabularies, exposed as a Registry",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://jsonschema-specifications.readthedocs.io/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Issues",
+          "type": "issue-tracker",
+          "url": "https://github.com/python-jsonschema/jsonschema-specifications/issues/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/python-jsonschema/jsonschema-specifications"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Funding",
+          "type": "other",
+          "url": "https://github.com/sponsors/Julian"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Tidelift",
+          "type": "other",
+          "url": "https://tidelift.com/subscription/pkg/pypi-jsonschema-specifications?utm_source=pypi-jsonschema-specifications&utm_medium=referral&utm_campaign=pypi-link"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://github.com/python-jsonschema/jsonschema-specifications"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "jsonschema-specifications",
+      "purl": "pkg:pypi/jsonschema-specifications@2023.11.2",
+      "type": "library",
+      "version": "2023.11.2"
+    },
+    {
+      "bom-ref": "license-expression==30.2.0",
+      "description": "license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/nexB/license-expression"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "license-expression",
+      "purl": "pkg:pypi/license-expression@30.2.0",
+      "type": "library",
+      "version": "30.2.0"
+    },
+    {
+      "bom-ref": "lxml==4.9.4",
+      "description": "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/lxml/lxml"
+        },
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://lxml.de/"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "name": "lxml",
+      "purl": "pkg:pypi/lxml@4.9.4",
+      "type": "library",
+      "version": "4.9.4"
+    },
+    {
+      "bom-ref": "packageurl-python==0.13.1",
+      "description": "A purl aka. Package URL parser and builder",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/package-url/packageurl-python"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "packageurl-python",
+      "purl": "pkg:pypi/packageurl-python@0.13.1",
+      "type": "library",
+      "version": "0.13.1"
+    },
+    {
+      "bom-ref": "pkgutil_resolve_name==1.3.10",
+      "description": "Resolve a name to an object.",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/graingert/pkgutil-resolve-name"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "pkgutil_resolve_name",
+      "purl": "pkg:pypi/pkgutil-resolve-name@1.3.10",
+      "type": "library",
+      "version": "1.3.10"
+    },
+    {
+      "bom-ref": "py-serializable==0.16.0",
+      "description": "Library for serializing and deserializing Python Objects to and from JSON and XML.",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://github.com/madpah/serializable/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Repository",
+          "type": "vcs",
+          "url": "https://github.com/madpah/serializable"
+        },
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/madpah/serializable"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "py-serializable",
+      "purl": "pkg:pypi/py-serializable@0.16.0",
+      "type": "library",
+      "version": "0.16.0"
+    },
+    {
+      "bom-ref": "python-dateutil==2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://dateutil.readthedocs.io/en/stable/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/dateutil/dateutil"
+        },
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/dateutil/dateutil"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "declared license of 'python-dateutil'",
+            "text": {
+              "content": "Dual License",
+              "contentType": "text/plain"
+            }
+          }
+        }
+      ],
+      "name": "python-dateutil",
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "referencing==0.32.0",
+      "description": "JSON Referencing + Python",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://referencing.readthedocs.io/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Issues",
+          "type": "issue-tracker",
+          "url": "https://github.com/python-jsonschema/referencing/issues/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/python-jsonschema/referencing"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Funding",
+          "type": "other",
+          "url": "https://github.com/sponsors/Julian"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Tidelift",
+          "type": "other",
+          "url": "https://tidelift.com/subscription/pkg/pypi-referencing?utm_source=pypi-referencing&utm_medium=referral&utm_campaign=pypi-link"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://github.com/python-jsonschema/referencing"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "referencing",
+      "purl": "pkg:pypi/referencing@0.32.0",
+      "type": "library",
+      "version": "0.32.0"
+    },
+    {
+      "bom-ref": "rfc3339-validator==0.1.4",
+      "description": "A pure python RFC3339 validator",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/naimetti/rfc3339-validator"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "name": "declared license of 'rfc3339-validator'",
+            "text": {
+              "content": "MIT license",
+              "contentType": "text/plain"
+            }
+          }
+        }
+      ],
+      "name": "rfc3339-validator",
+      "purl": "pkg:pypi/rfc3339-validator@0.1.4",
+      "type": "library",
+      "version": "0.1.4"
+    },
+    {
+      "bom-ref": "rfc3987==1.3.8",
+      "description": "Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Download-URL",
+          "type": "distribution",
+          "url": "https://github.com/dgerber/rfc3987"
+        },
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "http://pypi.python.org/pypi/rfc3987"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-3.0-or-later"
+          }
+        },
+        {
+          "license": {
+            "name": "declared license of 'rfc3987'",
+            "text": {
+              "content": "GNU GPLv3+",
+              "contentType": "text/plain"
+            }
+          }
+        }
+      ],
+      "name": "rfc3987",
+      "purl": "pkg:pypi/rfc3987@1.3.8",
+      "type": "library",
+      "version": "1.3.8"
+    },
+    {
+      "bom-ref": "rpds-py==0.15.2",
+      "description": "Python bindings to Rust's persistent data structures (rpds)",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://rpds.readthedocs.io/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Issues",
+          "type": "issue-tracker",
+          "url": "https://github.com/crate-py/rpds/issues/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/crate-py/rpds"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Funding",
+          "type": "other",
+          "url": "https://github.com/sponsors/Julian"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Tidelift",
+          "type": "other",
+          "url": "https://tidelift.com/subscription/pkg/pypi-rpds-py?utm_source=pypi-rpds-py&utm_medium=referral&utm_campaign=pypi-link"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://github.com/crate-py/rpds"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "rpds-py",
+      "purl": "pkg:pypi/rpds-py@0.15.2",
+      "type": "library",
+      "version": "0.15.2"
+    },
+    {
+      "bom-ref": "six==1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/benjaminp/six"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "sortedcontainers==2.4.0",
+      "description": "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "http://www.grantjenks.com/docs/sortedcontainers/"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "declared license of 'sortedcontainers'",
+            "text": {
+              "content": "Apache 2.0",
+              "contentType": "text/plain"
+            }
+          }
+        }
+      ],
+      "name": "sortedcontainers",
+      "purl": "pkg:pypi/sortedcontainers@2.4.0",
+      "type": "library",
+      "version": "2.4.0"
+    },
+    {
+      "bom-ref": "types-python-dateutil==2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Chat",
+          "type": "chat",
+          "url": "https://gitter.im/python/typing"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Issue tracker",
+          "type": "issue-tracker",
+          "url": "https://github.com/python/typeshed/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Changes",
+          "type": "release-notes",
+          "url": "https://github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/python-dateutil.md"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: GitHub",
+          "type": "vcs",
+          "url": "https://github.com/python/typeshed"
+        },
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/python/typeshed"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "declared license of 'types-python-dateutil'",
+            "text": {
+              "content": "Apache-2.0 license",
+              "contentType": "text/plain"
+            }
+          }
+        }
+      ],
+      "name": "types-python-dateutil",
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    },
+    {
+      "bom-ref": "uri-template==1.3.0",
+      "description": "RFC 6570 URI Template Processor",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: homepage",
+          "type": "website",
+          "url": "https://gitlab.linss.com/open-source/python/uri-template"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "name": "declared license of 'uri-template'",
+            "text": {
+              "content": "MIT License",
+              "contentType": "text/plain"
+            }
+          }
+        }
+      ],
+      "name": "uri-template",
+      "purl": "pkg:pypi/uri-template@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "webcolors==1.13",
+      "description": "A library for working with the color formats defined by HTML and CSS.",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: documentation",
+          "type": "documentation",
+          "url": "https://webcolors.readthedocs.io"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: homepage",
+          "type": "website",
+          "url": "https://github.com/ubernostrum/webcolors"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "name": "webcolors",
+      "purl": "pkg:pypi/webcolors@1.13",
+      "type": "library",
+      "version": "1.13"
+    },
+    {
+      "bom-ref": "zipp==3.17.0",
+      "description": "Backport of pathlib-compatible object wrapper for zip files",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/jaraco/zipp"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "zipp",
+      "purl": "pkg:pypi/zipp@3.17.0",
+      "type": "library",
+      "version": "3.17.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil==2.8.2",
+        "types-python-dateutil==2.8.19.14"
+      ],
+      "ref": "arrow==1.3.0"
+    },
+    {
+      "ref": "attrs==23.1.0"
+    },
+    {
+      "ref": "boolean.py==4.0"
+    },
+    {
+      "dependsOn": [
+        "jsonschema==4.20.0",
+        "license-expression==30.2.0",
+        "lxml==4.9.4",
+        "packageurl-python==0.13.1",
+        "py-serializable==0.16.0",
+        "sortedcontainers==2.4.0"
+      ],
+      "ref": "cyclonedx-python-lib==6.0.0"
+    },
+    {
+      "ref": "defusedxml==0.7.1"
+    },
+    {
+      "ref": "fqdn==1.5.1"
+    },
+    {
+      "ref": "idna==3.6"
+    },
+    {
+      "dependsOn": [
+        "zipp==3.17.0"
+      ],
+      "ref": "importlib-resources==6.1.1"
+    },
+    {
+      "dependsOn": [
+        "arrow==1.3.0"
+      ],
+      "ref": "isoduration==20.11.0"
+    },
+    {
+      "ref": "jsonpointer==2.4"
+    },
+    {
+      "dependsOn": [
+        "importlib-resources==6.1.1",
+        "referencing==0.32.0"
+      ],
+      "ref": "jsonschema-specifications==2023.11.2"
+    },
+    {
+      "dependsOn": [
+        "attrs==23.1.0",
+        "fqdn==1.5.1",
+        "idna==3.6",
+        "importlib-resources==6.1.1",
+        "isoduration==20.11.0",
+        "jsonpointer==2.4",
+        "jsonschema-specifications==2023.11.2",
+        "pkgutil_resolve_name==1.3.10",
+        "referencing==0.32.0",
+        "rfc3339-validator==0.1.4",
+        "rfc3987==1.3.8",
+        "rpds-py==0.15.2",
+        "uri-template==1.3.0",
+        "webcolors==1.13"
+      ],
+      "ref": "jsonschema==4.20.0"
+    },
+    {
+      "dependsOn": [
+        "boolean.py==4.0"
+      ],
+      "ref": "license-expression==30.2.0"
+    },
+    {
+      "ref": "lxml==4.9.4"
+    },
+    {
+      "ref": "packageurl-python==0.13.1"
+    },
+    {
+      "ref": "pkgutil_resolve_name==1.3.10"
+    },
+    {
+      "dependsOn": [
+        "defusedxml==0.7.1"
+      ],
+      "ref": "py-serializable==0.16.0"
+    },
+    {
+      "dependsOn": [
+        "six==1.16.0"
+      ],
+      "ref": "python-dateutil==2.8.2"
+    },
+    {
+      "dependsOn": [
+        "attrs==23.1.0",
+        "rpds-py==0.15.2"
+      ],
+      "ref": "referencing==0.32.0"
+    },
+    {
+      "dependsOn": [
+        "six==1.16.0"
+      ],
+      "ref": "rfc3339-validator==0.1.4"
+    },
+    {
+      "ref": "rfc3987==1.3.8"
+    },
+    {
+      "dependsOn": [
+        "cyclonedx-python-lib==6.0.0"
+      ],
+      "ref": "root-component"
+    },
+    {
+      "ref": "rpds-py==0.15.2"
+    },
+    {
+      "ref": "six==1.16.0"
+    },
+    {
+      "ref": "sortedcontainers==2.4.0"
+    },
+    {
+      "ref": "types-python-dateutil==2.8.19.14"
+    },
+    {
+      "ref": "uri-template==1.3.0"
+    },
+    {
+      "ref": "webcolors==1.13"
+    },
+    {
+      "ref": "zipp==3.17.0"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/environment/plain_with-extras_1.6.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-extras_1.6.xml.bin
@@ -1,0 +1,822 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow==1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://arrow.readthedocs.io</url>
+          <comment>from packaging metadata Project-URL: Documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://github.com/arrow-py/arrow/issues</url>
+          <comment>from packaging metadata Project-URL: Issues</comment>
+        </reference>
+        <reference type="other">
+          <url>https://github.com/arrow-py/arrow</url>
+          <comment>from packaging metadata Project-URL: Source</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="attrs==23.1.0">
+      <name>attrs</name>
+      <version>23.1.0</version>
+      <description>Classes Without Boilerplate</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/attrs@23.1.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://www.attrs.org/</url>
+          <comment>from packaging metadata Project-URL: Documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://github.com/python-attrs/attrs/issues</url>
+          <comment>from packaging metadata Project-URL: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://github.com/python-attrs/attrs</url>
+          <comment>from packaging metadata Project-URL: Source Code</comment>
+        </reference>
+        <reference type="other">
+          <url>https://github.com/sponsors/hynek</url>
+          <comment>from packaging metadata Project-URL: Funding</comment>
+        </reference>
+        <reference type="other">
+          <url>https://tidelift.com/subscription/pkg/pypi-attrs?utm_source=pypi-attrs&amp;utm_medium=pypi</url>
+          <comment>from packaging metadata Project-URL: Tidelift</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://www.attrs.org/en/stable/changelog.html</url>
+          <comment>from packaging metadata Project-URL: Changelog</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="boolean.py==4.0">
+      <name>boolean.py</name>
+      <version>4.0</version>
+      <description>Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.</description>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/boolean.py@4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/bastikr/boolean.py</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="cyclonedx-python-lib==6.0.0">
+      <name>cyclonedx-python-lib</name>
+      <version>6.0.0</version>
+      <description>Python library for CycloneDX</description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/cyclonedx-python-lib@6.0.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://cyclonedx-python-library.readthedocs.io/</url>
+          <comment>from packaging metadata Project-URL: Documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://github.com/CycloneDX/cyclonedx-python-lib/issues</url>
+          <comment>from packaging metadata Project-URL: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://owasp.org/donate/?reponame=www-project-cyclonedx&amp;title=OWASP+CycloneDX</url>
+          <comment>from packaging metadata Project-URL: Funding</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/CycloneDX/cyclonedx-python-lib</url>
+          <comment>from packaging metadata Project-URL: Repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/CycloneDX/cyclonedx-python-lib/#readme</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:python:package:required-extra">xml-validation</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="defusedxml==0.7.1">
+      <name>defusedxml</name>
+      <version>0.7.1</version>
+      <description>XML bomb protection for Python stdlib modules</description>
+      <licenses>
+        <license>
+          <id>Python-2.0</id>
+        </license>
+        <license>
+          <name>declared license of 'defusedxml'</name>
+          <text content-type="text/plain">PSFL</text>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/defusedxml@0.7.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.python.org/pypi/defusedxml</url>
+          <comment>from packaging metadata: Download-URL</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/tiran/defusedxml</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="fqdn==1.5.1">
+      <name>fqdn</name>
+      <version>1.5.1</version>
+      <description>Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers</description>
+      <licenses>
+        <license>
+          <name>declared license of 'fqdn'</name>
+          <text content-type="text/plain">MPL 2.0</text>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/fqdn@1.5.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/ypcrts/fqdn</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="idna==3.6">
+      <name>idna</name>
+      <version>3.6</version>
+      <description>Internationalized Domain Names in Applications (IDNA)</description>
+      <purl>pkg:pypi/idna@3.6</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/kjd/idna/issues</url>
+          <comment>from packaging metadata Project-URL: Issue tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://github.com/kjd/idna</url>
+          <comment>from packaging metadata Project-URL: Source</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://github.com/kjd/idna/blob/master/HISTORY.rst</url>
+          <comment>from packaging metadata Project-URL: Changelog</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="importlib-resources==6.1.1">
+      <name>importlib-resources</name>
+      <version>6.1.1</version>
+      <description>Read resources from Python packages</description>
+      <purl>pkg:pypi/importlib-resources@6.1.1</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://importlib-resources.readthedocs.io/</url>
+          <comment>from packaging metadata Project-URL: Documentation</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/python/importlib_resources</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="isoduration==20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <licenses>
+        <license>
+          <id>ISC</id>
+        </license>
+        <license>
+          <name>declared license of 'isoduration'</name>
+          <text content-type="text/plain">UNKNOWN</text>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/bolsote/isoduration/issues</url>
+          <comment>from packaging metadata Project-URL: Bug Reports</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://github.com/bolsote/isoduration/blob/master/CHANGELOG</url>
+          <comment>from packaging metadata Project-URL: Changelog</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/bolsote/isoduration</url>
+          <comment>from packaging metadata Project-URL: Repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/bolsote/isoduration</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="jsonpointer==2.4">
+      <name>jsonpointer</name>
+      <version>2.4</version>
+      <description>Identify specific nodes in a JSON document (RFC 6901) </description>
+      <licenses>
+        <license>
+          <name>declared license of 'jsonpointer'</name>
+          <text content-type="text/plain">Modified BSD License</text>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/jsonpointer@2.4</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/stefankoegl/python-json-pointer</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="jsonschema==4.20.0">
+      <name>jsonschema</name>
+      <version>4.20.0</version>
+      <description>An implementation of JSON Schema validation for Python</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/jsonschema@4.20.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://python-jsonschema.readthedocs.io/</url>
+          <comment>from packaging metadata Project-URL: Documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://github.com/python-jsonschema/jsonschema/issues/</url>
+          <comment>from packaging metadata Project-URL: Issues</comment>
+        </reference>
+        <reference type="other">
+          <url>https://github.com/python-jsonschema/jsonschema</url>
+          <comment>from packaging metadata Project-URL: Source</comment>
+        </reference>
+        <reference type="other">
+          <url>https://github.com/sponsors/Julian</url>
+          <comment>from packaging metadata Project-URL: Funding</comment>
+        </reference>
+        <reference type="other">
+          <url>https://tidelift.com/subscription/pkg/pypi-jsonschema?utm_source=pypi-jsonschema&amp;utm_medium=referral&amp;utm_campaign=pypi-link</url>
+          <comment>from packaging metadata Project-URL: Tidelift</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://github.com/python-jsonschema/jsonschema/blob/main/CHANGELOG.rst</url>
+          <comment>from packaging metadata Project-URL: Changelog</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/python-jsonschema/jsonschema</url>
+          <comment>from packaging metadata Project-URL: Homepage</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:python:package:required-extra">format</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema-specifications==2023.11.2">
+      <name>jsonschema-specifications</name>
+      <version>2023.11.2</version>
+      <description>The JSON Schema meta-schemas and vocabularies, exposed as a Registry</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/jsonschema-specifications@2023.11.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://jsonschema-specifications.readthedocs.io/</url>
+          <comment>from packaging metadata Project-URL: Documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://github.com/python-jsonschema/jsonschema-specifications/issues/</url>
+          <comment>from packaging metadata Project-URL: Issues</comment>
+        </reference>
+        <reference type="other">
+          <url>https://github.com/python-jsonschema/jsonschema-specifications</url>
+          <comment>from packaging metadata Project-URL: Source</comment>
+        </reference>
+        <reference type="other">
+          <url>https://github.com/sponsors/Julian</url>
+          <comment>from packaging metadata Project-URL: Funding</comment>
+        </reference>
+        <reference type="other">
+          <url>https://tidelift.com/subscription/pkg/pypi-jsonschema-specifications?utm_source=pypi-jsonschema-specifications&amp;utm_medium=referral&amp;utm_campaign=pypi-link</url>
+          <comment>from packaging metadata Project-URL: Tidelift</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/python-jsonschema/jsonschema-specifications</url>
+          <comment>from packaging metadata Project-URL: Homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="license-expression==30.2.0">
+      <name>license-expression</name>
+      <version>30.2.0</version>
+      <description>license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.</description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/license-expression@30.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/nexB/license-expression</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="lxml==4.9.4">
+      <name>lxml</name>
+      <version>4.9.4</version>
+      <description>Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.</description>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/lxml@4.9.4</purl>
+      <externalReferences>
+        <reference type="other">
+          <url>https://github.com/lxml/lxml</url>
+          <comment>from packaging metadata Project-URL: Source</comment>
+        </reference>
+        <reference type="website">
+          <url>https://lxml.de/</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="packageurl-python==0.13.1">
+      <name>packageurl-python</name>
+      <version>0.13.1</version>
+      <description>A purl aka. Package URL parser and builder</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/packageurl-python@0.13.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/package-url/packageurl-python</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkgutil_resolve_name==1.3.10">
+      <name>pkgutil_resolve_name</name>
+      <version>1.3.10</version>
+      <description>Resolve a name to an object.</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/pkgutil-resolve-name@1.3.10</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/graingert/pkgutil-resolve-name</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="py-serializable==0.16.0">
+      <name>py-serializable</name>
+      <version>0.16.0</version>
+      <description>Library for serializing and deserializing Python Objects to and from JSON and XML.</description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/py-serializable@0.16.0</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/madpah/serializable/issues</url>
+          <comment>from packaging metadata Project-URL: Bug Tracker</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/madpah/serializable</url>
+          <comment>from packaging metadata Project-URL: Repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/madpah/serializable</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="python-dateutil==2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <licenses>
+        <license>
+          <name>declared license of 'python-dateutil'</name>
+          <text content-type="text/plain">Dual License</text>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://dateutil.readthedocs.io/en/stable/</url>
+          <comment>from packaging metadata Project-URL: Documentation</comment>
+        </reference>
+        <reference type="other">
+          <url>https://github.com/dateutil/dateutil</url>
+          <comment>from packaging metadata Project-URL: Source</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dateutil/dateutil</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="referencing==0.32.0">
+      <name>referencing</name>
+      <version>0.32.0</version>
+      <description>JSON Referencing + Python</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/referencing@0.32.0</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://referencing.readthedocs.io/</url>
+          <comment>from packaging metadata Project-URL: Documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://github.com/python-jsonschema/referencing/issues/</url>
+          <comment>from packaging metadata Project-URL: Issues</comment>
+        </reference>
+        <reference type="other">
+          <url>https://github.com/python-jsonschema/referencing</url>
+          <comment>from packaging metadata Project-URL: Source</comment>
+        </reference>
+        <reference type="other">
+          <url>https://github.com/sponsors/Julian</url>
+          <comment>from packaging metadata Project-URL: Funding</comment>
+        </reference>
+        <reference type="other">
+          <url>https://tidelift.com/subscription/pkg/pypi-referencing?utm_source=pypi-referencing&amp;utm_medium=referral&amp;utm_campaign=pypi-link</url>
+          <comment>from packaging metadata Project-URL: Tidelift</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/python-jsonschema/referencing</url>
+          <comment>from packaging metadata Project-URL: Homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="rfc3339-validator==0.1.4">
+      <name>rfc3339-validator</name>
+      <version>0.1.4</version>
+      <description>A pure python RFC3339 validator</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+        <license>
+          <name>declared license of 'rfc3339-validator'</name>
+          <text content-type="text/plain">MIT license</text>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/rfc3339-validator@0.1.4</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/naimetti/rfc3339-validator</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="rfc3987==1.3.8">
+      <name>rfc3987</name>
+      <version>1.3.8</version>
+      <description>Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)</description>
+      <licenses>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+        <license>
+          <name>declared license of 'rfc3987'</name>
+          <text content-type="text/plain">GNU GPLv3+</text>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/rfc3987@1.3.8</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://github.com/dgerber/rfc3987</url>
+          <comment>from packaging metadata: Download-URL</comment>
+        </reference>
+        <reference type="website">
+          <url>http://pypi.python.org/pypi/rfc3987</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="rpds-py==0.15.2">
+      <name>rpds-py</name>
+      <version>0.15.2</version>
+      <description>Python bindings to Rust's persistent data structures (rpds)</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/rpds-py@0.15.2</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://rpds.readthedocs.io/</url>
+          <comment>from packaging metadata Project-URL: Documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://github.com/crate-py/rpds/issues/</url>
+          <comment>from packaging metadata Project-URL: Issues</comment>
+        </reference>
+        <reference type="other">
+          <url>https://github.com/crate-py/rpds</url>
+          <comment>from packaging metadata Project-URL: Source</comment>
+        </reference>
+        <reference type="other">
+          <url>https://github.com/sponsors/Julian</url>
+          <comment>from packaging metadata Project-URL: Funding</comment>
+        </reference>
+        <reference type="other">
+          <url>https://tidelift.com/subscription/pkg/pypi-rpds-py?utm_source=pypi-rpds-py&amp;utm_medium=referral&amp;utm_campaign=pypi-link</url>
+          <comment>from packaging metadata Project-URL: Tidelift</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/crate-py/rpds</url>
+          <comment>from packaging metadata Project-URL: Homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="six==1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/benjaminp/six</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="sortedcontainers==2.4.0">
+      <name>sortedcontainers</name>
+      <version>2.4.0</version>
+      <description>Sorted Containers -- Sorted List, Sorted Dict, Sorted Set</description>
+      <licenses>
+        <license>
+          <name>declared license of 'sortedcontainers'</name>
+          <text content-type="text/plain">Apache 2.0</text>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/sortedcontainers@2.4.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>http://www.grantjenks.com/docs/sortedcontainers/</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil==2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <licenses>
+        <license>
+          <name>declared license of 'types-python-dateutil'</name>
+          <text content-type="text/plain">Apache-2.0 license</text>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="chat">
+          <url>https://gitter.im/python/typing</url>
+          <comment>from packaging metadata Project-URL: Chat</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://github.com/python/typeshed/issues</url>
+          <comment>from packaging metadata Project-URL: Issue tracker</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/python-dateutil.md</url>
+          <comment>from packaging metadata Project-URL: Changes</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/python/typeshed</url>
+          <comment>from packaging metadata Project-URL: GitHub</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/python/typeshed</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="uri-template==1.3.0">
+      <name>uri-template</name>
+      <version>1.3.0</version>
+      <description>RFC 6570 URI Template Processor</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+        <license>
+          <name>declared license of 'uri-template'</name>
+          <text content-type="text/plain">MIT License</text>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/uri-template@1.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://gitlab.linss.com/open-source/python/uri-template</url>
+          <comment>from packaging metadata Project-URL: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="webcolors==1.13">
+      <name>webcolors</name>
+      <version>1.13</version>
+      <description>A library for working with the color formats defined by HTML and CSS.</description>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/webcolors@1.13</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://webcolors.readthedocs.io</url>
+          <comment>from packaging metadata Project-URL: documentation</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/ubernostrum/webcolors</url>
+          <comment>from packaging metadata Project-URL: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="zipp==3.17.0">
+      <name>zipp</name>
+      <version>3.17.0</version>
+      <description>Backport of pathlib-compatible object wrapper for zip files</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/zipp@3.17.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/jaraco/zipp</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow==1.3.0">
+      <dependency ref="python-dateutil==2.8.2"/>
+      <dependency ref="types-python-dateutil==2.8.19.14"/>
+    </dependency>
+    <dependency ref="attrs==23.1.0"/>
+    <dependency ref="boolean.py==4.0"/>
+    <dependency ref="cyclonedx-python-lib==6.0.0">
+      <dependency ref="jsonschema==4.20.0"/>
+      <dependency ref="license-expression==30.2.0"/>
+      <dependency ref="lxml==4.9.4"/>
+      <dependency ref="packageurl-python==0.13.1"/>
+      <dependency ref="py-serializable==0.16.0"/>
+      <dependency ref="sortedcontainers==2.4.0"/>
+    </dependency>
+    <dependency ref="defusedxml==0.7.1"/>
+    <dependency ref="fqdn==1.5.1"/>
+    <dependency ref="idna==3.6"/>
+    <dependency ref="importlib-resources==6.1.1">
+      <dependency ref="zipp==3.17.0"/>
+    </dependency>
+    <dependency ref="isoduration==20.11.0">
+      <dependency ref="arrow==1.3.0"/>
+    </dependency>
+    <dependency ref="jsonpointer==2.4"/>
+    <dependency ref="jsonschema-specifications==2023.11.2">
+      <dependency ref="importlib-resources==6.1.1"/>
+      <dependency ref="referencing==0.32.0"/>
+    </dependency>
+    <dependency ref="jsonschema==4.20.0">
+      <dependency ref="attrs==23.1.0"/>
+      <dependency ref="fqdn==1.5.1"/>
+      <dependency ref="idna==3.6"/>
+      <dependency ref="importlib-resources==6.1.1"/>
+      <dependency ref="isoduration==20.11.0"/>
+      <dependency ref="jsonpointer==2.4"/>
+      <dependency ref="jsonschema-specifications==2023.11.2"/>
+      <dependency ref="pkgutil_resolve_name==1.3.10"/>
+      <dependency ref="referencing==0.32.0"/>
+      <dependency ref="rfc3339-validator==0.1.4"/>
+      <dependency ref="rfc3987==1.3.8"/>
+      <dependency ref="rpds-py==0.15.2"/>
+      <dependency ref="uri-template==1.3.0"/>
+      <dependency ref="webcolors==1.13"/>
+    </dependency>
+    <dependency ref="license-expression==30.2.0">
+      <dependency ref="boolean.py==4.0"/>
+    </dependency>
+    <dependency ref="lxml==4.9.4"/>
+    <dependency ref="packageurl-python==0.13.1"/>
+    <dependency ref="pkgutil_resolve_name==1.3.10"/>
+    <dependency ref="py-serializable==0.16.0">
+      <dependency ref="defusedxml==0.7.1"/>
+    </dependency>
+    <dependency ref="python-dateutil==2.8.2">
+      <dependency ref="six==1.16.0"/>
+    </dependency>
+    <dependency ref="referencing==0.32.0">
+      <dependency ref="attrs==23.1.0"/>
+      <dependency ref="rpds-py==0.15.2"/>
+    </dependency>
+    <dependency ref="rfc3339-validator==0.1.4">
+      <dependency ref="six==1.16.0"/>
+    </dependency>
+    <dependency ref="rfc3987==1.3.8"/>
+    <dependency ref="root-component">
+      <dependency ref="cyclonedx-python-lib==6.0.0"/>
+    </dependency>
+    <dependency ref="rpds-py==0.15.2"/>
+    <dependency ref="six==1.16.0"/>
+    <dependency ref="sortedcontainers==2.4.0"/>
+    <dependency ref="types-python-dateutil==2.8.19.14"/>
+    <dependency ref="uri-template==1.3.0"/>
+    <dependency ref="webcolors==1.13"/>
+    <dependency ref="zipp==3.17.0"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/environment/plain_with-license-file_1.6.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-license-file_1.6.json.bin
@@ -1,0 +1,46 @@
+{
+  "dependencies": [
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "with licenses from file, instead of SPDX ID/Expression",
+      "licenses": [
+        {
+          "license": {
+            "name": "declared license of 'with-license-file'",
+            "text": {
+              "content": "VGhpcyBpcyB0aGUgbGljZW5zZSB0ZXh0IG9mIHRoaXMgY29tcG9uZW50LgpJdCBpcyBleHBlY3RlZCB0byBiZSBhdmFpbGFibGUgaW4gYSBTQk9NLgo=",
+              "contentType": "text/plain",
+              "encoding": "base64"
+            }
+          }
+        }
+      ],
+      "name": "with-license-file",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/environment/plain_with-license-file_1.6.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-license-file_1.6.xml.bin
@@ -1,0 +1,61 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>with-license-file</name>
+      <version>0.1.0</version>
+      <description>with licenses from file, instead of SPDX ID/Expression</description>
+      <licenses>
+        <license>
+          <name>declared license of 'with-license-file'</name>
+          <text content-type="text/plain" encoding="base64">VGhpcyBpcyB0aGUgbGljZW5zZSB0ZXh0IG9mIHRoaXMgY29tcG9uZW50LgpJdCBpcyBleHBlY3RlZCB0byBiZSBhdmFpbGFibGUgaW4gYSBTQk9NLgo=</text>
+        </license>
+      </licenses>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <dependencies>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/environment/plain_with-license-text_1.6.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-license-text_1.6.json.bin
@@ -1,0 +1,139 @@
+{
+  "components": [
+    {
+      "bom-ref": "package-a==23.42",
+      "description": "some package A",
+      "externalReferences": [
+        {
+          "comment": "PackageSource: Archive",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c8da28603857d4073c67e751ba3cd526a7ef414135faecfec164e7d01be24be"
+            }
+          ],
+          "type": "distribution",
+          "url": "file://.../tests/_data/infiles/_helpers/local_pckages/a/dist/package_a-23.42-py3-none-any.whl"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "declared license of 'package-a'",
+            "text": {
+              "content": "some license text",
+              "contentType": "text/plain"
+            }
+          }
+        }
+      ],
+      "name": "package-a",
+      "type": "library",
+      "version": "23.42"
+    },
+    {
+      "bom-ref": "package-b==23.42",
+      "description": "some package B",
+      "externalReferences": [
+        {
+          "comment": "PackageSource: Archive",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "583f7cb9db5c26194e8004ac82a90d7b46664da8da674919d3e2189c332a1f78"
+            }
+          ],
+          "type": "distribution",
+          "url": "file://.../tests/_data/infiles/_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "package-b",
+      "type": "library",
+      "version": "23.42"
+    },
+    {
+      "bom-ref": "package-c==23.42",
+      "description": "some package C",
+      "externalReferences": [
+        {
+          "comment": "PackageSource: Archive",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c1ac59f18ed20f2e651a37f74134ade2a396e27513ef1c73461873c49058f641"
+            }
+          ],
+          "type": "distribution",
+          "url": "file://.../tests/_data/infiles/_helpers/local_pckages/c/dist/package_c-23.42-py3-none-any.whl"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "package-c",
+      "type": "library",
+      "version": "23.42"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "package-a==23.42"
+    },
+    {
+      "ref": "package-b==23.42"
+    },
+    {
+      "ref": "package-c==23.42"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "with licenses as text, instead of SPDX ID/Expression",
+      "licenses": [
+        {
+          "license": {
+            "name": "declared license of 'with-license-text'",
+            "text": {
+              "content": "This is the license text of this component.\nIt is expected to be available in a SBOM.",
+              "contentType": "text/plain"
+            }
+          }
+        }
+      ],
+      "name": "with-license-text",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/environment/plain_with-license-text_1.6.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-license-text_1.6.xml.bin
@@ -1,0 +1,123 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>with-license-text</name>
+      <version>0.1.0</version>
+      <description>with licenses as text, instead of SPDX ID/Expression</description>
+      <licenses>
+        <license>
+          <name>declared license of 'with-license-text'</name>
+          <text content-type="text/plain">This is the license text of this component.
+It is expected to be available in a SBOM.</text>
+        </license>
+      </licenses>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="package-a==23.42">
+      <name>package-a</name>
+      <version>23.42</version>
+      <description>some package A</description>
+      <licenses>
+        <license>
+          <name>declared license of 'package-a'</name>
+          <text content-type="text/plain">some license text</text>
+        </license>
+      </licenses>
+      <externalReferences>
+        <reference type="distribution">
+          <url>file://.../tests/_data/infiles/_helpers/local_pckages/a/dist/package_a-23.42-py3-none-any.whl</url>
+          <comment>PackageSource: Archive</comment>
+          <hashes>
+            <hash alg="SHA-256">5c8da28603857d4073c67e751ba3cd526a7ef414135faecfec164e7d01be24be</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="package-b==23.42">
+      <name>package-b</name>
+      <version>23.42</version>
+      <description>some package B</description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <externalReferences>
+        <reference type="distribution">
+          <url>file://.../tests/_data/infiles/_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl</url>
+          <comment>PackageSource: Archive</comment>
+          <hashes>
+            <hash alg="SHA-256">583f7cb9db5c26194e8004ac82a90d7b46664da8da674919d3e2189c332a1f78</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="package-c==23.42">
+      <name>package-c</name>
+      <version>23.42</version>
+      <description>some package C</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="distribution">
+          <url>file://.../tests/_data/infiles/_helpers/local_pckages/c/dist/package_c-23.42-py3-none-any.whl</url>
+          <comment>PackageSource: Archive</comment>
+          <hashes>
+            <hash alg="SHA-256">c1ac59f18ed20f2e651a37f74134ade2a396e27513ef1c73461873c49058f641</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="package-a==23.42"/>
+    <dependency ref="package-b==23.42"/>
+    <dependency ref="package-c==23.42"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/environment/plain_with-urls_1.6.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.6.json.bin
@@ -1,0 +1,205 @@
+{
+  "components": [
+    {
+      "bom-ref": "packaging==23.2",
+      "description": "Core utilities for Python packages",
+      "externalReferences": [
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://packaging.pypa.io/"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Source",
+          "type": "other",
+          "url": "https://github.com/pypa/packaging"
+        },
+        {
+          "comment": "PackageSource: VCS 'git'",
+          "type": "vcs",
+          "url": "https://github.com/pypa/packaging.git#b3a5d7d68991c040615d5345bb55f61de53ba176"
+        }
+      ],
+      "name": "packaging",
+      "properties": [
+        {
+          "name": "cdx:poetry:package:source:vcs:commit_id",
+          "value": "b3a5d7d68991c040615d5345bb55f61de53ba176"
+        },
+        {
+          "name": "cdx:poetry:package:source:vcs:requested_revision",
+          "value": "23.2"
+        }
+      ],
+      "purl": "pkg:pypi/packaging@23.2?vcs_url=git%2Bhttps://github.com/pypa/packaging.git%40b3a5d7d68991c040615d5345bb55f61de53ba176",
+      "type": "library",
+      "version": "23.2"
+    },
+    {
+      "bom-ref": "six==1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "PackageSource: Archive",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from packaging metadata: Home-page",
+          "type": "website",
+          "url": "https://github.com/benjaminp/six"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "tomli==2.0.1",
+      "description": "A lil' TOML parser",
+      "externalReferences": [
+        {
+          "comment": "PackageSource: Archive",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "release-notes",
+          "url": "https://github.com/hukkin/tomli/blob/master/CHANGELOG.md"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Homepage",
+          "type": "website",
+          "url": "https://github.com/hukkin/tomli"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "tomli",
+      "purl": "pkg:pypi/tomli@2.0.1",
+      "type": "library",
+      "version": "2.0.1"
+    },
+    {
+      "bom-ref": "urllib3==2.2.0",
+      "description": "HTTP library with thread-safe connection pooling, file post, and more.",
+      "externalReferences": [
+        {
+          "comment": "PackageSource: Archive",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "672a674765aba37fe6f3e3b05372bf13140ef501c4d79ae29e998e3910b6a8e9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Documentation",
+          "type": "documentation",
+          "url": "https://urllib3.readthedocs.io"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Issue tracker",
+          "type": "issue-tracker",
+          "url": "https://github.com/urllib3/urllib3/issues"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Code",
+          "type": "other",
+          "url": "https://github.com/urllib3/urllib3"
+        },
+        {
+          "comment": "from packaging metadata Project-URL: Changelog",
+          "type": "release-notes",
+          "url": "https://github.com/urllib3/urllib3/blob/main/CHANGES.rst"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3@2.2.0?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
+      "type": "library",
+      "version": "2.2.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "packaging==23.2"
+    },
+    {
+      "dependsOn": [
+        "six==1.16.0"
+      ],
+      "ref": "root-component"
+    },
+    {
+      "ref": "six==1.16.0"
+    },
+    {
+      "ref": "tomli==2.0.1"
+    },
+    {
+      "ref": "urllib3==2.2.0"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "packages from direct urls",
+      "name": "with-urls",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/environment/plain_with-urls_1.6.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.6.xml.bin
@@ -1,0 +1,175 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>with-urls</name>
+      <version>0.1.0</version>
+      <description>packages from direct urls</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="packaging==23.2">
+      <name>packaging</name>
+      <version>23.2</version>
+      <description>Core utilities for Python packages</description>
+      <purl>pkg:pypi/packaging@23.2?vcs_url=git%2Bhttps://github.com/pypa/packaging.git%40b3a5d7d68991c040615d5345bb55f61de53ba176</purl>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://packaging.pypa.io/</url>
+          <comment>from packaging metadata Project-URL: Documentation</comment>
+        </reference>
+        <reference type="other">
+          <url>https://github.com/pypa/packaging</url>
+          <comment>from packaging metadata Project-URL: Source</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/pypa/packaging.git#b3a5d7d68991c040615d5345bb55f61de53ba176</url>
+          <comment>PackageSource: VCS 'git'</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
+        <property name="cdx:poetry:package:source:vcs:requested_revision">23.2</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six==1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>PackageSource: Archive</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/benjaminp/six</url>
+          <comment>from packaging metadata: Home-page</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="tomli==2.0.1">
+      <name>tomli</name>
+      <version>2.0.1</version>
+      <description>A lil' TOML parser</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/tomli@2.0.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz</url>
+          <comment>PackageSource: Archive</comment>
+          <hashes>
+            <hash alg="SHA-256">de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f</hash>
+          </hashes>
+        </reference>
+        <reference type="release-notes">
+          <url>https://github.com/hukkin/tomli/blob/master/CHANGELOG.md</url>
+          <comment>from packaging metadata Project-URL: Changelog</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/hukkin/tomli</url>
+          <comment>from packaging metadata Project-URL: Homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="urllib3==2.2.0">
+      <name>urllib3</name>
+      <version>2.2.0</version>
+      <description>HTTP library with thread-safe connection pooling, file post, and more.</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:pypi/urllib3@2.2.0?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
+          <comment>PackageSource: Archive</comment>
+          <hashes>
+            <hash alg="SHA-256">672a674765aba37fe6f3e3b05372bf13140ef501c4d79ae29e998e3910b6a8e9</hash>
+          </hashes>
+        </reference>
+        <reference type="documentation">
+          <url>https://urllib3.readthedocs.io</url>
+          <comment>from packaging metadata Project-URL: Documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://github.com/urllib3/urllib3/issues</url>
+          <comment>from packaging metadata Project-URL: Issue tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://github.com/urllib3/urllib3</url>
+          <comment>from packaging metadata Project-URL: Code</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://github.com/urllib3/urllib3/blob/main/CHANGES.rst</url>
+          <comment>from packaging metadata Project-URL: Changelog</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="packaging==23.2"/>
+    <dependency ref="root-component">
+      <dependency ref="six==1.16.0"/>
+    </dependency>
+    <dependency ref="six==1.16.0"/>
+    <dependency ref="tomli==2.0.1"/>
+    <dependency ref="urllib3==2.2.0"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/plain_category-deps_1.6.json.bin
+++ b/tests/_data/snapshots/pipenv/plain_category-deps_1.6.json.bin
@@ -1,0 +1,69 @@
+{
+  "components": [
+    {
+      "bom-ref": "toml==0.10.2",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "root-component"
+    },
+    {
+      "ref": "toml==0.10.2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "dependencies organized in groups",
+      "name": "category-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/pipenv/plain_category-deps_1.6.xml.bin
+++ b/tests/_data/snapshots/pipenv/plain_category-deps_1.6.xml.bin
@@ -1,0 +1,76 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>category-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="toml==0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="root-component"/>
+    <dependency ref="toml==0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/plain_default-and-dev_1.6.json.bin
+++ b/tests/_data/snapshots/pipenv/plain_default-and-dev_1.6.json.bin
@@ -1,0 +1,102 @@
+{
+  "components": [
+    {
+      "bom-ref": "colorama==0.4.6",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "toml==0.10.2",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "colorama==0.4.6"
+    },
+    {
+      "ref": "root-component"
+    },
+    {
+      "ref": "toml==0.10.2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "default and dev depenndencies",
+      "name": "default-and-dev",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/pipenv/plain_default-and-dev_1.6.xml.bin
+++ b/tests/_data/snapshots/pipenv/plain_default-and-dev_1.6.xml.bin
@@ -1,0 +1,95 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>default-and-dev</name>
+      <version>0.1.0</version>
+      <description>default and dev depenndencies</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="colorama==0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml==0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="colorama==0.4.6"/>
+    <dependency ref="root-component"/>
+    <dependency ref="toml==0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/plain_editable-self_1.6.json.bin
+++ b/tests/_data/snapshots/pipenv/plain_editable-self_1.6.json.bin
@@ -1,0 +1,40 @@
+{
+  "dependencies": [
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "install the current project as an editable",
+      "name": "editable-self",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/pipenv/plain_editable-self_1.6.xml.bin
+++ b/tests/_data/snapshots/pipenv/plain_editable-self_1.6.xml.bin
@@ -1,0 +1,58 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>editable-self</name>
+      <version>0.1.0</version>
+      <description>install the current project as an editable</description>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <dependencies>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/plain_local_1.6.json.bin
+++ b/tests/_data/snapshots/pipenv/plain_local_1.6.json.bin
@@ -1,0 +1,111 @@
+{
+  "components": [
+    {
+      "bom-ref": "package-a",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3869fe3f4a6cca5b203b2e2cd8858c834f651e1b0fa76d5c0232e36472199592"
+            }
+          ],
+          "type": "distribution",
+          "url": "../../_helpers/local_pckages/a/dist/package-a-23.42.tar.gz"
+        }
+      ],
+      "name": "package-a",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "bom-ref": "package-b",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4aacda53fa274f5ff7eed71a9916904ffb3a11b05dc5ca529d7ddb78ae2dc602"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:../../_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl"
+        }
+      ],
+      "name": "package-b",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "bom-ref": "package-c",
+      "externalReferences": [
+        {
+          "comment": "from path",
+          "type": "distribution",
+          "url": "../../_helpers/local_pckages/c"
+        }
+      ],
+      "name": "package-c",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "package-a"
+    },
+    {
+      "ref": "package-b"
+    },
+    {
+      "ref": "package-c"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "packages from local paths",
+      "name": "local",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/pipenv/plain_local_1.6.xml.bin
+++ b/tests/_data/snapshots/pipenv/plain_local_1.6.xml.bin
@@ -1,0 +1,102 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>local</name>
+      <version>0.1.0</version>
+      <description>packages from local paths</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="package-a">
+      <name>package-a</name>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../_helpers/local_pckages/a/dist/package-a-23.42.tar.gz</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">3869fe3f4a6cca5b203b2e2cd8858c834f651e1b0fa76d5c0232e36472199592</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="package-b">
+      <name>package-b</name>
+      <externalReferences>
+        <reference type="distribution">
+          <url>file:../../_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">4aacda53fa274f5ff7eed71a9916904ffb3a11b05dc5ca529d7ddb78ae2dc602</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="package-c">
+      <name>package-c</name>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../_helpers/local_pckages/c</url>
+          <comment>from path</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="package-a"/>
+    <dependency ref="package-b"/>
+    <dependency ref="package-c"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/plain_no-deps_1.6.json.bin
+++ b/tests/_data/snapshots/pipenv/plain_no-deps_1.6.json.bin
@@ -1,0 +1,71 @@
+{
+  "dependencies": [
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "packages with all meta, but no deps",
+      "externalReferences": [
+        {
+          "comment": "from pyproject urls: documentation",
+          "type": "documentation",
+          "url": "https://oss.acme.org/my-project/docs/"
+        },
+        {
+          "comment": "from pyproject urls: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://oss.acme.org/my-project/bugs/"
+        },
+        {
+          "comment": "from pyproject urls: Funding",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/funding/"
+        },
+        {
+          "comment": "from pyproject urls: Change log",
+          "type": "release-notes",
+          "url": "https://oss.acme.org/my-project/changelog/"
+        },
+        {
+          "comment": "from pyproject urls: repository",
+          "type": "vcs",
+          "url": "https://oss.acme.org/my-project.git"
+        },
+        {
+          "comment": "from pyproject urls: homepage",
+          "type": "website",
+          "url": "https://oss.acme.org/my-project/"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "no-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/pipenv/plain_no-deps_1.6.xml.bin
+++ b/tests/_data/snapshots/pipenv/plain_no-deps_1.6.xml.bin
@@ -1,0 +1,84 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>no-deps</name>
+      <version>0.1.0</version>
+      <description>packages with all meta, but no deps</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://oss.acme.org/my-project/docs/</url>
+          <comment>from pyproject urls: documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://oss.acme.org/my-project/bugs/</url>
+          <comment>from pyproject urls: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/funding/</url>
+          <comment>from pyproject urls: Funding</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://oss.acme.org/my-project/changelog/</url>
+          <comment>from pyproject urls: Change log</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://oss.acme.org/my-project.git</url>
+          <comment>from pyproject urls: repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://oss.acme.org/my-project/</url>
+          <comment>from pyproject urls: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <dependencies>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/plain_normalize-packagename_1.6.json.bin
+++ b/tests/_data/snapshots/pipenv/plain_normalize-packagename_1.6.json.bin
@@ -1,0 +1,331 @@
+{
+  "components": [
+    {
+      "bom-ref": "ruamel-yaml==0.18.5",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "61917e3a35a569c1133a8f772e1226961bf5a1198bea7e23f06a0841dea1ab0e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a013ac02f99a69cdd6277d9664689eb1acba07069f912823177c5eced21a6ada"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml/"
+        }
+      ],
+      "name": "ruamel-yaml",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "jinja2"
+        }
+      ],
+      "purl": "pkg:pypi/ruamel-yaml@0.18.5",
+      "type": "library",
+      "version": "0.18.5"
+    },
+    {
+      "bom-ref": "ruamel.yaml.clib==0.2.8",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "024cfe1fc7c7f4e1aff4a81e718109e13409767e4f871443cbff3dba3578203d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "03d1162b6d1df1caa3a4bd27aa51ce17c9afc2046c31b0ad60a0a96ec22f8001"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "07238db9cbdf8fc1e9de2489a4f68474e70dffcb32232db7c08fa61ca0c7c462"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "09b055c05697b38ecacb7ac50bdab2240bfca1a0c4872b0fd309bb07dc9aa3a9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1707814f0d9791df063f8c19bb51b0d1278b8e9a2353abbb676c2f685dee6afe"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1758ce7d8e1a29d23de54a16ae867abd370f01b5a69e1a3ba75223eaa3ca1a1b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "184565012b60405d93838167f425713180b949e9d8dd0bbc7b49f074407c5a8b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1b617618914cb00bf5c34d4357c37aa15183fa229b24767259657746c9077615"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1dc67314e7e1086c9fdf2680b7b6c2be1c0d8e3a8279f2e993ca2a7545fecf62"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "25ac8c08322002b06fa1d49d1646181f0b2c72f5cbc15a85e80b4c30a544bb15"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "25c515e350e5b739842fc3228d662413ef28f295791af5e5110b543cf0b57d9b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "305889baa4043a09e5b76f8e2a51d4ffba44259f6b4c72dec8ca56207d9c6fe1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3213ece08ea033eb159ac52ae052a4899b56ecc124bb80020d9bbceeb50258e9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3f215c5daf6a9d7bbed4a0a4f760f3113b10e82ff4c5c44bec20a68c8014f675"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "46d378daaac94f454b3a0e3d8d78cafd78a026b1d71443f4966c696b48a6d899"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4ecbf9c3e19f9562c7fdd462e8d18dd902a47ca046a2e64dba80699f0b6c09b7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "53a300ed9cea38cf5a2a9b069058137c2ca1ce658a874b79baceb8f892f915a7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "56f4252222c067b4ce51ae12cbac231bce32aee1d33fbfc9d17e5b8d6966c312"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5c365d91c88390c8d0a8545df0b5857172824b1c604e867161e6b3d59a827eaa"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "700e4ebb569e59e16a976857c8798aee258dceac7c7d6b50cab63e080058df91"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "75e1ed13e1f9de23c5607fe6bd1aeaae21e523b32d83bb33918245361e9cc51b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "77159f5d5b5c14f7c34073862a6b7d34944075d9f93e681638f6d753606c6ce6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "7f67a1ee819dc4562d444bbafb135832b0b909f81cc90f7aa00260968c9ca1b3"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "840f0c7f194986a63d2c2465ca63af8ccbbc90ab1c6001b1978f05119b5e7334"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "84b554931e932c46f94ab306913ad7e11bba988104c5cff26d90d03f68258cd5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "87ea5ff66d8064301a154b3933ae406b0863402a799b16e4a1d24d9fbbcbe0d3"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "955eae71ac26c1ab35924203fda6220f84dce57d6d7884f189743e2abe3a9fbe"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a1a45e0bb052edf6a1d3a93baef85319733a888363938e1fc9924cb00c8df24c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a5aa27bad2bb83670b71683aae140a1f52b0857a2deff56ad3f6c13a017a26ed"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a6a9ffd280b71ad062eae53ac1659ad86a17f59a0fdc7699fd9be40525153337"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a75879bacf2c987c003368cf14bed0ffe99e8e85acfa6c0bfffc21a090f16880"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "aa2267c6a303eb483de8d02db2871afb5c5fc15618d894300b88958f729ad74f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "aab7fd643f71d7946f2ee58cc88c9b7bfc97debd71dcc93e03e2d174628e7e2d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b16420e621d26fdfa949a8b4b47ade8810c56002f5389970db4ddda51dbff248"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b42169467c42b692c19cf539c38d4602069d8c1505e97b86387fcf7afb766e1d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bba64af9fa9cebe325a62fa398760f5c7206b215201b0ec825005f1b18b9bccf"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bef08cd86169d9eafb3ccb0a39edb11d8e25f3dae2b28f5c52fd997521133069"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c2a72e9109ea74e511e29032f3b670835f8a59bbdc9ce692c5b4ed91ccf1eedb"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c58ecd827313af6864893e7af0a3bb85fd529f862b6adbefe14643947cfe2942"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c69212f63169ec1cfc9bb44723bf2917cbbd8f6191a00ef3410f5a7fe300722d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "cabddb8d8ead485e255fe80429f833172b4cadf99274db39abc080e068cbcc31"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d176b57452ab5b7028ac47e7b3cf644bcfdc8cacfecf7e71759f7f51a59e5c92"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "da09ad1c359a728e112d60116f626cc9f29730ff3e0e7db72b9a2dbc2e4beed5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e2b4c44b60eadec492926a7270abb100ef9f72798e18743939bdbf037aab8c28"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e79e5db08739731b0ce4850bed599235d601701d5694c36570a99a0c5ca41a9d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ebc06178e8821efc9692ea7544aa5644217358490145629914d8020042c24aa1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "edaef1c1200c4b4cb914583150dcaa3bc30e592e907c01117c08b13a07255ec2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f481f16baec5290e45aebdc2a5168ebc6d35189ae6fea7a58787613a25f6e875"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "fff3573c2db359f091e1589c3d7c5fc2f86f5bdb6f24252c2d8e539d4e45f412"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel.yaml.clib/"
+        }
+      ],
+      "name": "ruamel.yaml.clib",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/ruamel.yaml.clib@0.2.8",
+      "type": "library",
+      "version": "0.2.8"
+    },
+    {
+      "bom-ref": "ruamel.yaml.jinja2==0.2.7",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8449be29d9a157fa92d1648adc161d718e469f0d38a6b21e0eabb76fd5b3e663"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "eb36abd4d308794e9a497e48f98cbd2b921d2cd2946bbc9f1bea42c9b142a241"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel.yaml.jinja2/"
+        }
+      ],
+      "name": "ruamel.yaml.jinja2",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/ruamel.yaml.jinja2@0.2.7",
+      "type": "library",
+      "version": "0.2.7"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "root-component"
+    },
+    {
+      "ref": "ruamel-yaml==0.18.5"
+    },
+    {
+      "ref": "ruamel.yaml.clib==0.2.8"
+    },
+    {
+      "ref": "ruamel.yaml.jinja2==0.2.7"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "packages with non-normalized names",
+      "name": "normalize-packagename",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/pipenv/plain_normalize-packagename_1.6.xml.bin
+++ b/tests/_data/snapshots/pipenv/plain_normalize-packagename_1.6.xml.bin
@@ -1,0 +1,163 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>normalize-packagename</name>
+      <version>0.1.0</version>
+      <description>packages with non-normalized names</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="ruamel-yaml==0.18.5">
+      <name>ruamel-yaml</name>
+      <version>0.18.5</version>
+      <purl>pkg:pypi/ruamel-yaml@0.18.5</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">61917e3a35a569c1133a8f772e1226961bf5a1198bea7e23f06a0841dea1ab0e</hash>
+            <hash alg="SHA-256">a013ac02f99a69cdd6277d9664689eb1acba07069f912823177c5eced21a6ada</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+        <property name="cdx:python:package:required-extra">jinja2</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="ruamel.yaml.clib==0.2.8">
+      <name>ruamel.yaml.clib</name>
+      <version>0.2.8</version>
+      <purl>pkg:pypi/ruamel.yaml.clib@0.2.8</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel.yaml.clib/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">024cfe1fc7c7f4e1aff4a81e718109e13409767e4f871443cbff3dba3578203d</hash>
+            <hash alg="SHA-256">03d1162b6d1df1caa3a4bd27aa51ce17c9afc2046c31b0ad60a0a96ec22f8001</hash>
+            <hash alg="SHA-256">07238db9cbdf8fc1e9de2489a4f68474e70dffcb32232db7c08fa61ca0c7c462</hash>
+            <hash alg="SHA-256">09b055c05697b38ecacb7ac50bdab2240bfca1a0c4872b0fd309bb07dc9aa3a9</hash>
+            <hash alg="SHA-256">1707814f0d9791df063f8c19bb51b0d1278b8e9a2353abbb676c2f685dee6afe</hash>
+            <hash alg="SHA-256">1758ce7d8e1a29d23de54a16ae867abd370f01b5a69e1a3ba75223eaa3ca1a1b</hash>
+            <hash alg="SHA-256">184565012b60405d93838167f425713180b949e9d8dd0bbc7b49f074407c5a8b</hash>
+            <hash alg="SHA-256">1b617618914cb00bf5c34d4357c37aa15183fa229b24767259657746c9077615</hash>
+            <hash alg="SHA-256">1dc67314e7e1086c9fdf2680b7b6c2be1c0d8e3a8279f2e993ca2a7545fecf62</hash>
+            <hash alg="SHA-256">25ac8c08322002b06fa1d49d1646181f0b2c72f5cbc15a85e80b4c30a544bb15</hash>
+            <hash alg="SHA-256">25c515e350e5b739842fc3228d662413ef28f295791af5e5110b543cf0b57d9b</hash>
+            <hash alg="SHA-256">305889baa4043a09e5b76f8e2a51d4ffba44259f6b4c72dec8ca56207d9c6fe1</hash>
+            <hash alg="SHA-256">3213ece08ea033eb159ac52ae052a4899b56ecc124bb80020d9bbceeb50258e9</hash>
+            <hash alg="SHA-256">3f215c5daf6a9d7bbed4a0a4f760f3113b10e82ff4c5c44bec20a68c8014f675</hash>
+            <hash alg="SHA-256">46d378daaac94f454b3a0e3d8d78cafd78a026b1d71443f4966c696b48a6d899</hash>
+            <hash alg="SHA-256">4ecbf9c3e19f9562c7fdd462e8d18dd902a47ca046a2e64dba80699f0b6c09b7</hash>
+            <hash alg="SHA-256">53a300ed9cea38cf5a2a9b069058137c2ca1ce658a874b79baceb8f892f915a7</hash>
+            <hash alg="SHA-256">56f4252222c067b4ce51ae12cbac231bce32aee1d33fbfc9d17e5b8d6966c312</hash>
+            <hash alg="SHA-256">5c365d91c88390c8d0a8545df0b5857172824b1c604e867161e6b3d59a827eaa</hash>
+            <hash alg="SHA-256">700e4ebb569e59e16a976857c8798aee258dceac7c7d6b50cab63e080058df91</hash>
+            <hash alg="SHA-256">75e1ed13e1f9de23c5607fe6bd1aeaae21e523b32d83bb33918245361e9cc51b</hash>
+            <hash alg="SHA-256">77159f5d5b5c14f7c34073862a6b7d34944075d9f93e681638f6d753606c6ce6</hash>
+            <hash alg="SHA-256">7f67a1ee819dc4562d444bbafb135832b0b909f81cc90f7aa00260968c9ca1b3</hash>
+            <hash alg="SHA-256">840f0c7f194986a63d2c2465ca63af8ccbbc90ab1c6001b1978f05119b5e7334</hash>
+            <hash alg="SHA-256">84b554931e932c46f94ab306913ad7e11bba988104c5cff26d90d03f68258cd5</hash>
+            <hash alg="SHA-256">87ea5ff66d8064301a154b3933ae406b0863402a799b16e4a1d24d9fbbcbe0d3</hash>
+            <hash alg="SHA-256">955eae71ac26c1ab35924203fda6220f84dce57d6d7884f189743e2abe3a9fbe</hash>
+            <hash alg="SHA-256">a1a45e0bb052edf6a1d3a93baef85319733a888363938e1fc9924cb00c8df24c</hash>
+            <hash alg="SHA-256">a5aa27bad2bb83670b71683aae140a1f52b0857a2deff56ad3f6c13a017a26ed</hash>
+            <hash alg="SHA-256">a6a9ffd280b71ad062eae53ac1659ad86a17f59a0fdc7699fd9be40525153337</hash>
+            <hash alg="SHA-256">a75879bacf2c987c003368cf14bed0ffe99e8e85acfa6c0bfffc21a090f16880</hash>
+            <hash alg="SHA-256">aa2267c6a303eb483de8d02db2871afb5c5fc15618d894300b88958f729ad74f</hash>
+            <hash alg="SHA-256">aab7fd643f71d7946f2ee58cc88c9b7bfc97debd71dcc93e03e2d174628e7e2d</hash>
+            <hash alg="SHA-256">b16420e621d26fdfa949a8b4b47ade8810c56002f5389970db4ddda51dbff248</hash>
+            <hash alg="SHA-256">b42169467c42b692c19cf539c38d4602069d8c1505e97b86387fcf7afb766e1d</hash>
+            <hash alg="SHA-256">bba64af9fa9cebe325a62fa398760f5c7206b215201b0ec825005f1b18b9bccf</hash>
+            <hash alg="SHA-256">beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512</hash>
+            <hash alg="SHA-256">bef08cd86169d9eafb3ccb0a39edb11d8e25f3dae2b28f5c52fd997521133069</hash>
+            <hash alg="SHA-256">c2a72e9109ea74e511e29032f3b670835f8a59bbdc9ce692c5b4ed91ccf1eedb</hash>
+            <hash alg="SHA-256">c58ecd827313af6864893e7af0a3bb85fd529f862b6adbefe14643947cfe2942</hash>
+            <hash alg="SHA-256">c69212f63169ec1cfc9bb44723bf2917cbbd8f6191a00ef3410f5a7fe300722d</hash>
+            <hash alg="SHA-256">cabddb8d8ead485e255fe80429f833172b4cadf99274db39abc080e068cbcc31</hash>
+            <hash alg="SHA-256">d176b57452ab5b7028ac47e7b3cf644bcfdc8cacfecf7e71759f7f51a59e5c92</hash>
+            <hash alg="SHA-256">da09ad1c359a728e112d60116f626cc9f29730ff3e0e7db72b9a2dbc2e4beed5</hash>
+            <hash alg="SHA-256">e2b4c44b60eadec492926a7270abb100ef9f72798e18743939bdbf037aab8c28</hash>
+            <hash alg="SHA-256">e79e5db08739731b0ce4850bed599235d601701d5694c36570a99a0c5ca41a9d</hash>
+            <hash alg="SHA-256">ebc06178e8821efc9692ea7544aa5644217358490145629914d8020042c24aa1</hash>
+            <hash alg="SHA-256">edaef1c1200c4b4cb914583150dcaa3bc30e592e907c01117c08b13a07255ec2</hash>
+            <hash alg="SHA-256">f481f16baec5290e45aebdc2a5168ebc6d35189ae6fea7a58787613a25f6e875</hash>
+            <hash alg="SHA-256">fff3573c2db359f091e1589c3d7c5fc2f86f5bdb6f24252c2d8e539d4e45f412</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="ruamel.yaml.jinja2==0.2.7">
+      <name>ruamel.yaml.jinja2</name>
+      <version>0.2.7</version>
+      <purl>pkg:pypi/ruamel.yaml.jinja2@0.2.7</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel.yaml.jinja2/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">8449be29d9a157fa92d1648adc161d718e469f0d38a6b21e0eabb76fd5b3e663</hash>
+            <hash alg="SHA-256">eb36abd4d308794e9a497e48f98cbd2b921d2cd2946bbc9f1bea42c9b142a241</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="root-component"/>
+    <dependency ref="ruamel-yaml==0.18.5"/>
+    <dependency ref="ruamel.yaml.clib==0.2.8"/>
+    <dependency ref="ruamel.yaml.jinja2==0.2.7"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/plain_private-packages_1.6.json.bin
+++ b/tests/_data/snapshots/pipenv/plain_private-packages_1.6.json.bin
@@ -1,0 +1,270 @@
+{
+  "components": [
+    {
+      "bom-ref": "numpy==1.26.2",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "06fa1ed84aa60ea6ef9f91ba57b5ed963c3729534e6e54055fc151fad0423f0a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "174a8880739c16c925799c018f3f55b8130c1f7c8e75ab0a6fa9d41cab092fd6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1a13860fdcd95de7cf58bd6f8bc5a5ef81c0b0625eb2c9a783948847abbef2c2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1cc3d5029a30fb5f06704ad6b23b35e11309491c999838c31f124fee32107c79"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "22f8fc02fdbc829e7a8c578dd8d2e15a9074b630d4da29cda483337e300e3ee9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "26c9d33f8e8b846d5a65dd068c14e04018d05533b348d9eaeef6c1bd787f9919"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2b3fca8a5b00184828d12b073af4d0fc5fdd94b1632c2477526f6bd7842d700d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2beef57fb031dcc0dc8fa4fe297a742027b954949cabb52a2a376c144e5e6060"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "36340109af8da8805d8851ef1d74761b3b88e81a9bd80b290bbfed61bd2b4f75"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3703fc9258a4a122d17043e57b35e5ef1c5a5837c3db8be396c82e04c1cf9b0f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3ced40d4e9e18242f70dd02d739e44698df3dcb010d31f495ff00a31ef6014fe"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4a06263321dfd3598cacb252f51e521a8cb4b6df471bb12a7ee5cbab20ea9167"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4eb8df4bf8d3d90d091e0146f6c28492b0be84da3e409ebef54349f71ed271ef"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5d5244aabd6ed7f312268b9247be47343a654ebea52a60f002dc70c769048e75"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "64308ebc366a8ed63fd0bf426b6a9468060962f1a4339ab1074c228fa6ade8e3"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6a3cdb4d9c70e6b8c0814239ead47da00934666f668426fc6e94cce869e13fd7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "854ab91a2906ef29dc3925a064fcd365c7b4da743f84b123002f6139bcb3f8a7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "94cc3c222bb9fb5a12e334d0479b97bb2df446fbe622b470928f5284ffca3f8d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "96ca5482c3dbdd051bcd1fce8034603d6ebfc125a7bd59f55b40d8f5d246832b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a2bbc29fcb1771cd7b7425f98b05307776a6baf43035d3b80c4b0f29e9545186"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a4cd6ed4a339c21f1d1b0fdf13426cb3b284555c27ac2f156dfdaaa7e16bfab0"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "aa18428111fb9a591d7a9cc1b48150097ba6a7e8299fb56bdf574df650e7d1f1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "aa317b2325f7aa0a9471663e6093c210cb2ae9c0ad824732b307d2c51983d5b6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b04f5dc6b3efdaab541f7857351aac359e6ae3c126e2edb376929bd3b7f92d7e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b272d4cecc32c9e19911891446b72e986157e6a1809b7b56518b4f3755267523"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b361d369fc7e5e1714cf827b731ca32bff8d411212fccd29ad98ad622449cc36"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b96e7b9c624ef3ae2ae0e04fa9b460f6b9f17ad8b4bec6d7756510f1f6c0c841"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "baf8aab04a2c0e859da118f0b38617e5ee65d75b83795055fb66c0d5e9e9b818"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bcc008217145b3d77abd3e4d5ef586e3bdfba8fe17940769f8aa09b99e856c00"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bd3f0091e845164a20bd5a326860c840fe2af79fa12e0469a12768a3ec578d80"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "cc392fdcbd21d4be6ae1bb4475a03ce3b025cd49a9be5345d76d7585aea69440"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d73a3abcac238250091b11caef9ad12413dab01669511779bc9b29261dd50210"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f43740ab089277d403aa07567be138fc2a89d4d9892d113b76153e0e412409f8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f79b231bf5c16b1f39c7f4875e1ded36abee1591e98742b05d8a0fb55d8a3eec"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "fe6b44fb8fcdf7eda4ef4461b97b3f63c466b27ab151bec2366db8b197387841"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/numpy/"
+        }
+      ],
+      "name": "numpy",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/numpy@1.26.2",
+      "type": "library",
+      "version": "1.26.2"
+    },
+    {
+      "bom-ref": "six",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/six?download_url=https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl",
+      "type": "library"
+    },
+    {
+      "bom-ref": "toml==0.10.2",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pysrc1.acme.org",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/toml/"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "numpy==1.26.2"
+    },
+    {
+      "ref": "root-component"
+    },
+    {
+      "ref": "six"
+    },
+    {
+      "ref": "toml==0.10.2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "packages from aternative package repositories",
+      "name": "private-packges",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/pipenv/plain_private-packages_1.6.xml.bin
+++ b/tests/_data/snapshots/pipenv/plain_private-packages_1.6.xml.bin
@@ -1,0 +1,147 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>private-packges</name>
+      <version>0.1.0</version>
+      <description>packages from aternative package repositories</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="numpy==1.26.2">
+      <name>numpy</name>
+      <version>1.26.2</version>
+      <purl>pkg:pypi/numpy@1.26.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/numpy/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">06fa1ed84aa60ea6ef9f91ba57b5ed963c3729534e6e54055fc151fad0423f0a</hash>
+            <hash alg="SHA-256">174a8880739c16c925799c018f3f55b8130c1f7c8e75ab0a6fa9d41cab092fd6</hash>
+            <hash alg="SHA-256">1a13860fdcd95de7cf58bd6f8bc5a5ef81c0b0625eb2c9a783948847abbef2c2</hash>
+            <hash alg="SHA-256">1cc3d5029a30fb5f06704ad6b23b35e11309491c999838c31f124fee32107c79</hash>
+            <hash alg="SHA-256">22f8fc02fdbc829e7a8c578dd8d2e15a9074b630d4da29cda483337e300e3ee9</hash>
+            <hash alg="SHA-256">26c9d33f8e8b846d5a65dd068c14e04018d05533b348d9eaeef6c1bd787f9919</hash>
+            <hash alg="SHA-256">2b3fca8a5b00184828d12b073af4d0fc5fdd94b1632c2477526f6bd7842d700d</hash>
+            <hash alg="SHA-256">2beef57fb031dcc0dc8fa4fe297a742027b954949cabb52a2a376c144e5e6060</hash>
+            <hash alg="SHA-256">36340109af8da8805d8851ef1d74761b3b88e81a9bd80b290bbfed61bd2b4f75</hash>
+            <hash alg="SHA-256">3703fc9258a4a122d17043e57b35e5ef1c5a5837c3db8be396c82e04c1cf9b0f</hash>
+            <hash alg="SHA-256">3ced40d4e9e18242f70dd02d739e44698df3dcb010d31f495ff00a31ef6014fe</hash>
+            <hash alg="SHA-256">4a06263321dfd3598cacb252f51e521a8cb4b6df471bb12a7ee5cbab20ea9167</hash>
+            <hash alg="SHA-256">4eb8df4bf8d3d90d091e0146f6c28492b0be84da3e409ebef54349f71ed271ef</hash>
+            <hash alg="SHA-256">5d5244aabd6ed7f312268b9247be47343a654ebea52a60f002dc70c769048e75</hash>
+            <hash alg="SHA-256">64308ebc366a8ed63fd0bf426b6a9468060962f1a4339ab1074c228fa6ade8e3</hash>
+            <hash alg="SHA-256">6a3cdb4d9c70e6b8c0814239ead47da00934666f668426fc6e94cce869e13fd7</hash>
+            <hash alg="SHA-256">854ab91a2906ef29dc3925a064fcd365c7b4da743f84b123002f6139bcb3f8a7</hash>
+            <hash alg="SHA-256">94cc3c222bb9fb5a12e334d0479b97bb2df446fbe622b470928f5284ffca3f8d</hash>
+            <hash alg="SHA-256">96ca5482c3dbdd051bcd1fce8034603d6ebfc125a7bd59f55b40d8f5d246832b</hash>
+            <hash alg="SHA-256">a2bbc29fcb1771cd7b7425f98b05307776a6baf43035d3b80c4b0f29e9545186</hash>
+            <hash alg="SHA-256">a4cd6ed4a339c21f1d1b0fdf13426cb3b284555c27ac2f156dfdaaa7e16bfab0</hash>
+            <hash alg="SHA-256">aa18428111fb9a591d7a9cc1b48150097ba6a7e8299fb56bdf574df650e7d1f1</hash>
+            <hash alg="SHA-256">aa317b2325f7aa0a9471663e6093c210cb2ae9c0ad824732b307d2c51983d5b6</hash>
+            <hash alg="SHA-256">b04f5dc6b3efdaab541f7857351aac359e6ae3c126e2edb376929bd3b7f92d7e</hash>
+            <hash alg="SHA-256">b272d4cecc32c9e19911891446b72e986157e6a1809b7b56518b4f3755267523</hash>
+            <hash alg="SHA-256">b361d369fc7e5e1714cf827b731ca32bff8d411212fccd29ad98ad622449cc36</hash>
+            <hash alg="SHA-256">b96e7b9c624ef3ae2ae0e04fa9b460f6b9f17ad8b4bec6d7756510f1f6c0c841</hash>
+            <hash alg="SHA-256">baf8aab04a2c0e859da118f0b38617e5ee65d75b83795055fb66c0d5e9e9b818</hash>
+            <hash alg="SHA-256">bcc008217145b3d77abd3e4d5ef586e3bdfba8fe17940769f8aa09b99e856c00</hash>
+            <hash alg="SHA-256">bd3f0091e845164a20bd5a326860c840fe2af79fa12e0469a12768a3ec578d80</hash>
+            <hash alg="SHA-256">cc392fdcbd21d4be6ae1bb4475a03ce3b025cd49a9be5345d76d7585aea69440</hash>
+            <hash alg="SHA-256">d73a3abcac238250091b11caef9ad12413dab01669511779bc9b29261dd50210</hash>
+            <hash alg="SHA-256">f43740ab089277d403aa07567be138fc2a89d4d9892d113b76153e0e412409f8</hash>
+            <hash alg="SHA-256">f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea</hash>
+            <hash alg="SHA-256">f79b231bf5c16b1f39c7f4875e1ded36abee1591e98742b05d8a0fb55d8a3eec</hash>
+            <hash alg="SHA-256">fe6b44fb8fcdf7eda4ef4461b97b3f63c466b27ab151bec2366db8b197387841</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six">
+      <name>six</name>
+      <purl>pkg:pypi/six?download_url=https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml==0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <purl>pkg:pypi/toml@0.10.2?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/toml/</url>
+          <comment>from explicit index: pysrc1.acme.org</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="numpy==1.26.2"/>
+    <dependency ref="root-component"/>
+    <dependency ref="six"/>
+    <dependency ref="toml==0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/plain_with-extras_1.6.json.bin
+++ b/tests/_data/snapshots/pipenv/plain_with-extras_1.6.json.bin
@@ -1,0 +1,1625 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow==1.3.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "attrs==23.2.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/"
+        }
+      ],
+      "name": "attrs",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/attrs@23.2.0",
+      "type": "library",
+      "version": "23.2.0"
+    },
+    {
+      "bom-ref": "boolean.py==4.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "17b9a181630e43dde1851d42bef546d616d5d9b4480357514597e78b203d06e4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2876f2051d7d6394a531d82dc6eb407faa0b01a0a0b3083817ccd7323b8d96bd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/boolean.py/"
+        }
+      ],
+      "name": "boolean.py",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/boolean.py@4.0",
+      "type": "library",
+      "version": "4.0"
+    },
+    {
+      "bom-ref": "cyclonedx-python-lib==5.1.1",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "215a636a4e77385d2cf4c6c9801c9bad4791849634f2c6daa45ab2c6cb0a85f6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2989db0cd8bb4c0c442423d71ed7a84ae059e16a2d0f932cc4bf92da7385cdb3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/cyclonedx-python-lib/"
+        }
+      ],
+      "name": "cyclonedx-python-lib",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "json-validation"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "xml-validation"
+        }
+      ],
+      "purl": "pkg:pypi/cyclonedx-python-lib@5.1.1",
+      "type": "library",
+      "version": "5.1.1"
+    },
+    {
+      "bom-ref": "defusedxml==0.7.1",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/defusedxml/"
+        }
+      ],
+      "name": "defusedxml",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/defusedxml@0.7.1",
+      "type": "library",
+      "version": "0.7.1"
+    },
+    {
+      "bom-ref": "fqdn==1.5.1",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fqdn/"
+        }
+      ],
+      "name": "fqdn",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/fqdn@1.5.1",
+      "type": "library",
+      "version": "1.5.1"
+    },
+    {
+      "bom-ref": "idna==3.6",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/"
+        }
+      ],
+      "name": "idna",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/idna@3.6",
+      "type": "library",
+      "version": "3.6"
+    },
+    {
+      "bom-ref": "isoduration==20.11.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "jsonpointer==2.4",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonpointer/"
+        }
+      ],
+      "name": "jsonpointer",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/jsonpointer@2.4",
+      "type": "library",
+      "version": "2.4"
+    },
+    {
+      "bom-ref": "jsonschema==4.21.1",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7996507afae316306f9e2290407761157c6f78002dcf7419acb99822143d1c6f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "85727c00279f5fa6bedbe6238d2aa6403bedd8b4864ab11207d07df3cc1b2ee5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema/"
+        }
+      ],
+      "name": "jsonschema",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "format"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema@4.21.1",
+      "type": "library",
+      "version": "4.21.1"
+    },
+    {
+      "bom-ref": "jsonschema-specifications==2023.12.1",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48a76787b3e70f5ed53f1160d2b81f586e4ca6d1548c5de7085d1682674764cc"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "87e4fdf3a94858b8a2ba2778d9ba57d8a9cafca7c7489c46ba0d30a8bc6a9c3c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/"
+        }
+      ],
+      "name": "jsonschema-specifications",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema-specifications@2023.12.1",
+      "type": "library",
+      "version": "2023.12.1"
+    },
+    {
+      "bom-ref": "license-expression==30.2.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1a7dc2bb2d09cdc983d072e4f9adc787e107e09def84cbb3919baaaf4f8e6fa1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "599928edd995c43fc335e0af342076144dc71cb858afa1ed9c1c30c4e81794f5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/license-expression/"
+        }
+      ],
+      "name": "license-expression",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/license-expression@30.2.0",
+      "type": "library",
+      "version": "30.2.0"
+    },
+    {
+      "bom-ref": "lxml==4.9.4",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "00e91573183ad273e242db5585b52670eddf92bacad095ce25c1e682da14ed91"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "01bf1df1db327e748dcb152d17389cf6d0a8c5d533ef9bab781e9d5037619229"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "056a17eaaf3da87a05523472ae84246f87ac2f29a53306466c22e60282e54ff8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "0a08c89b23117049ba171bf51d2f9c5f3abf507d65d016d6e0fa2f37e18c0fc5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1343df4e2e6e51182aad12162b23b0a4b3fd77f17527a78c53f0f23573663545"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1449f9451cd53e0fd0a7ec2ff5ede4686add13ac7a7bfa6988ff6d75cff3ebe2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "16b9ec51cc2feab009e800f2c6327338d6ee4e752c76e95a35c4465e80390ccd"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1f10f250430a4caf84115b1e0f23f3615566ca2369d1962f82bef40dd99cd81a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "231142459d32779b209aa4b4d460b175cadd604fed856f25c1571a9d78114771"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "232fd30903d3123be4c435fb5159938c6225ee8607b635a4d3fca847003134ba"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "23d891e5bdc12e2e506e7d225d6aa929e0a0368c9916c1fddefab88166e98b20"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "266f655d1baff9c47b52f529b5f6bec33f66042f65f7c56adde3fcf2ed62ae8b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "273473d34462ae6e97c0f4e517bd1bf9588aa67a1d47d93f760a1282640e24ac"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2bd9ac6e44f2db368ef8986f3989a4cad3de4cd55dbdda536e253000c801bcc7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "33714fcf5af4ff7e70a49731a7cc8fd9ce910b9ac194f66eaa18c3cc0a4c02be"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "359a8b09d712df27849e0bcb62c6a3404e780b274b0b7e4c39a88826d1926c28"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "365005e8b0718ea6d64b374423e870648ab47c3a905356ab6e5a5ff03962b9a9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "389d2b2e543b27962990ab529ac6720c3dded588cc6d0f6557eec153305a3622"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3b505f2bbff50d261176e67be24e8909e54b5d9d08b12d4946344066d66b3e43"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3d74d4a3c4b8f7a1f676cedf8e84bcc57705a6d7925e6daef7a1e54ae543a197"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3f3f00a9061605725df1816f5713d10cd94636347ed651abdbc75828df302b20"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "43498ea734ccdfb92e1886dfedaebeb81178a241d39a79d5351ba2b671bff2b2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4855161013dfb2b762e02b3f4d4a21cc7c6aec13c69e3bffbf5022b3e708dd97"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4d973729ce04784906a19108054e1fd476bc85279a403ea1a72fdb051c76fa48"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4ece9cca4cd1c8ba889bfa67eae7f21d0d1a2e715b4d5045395113361e8c533d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "506becdf2ecaebaf7f7995f776394fcc8bd8a78022772de66677c84fb02dd33d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "520486f27f1d4ce9654154b4494cf9307b495527f3a2908ad4cb48e4f7ed7ef7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5557461f83bb7cc718bc9ee1f7156d50e31747e5b38d79cf40f79ab1447afd2d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "562778586949be7e0d7435fcb24aca4810913771f845d99145a6cee64d5b67ca"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "59bb5979f9941c61e907ee571732219fa4774d5a18f3fa5ff2df963f5dfaa6bc"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "606d445feeb0856c2b424405236a01c71af7c97e5fe42fbc778634faef2b47e4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6197c3f3c0b960ad033b9b7d611db11285bb461fc6b802c1dd50d04ad715c225"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "647459b23594f370c1c01768edaa0ba0959afc39caeeb793b43158bb9bb6a663"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "647bfe88b1997d7ae8d45dabc7c868d8cb0c8412a6e730a7651050b8c7289cf2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6bee9c2e501d835f91460b2c904bc359f8433e96799f5c2ff20feebd9bb1e590"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6dbdacf5752fbd78ccdb434698230c4f0f95df7dd956d5f205b5ed6911a1367c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "701847a7aaefef121c5c0d855b2affa5f9bd45196ef00266724a80e439220e46"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "786d6b57026e7e04d184313c1359ac3d68002c33e4b1042ca58c362f1d09ff58"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "7b378847a09d6bd46047f5f3599cdc64fcb4cc5a5a2dd0a2af610361fbe77b16"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "7d1d6c9e74c70ddf524e3c09d9dc0522aba9370708c2cb58680ea40174800013"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "857d6565f9aa3464764c2cb6a2e3c2e75e1970e877c188f4aeae45954a314e0c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8671622256a0859f5089cbe0ce4693c2af407bc053dcc99aadff7f5310b4aa02"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "88f7c383071981c74ec1998ba9b437659e4fd02a3c4a4d3efc16774eb108d0ec"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8aecb5a7f6f7f8fe9cac0bcadd39efaca8bbf8d1bf242e9f175cbe4c925116c3"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "91bbf398ac8bb7d65a5a52127407c05f75a18d7015a270fdd94bbcb04e65d573"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "936e8880cc00f839aa4173f94466a8406a96ddce814651075f95837316369899"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "953dd5481bd6252bd480d6ec431f61d7d87fdcbbb71b0d2bdcfc6ae00bb6fb10"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "95ae6c5a196e2f239150aa4a479967351df7f44800c93e5a975ec726fef005e2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9a2b5915c333e4364367140443b59f09feae42184459b913f0f41b9fed55794a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9ae6c3363261021144121427b1552b29e7b59de9d6a75bf51e03bc072efb3c37"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9b556596c49fa1232b0fff4b0e69b9d4083a502e60e404b44341e2f8fb7187f5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9c131447768ed7bc05a02553d939e7f0e807e533441901dd504e217b76307745"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9d9d5726474cbbef279fd709008f91a49c4f758bec9c062dfbba88eab00e3ff9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a1bdcbebd4e13446a14de4dd1825f1e778e099f17f79718b4aeaf2403624b0f7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a602ed9bd2c7d85bd58592c28e101bd9ff9c718fbde06545a70945ffd5d11868"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a8edae5253efa75c2fc79a90068fe540b197d1c7ab5803b800fccfe240eed33c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a905affe76f1802edcac554e3ccf68188bea16546071d7583fb1b693f9cf756b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a9e7c6d89c77bb2770c9491d988f26a4b161d05c8ca58f63fb1f1b6b9a74be45"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "aa9b5abd07f71b081a33115d9758ef6077924082055005808f68feccb27616bd"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "aaa5c173a26960fe67daa69aa93d6d6a1cd714a6eb13802d4e4bd1d24a530644"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ac7674d1638df129d9cb4503d20ffc3922bd463c865ef3cb412f2c926108e9a4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b1541e50b78e15fa06a2670157a1962ef06591d4c998b998047fff5e3236880e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b1980dbcaad634fe78e710c8587383e6e3f61dbe146bcbfd13a9c8ab2d7b1192"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bafa65e3acae612a7799ada439bd202403414ebe23f52e5b17f6ffc2eb98c2be"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bb5bd6212eb0edfd1e8f254585290ea1dadc3687dd8fd5e2fd9a87c31915cdab"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bbdd69e20fe2943b51e2841fc1e6a3c1de460d630f65bde12452d8c97209464d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bc354b1393dce46026ab13075f77b30e40b61b1a53e852e99d3cc5dd1af4bc85"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bcee502c649fa6351b44bb014b98c09cb00982a475a1912a9881ca28ab4f9cd9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bdd9abccd0927673cffe601d2c6cdad1c9321bf3437a2f507d6b037ef91ea307"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c42ae7e010d7d6bc51875d768110c10e8a59494855c3d4c348b068f5fb81fdcd"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c71b5b860c5215fdbaa56f715bc218e45a98477f816b46cfde4a84d25b13274e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c7721a3ef41591341388bb2265395ce522aba52f969d33dacd822da8f018aff8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ca8e44b5ba3edb682ea4e6185b49661fc22b230cf811b9c13963c9f982d1d964"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "cb53669442895763e61df5c995f0e8361b61662f26c1b04ee82899c2789c8f69"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "cc02c06e9e320869d7d1bd323df6dd4281e78ac2e7f8526835d3d48c69060683"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d3caa09e613ece43ac292fbed513a4bce170681a447d25ffcbc1b647d45a39c5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d82411dbf4d3127b6cde7da0f9373e37ad3a43e89ef374965465928f01c2b979"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "dbcb2dc07308453db428a95a4d03259bd8caea97d7f0776842299f2d00c72fc8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "dd4fda67f5faaef4f9ee5383435048ee3e11ad996901225ad7615bc92245bc8e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ddd92e18b783aeb86ad2132d84a4b795fc5ec612e3545c1b687e7747e66e2b53"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "de362ac8bc962408ad8fae28f3967ce1a262b5d63ab8cefb42662566737f1dc7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e214025e23db238805a600f1f37bf9f9a15413c7bf5f9d6ae194f84980c78722"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e8f9f93a23634cfafbad6e46ad7d09e0f4a25a2400e4a64b1b7b7c0fbaa06d9d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e96a1788f24d03e8d61679f9881a883ecdf9c445a38f9ae3f3f193ab6c591c66"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ec53a09aee61d45e7dbe7e91252ff0491b6b5fee3d85b2d45b173d8ab453efc1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f10250bb190fb0742e3e1958dd5c100524c2cc5096c67c8da51233f7448dc137"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f1faee2a831fe249e1bae9cbc68d3cd8a30f7e37851deee4d7962b17c410dd56"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f610d980e3fccf4394ab3806de6065682982f3d27c12d4ce3ee46a8183d64a6a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f6c35b2f87c004270fa2e703b872fcc984d714d430b305145c39d53074e1ffe0"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f836f39678cb47c9541f04d8ed4545719dc31ad850bf1832d6b4171e30d65d23"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f99768232f036b4776ce419d3244a04fe83784bce871b16d2c2e984c7fcea847"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "fd814847901df6e8de13ce69b84c31fc9b3fb591224d6762d0b256d510cbf382"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "fdb325b7fba1e2c40b9b1db407f85642e32404131c08480dd652110fc908561b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/"
+        }
+      ],
+      "name": "lxml",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/lxml@4.9.4",
+      "type": "library",
+      "version": "4.9.4"
+    },
+    {
+      "bom-ref": "packageurl-python==0.13.4",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "62aa13d60a0082ff115784fefdfe73a12f310e455365cca7c6d362161067f35f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6eb5e995009cc73387095e0b507ab65df51357d25ddc5fce3d3545ad6dcbbee8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/packageurl-python/"
+        }
+      ],
+      "name": "packageurl-python",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/packageurl-python@0.13.4",
+      "type": "library",
+      "version": "0.13.4"
+    },
+    {
+      "bom-ref": "py-serializable==0.15.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8fc41457d8ee5f5c5a12f41fd87bf1a4f2ecf9da39fee92059b728e78f320771"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d3f1201b33420c481aa83f7860c7bf2c2f036ba3ea82b6e15a96696457c36cd2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-serializable/"
+        }
+      ],
+      "name": "py-serializable",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/py-serializable@0.15.0",
+      "type": "library",
+      "version": "0.15.0"
+    },
+    {
+      "bom-ref": "python-dateutil==2.8.2",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "referencing==0.33.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "39240f2ecc770258f28b642dd47fd74bc8b02484de54e1882b74b35ebd779bd5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c775fedf74bc0f9189c2a3be1c12fd03e8c23f4d371dce795df44e06c5b412f7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/"
+        }
+      ],
+      "name": "referencing",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/referencing@0.33.0",
+      "type": "library",
+      "version": "0.33.0"
+    },
+    {
+      "bom-ref": "rfc3339-validator==0.1.4",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3339-validator/"
+        }
+      ],
+      "name": "rfc3339-validator",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/rfc3339-validator@0.1.4",
+      "type": "library",
+      "version": "0.1.4"
+    },
+    {
+      "bom-ref": "rfc3987==1.3.8",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3987/"
+        }
+      ],
+      "name": "rfc3987",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/rfc3987@1.3.8",
+      "type": "library",
+      "version": "1.3.8"
+    },
+    {
+      "bom-ref": "rpds-py==0.17.1",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "01f58a7306b64e0a4fe042047dd2b7d411ee82e54240284bab63e325762c1147"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "0210b2668f24c078307260bf88bdac9d6f1093635df5123789bfee4d8d7fc8e7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "02866e060219514940342a1f84303a1ef7a1dad0ac311792fbbe19b521b489d2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "0387ce69ba06e43df54e43968090f3626e231e4bc9150e4c3246947567695f68"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "060f412230d5f19fc8c8b75f315931b408d8ebf56aec33ef4168d1b9e54200b1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "071bc28c589b86bc6351a339114fb7a029f5cddbaca34103aa573eba7b482382"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "0bfb09bf41fe7c51413f563373e5f537eaa653d7adc4830399d4e9bdc199959d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "10162fe3f5f47c37ebf6d8ff5a2368508fe22007e3077bf25b9c7d803454d921"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "149c5cd24f729e3567b56e1795f74577aa3126c14c11e457bec1b1c90d212e38"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1701fc54460ae2e5efc1dd6350eafd7a760f516df8dbe51d4a1c79d69472fbd4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1957a2ab607f9added64478a6982742eb29f109d89d065fa44e01691a20fc20a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1a746a6d49665058a5896000e8d9d2f1a6acba8a03b389c1e4c06e11e0b7f40d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1bfcad3109c1e5ba3cbe2f421614e70439f72897515a96c462ea657261b96518"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1d36b2b59e8cc6e576f8f7b671e32f2ff43153f0ad6d0201250a7c07f25d570e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1db228102ab9d1ff4c64148c96320d0be7044fa28bd865a9ce628ce98da5973d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1dc29db3900cb1bb40353772417800f29c3d078dbc8024fd64655a04ee3c4bdf"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1e626b365293a2142a62b9a614e1f8e331b28f3ca57b9f05ebbf4cf2a0f0bdc5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1f3c3461ebb4c4f1bbc70b15d20b565759f97a5aaf13af811fcefc892e9197ba"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "20de7b7179e2031a04042e85dc463a93a82bc177eeba5ddd13ff746325558aa6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "24e4900a6643f87058a27320f81336d527ccfe503984528edde4bb660c8c8d59"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2528ff96d09f12e638695f3a2e0c609c7b84c6df7c5ae9bfeb9252b6fa686253"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "25f071737dae674ca8937a73d0f43f5a52e92c2d178330b4c0bb6ab05586ffa6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "270987bc22e7e5a962b1094953ae901395e8c1e1e83ad016c5cfcfff75a15a3f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "292f7344a3301802e7c25c53792fae7d1593cb0e50964e7bcdcc5cf533d634e3"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2953937f83820376b5979318840f3ee47477d94c17b940fe31d9458d79ae7eea"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2a792b2e1d3038daa83fa474d559acfd6dc1e3650ee93b2662ddc17dbff20ad1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2a7b2f2f56a16a6d62e55354dd329d929560442bd92e87397b7a9586a32e3e76"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2f4eb548daf4836e3b2c662033bfbfc551db58d30fd8fe660314f86bf8510b93"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3664d126d3388a887db44c2e293f87d500c4184ec43d5d14d2d2babdb4c64cad"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3677fcca7fb728c86a78660c7fb1b07b69b281964673f486ae72860e13f512ad"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "380e0df2e9d5d5d339803cfc6d183a5442ad7ab3c63c2a0982e8c824566c5ccc"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3ac732390d529d8469b831949c78085b034bff67f584559340008d0f6041a049"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4128980a14ed805e1b91a7ed551250282a8ddf8201a4e9f8f5b7e6225f54170d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4341bd7579611cf50e7b20bb8c2e23512a3dc79de987a1f411cb458ab670eb90"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "436474f17733c7dca0fbf096d36ae65277e8645039df12a0fa52445ca494729d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4dc889a9d8a34758d0fcc9ac86adb97bab3fb7f0c4d29794357eb147536483fd"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4e21b76075c01d65d0f0f34302b5a7457d95721d5e0667aea65e5bb3ab415c25"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "516fb8c77805159e97a689e2f1c80655c7658f5af601c34ffdb916605598cda2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5576ee2f3a309d2bb403ec292d5958ce03953b0e57a11d224c1f134feaf8c40f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5a024fa96d541fd7edaa0e9d904601c6445e95a729a2900c5aec6555fe921ed6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5d0e8a6434a3fbf77d11448c9c25b2f25244226cfbec1a5159947cac5b8c5fa4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5e7d63ec01fe7c76c2dbb7e972fece45acbb8836e72682bde138e7e039906e2c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "60e820ee1004327609b28db8307acc27f5f2e9a0b185b2064c5f23e815f248f8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "637b802f3f069a64436d432117a7e58fab414b4e27a7e81049817ae94de45d8d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "65dcf105c1943cba45d19207ef51b8bc46d232a381e94dd38719d52d3980015b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "698ea95a60c8b16b58be9d854c9f993c639f5c214cf9ba782eca53a8789d6b19"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "70fcc6c2906cfa5c6a552ba7ae2ce64b6c32f437d8f3f8eea49925b278a61453"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "720215373a280f78a1814becb1312d4e4d1077b1202a56d2b0815e95ccb99ce9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "7450dbd659fed6dd41d1a7d47ed767e893ba402af8ae664c157c255ec6067fde"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "7b7d9ca34542099b4e185b3c2a2b2eda2e318a7dbde0b0d83357a6d4421b5296"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "7fbd70cb8b54fe745301921b0816c08b6d917593429dfc437fd024b5ba713c58"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "81038ff87a4e04c22e1d81f947c6ac46f122e0c80460b9006e6517c4d842a6ec"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "810685321f4a304b2b55577c915bece4c4a06dfe38f6e62d9cc1d6ca8ee86b99"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "82ada4a8ed9e82e443fcef87e22a3eed3654dd3adf6e3b3a0deb70f03e86142a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "841320e1841bb53fada91c9725e766bb25009cfd4144e92298db296fb6c894fb"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8587fd64c2a91c33cdc39d0cebdaf30e79491cc029a37fcd458ba863f8815383"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8ffe53e1d8ef2520ebcf0c9fec15bb721da59e8ef283b6ff3079613b1e30513d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9051e3d2af8f55b42061603e29e744724cb5f65b128a491446cc029b3e2ea896"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "91e5a8200e65aaac342a791272c564dffcf1281abd635d304d6c4e6b495f29dc"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "93432e747fb07fa567ad9cc7aaadd6e29710e515aabf939dfbed8046041346c6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "938eab7323a736533f015e6069a7d53ef2dcc841e4e533b782c2bfb9fb12d84b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9584f8f52010295a4a417221861df9bea4c72d9632562b6e59b3c7b87a1522b7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9737bdaa0ad33d34c0efc718741abaafce62fadae72c8b251df9b0c823c63b22"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "99da0a4686ada4ed0f778120a0ea8d066de1a0a92ab0d13ae68492a437db78bf"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "99f567dae93e10be2daaa896e07513dd4bf9c2ecf0576e0533ac36ba3b1d5394"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9bdf1303df671179eaf2cb41e8515a07fc78d9d00f111eadbe3e14262f59c3d0"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9f0e4dc0f17dcea4ab9d13ac5c666b6b5337042b4d8f27e01b70fae41dd65c57"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a000133a90eea274a6f28adc3084643263b1e7c1a5a66eb0a0a7a36aa757ed74"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a3264e3e858de4fc601741498215835ff324ff2482fd4e4af61b46512dd7fc83"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a71169d505af63bb4d20d23a8fbd4c6ce272e7bce6cc31f617152aa784436f29"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a967dd6afda7715d911c25a6ba1517975acd8d1092b2f326718725461a3d33f9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "aa5bfb13f1e89151ade0eb812f7b0d7a4d643406caaad65ce1cbabe0a66d695f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ae35e8e6801c5ab071b992cb2da958eee76340e6926ec693b5ff7d6381441745"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b686f25377f9c006acbac63f61614416a6317133ab7fafe5de5f7dc8a06d42eb"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b760a56e080a826c2e5af09002c1a037382ed21d03134eb6294812dda268c811"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b86b21b348f7e5485fae740d845c65a880f5d1eda1e063bc59bef92d1f7d0c55"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b9412abdf0ba70faa6e2ee6c0cc62a8defb772e78860cef419865917d86c7342"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bd345a13ce06e94c753dab52f8e71e5252aec1e4f8022d24d56decd31e1b9b23"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "be22ae34d68544df293152b7e50895ba70d2a833ad9566932d750d3625918b82"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bf046179d011e6114daf12a534d874958b039342b347348a78b7cdf0dd9d6041"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c3d2010656999b63e628a3c694f23020322b4178c450dc478558a2b6ef3cb9bb"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c64602e8be701c6cfe42064b71c84ce62ce66ddc6422c15463fd8127db3d8066"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d65e6b4f1443048eb7e833c2accb4fa7ee67cc7d54f31b4f0555b474758bee55"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d8bbd8e56f3ba25a7d0cf980fc42b34028848a53a0e36c9918550e0280b9d0b6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "da1ead63368c04a9bded7904757dfcae01eba0e0f9bc41d3d7f57ebf1c04015a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "dbbb95e6fc91ea3102505d111b327004d1c4ce98d56a4a02e82cd451f9f57140"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "dbc56680ecf585a384fbd93cd42bc82668b77cb525343170a2d86dafaed2a84b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "df3b6f45ba4515632c5064e35ca7f31d51d13d1479673185ba8f9fefbbed58b9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "dfe07308b311a8293a0d5ef4e61411c5c20f682db6b5e73de6c7c8824272c256"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e796051f2070f47230c745d0a77a91088fbee2cc0502e9b796b9c6471983718c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "efa767c220d94aa4ac3a6dd3aeb986e9f229eaf5bce92d8b1b3018d06bed3772"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f0b8bf5b8db49d8fd40f54772a1dcf262e8be0ad2ab0206b5a2ec109c176c0a4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f175e95a197f6a4059b50757a3dca33b32b61691bdbd22c29e8a8d21d3914cae"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f2f3b28b40fddcb6c1f1f6c88c6f3769cd933fa493ceb79da45968a21dccc920"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f6c43b6f97209e370124baf2bf40bb1e8edc25311a158867eb1c3a5d449ebc7a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f7f4cb1f173385e8a39c29510dd11a78bf44e360fb75610594973f5ea141028b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "fad059a4bd14c45776600d223ec194e77db6c20255578bb5bcdd7c18fd169361"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ff1dcb8e8bc2261a088821b2595ef031c91d499a0c1b031c152d43fe0a6ecec8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ffee088ea9b593cc6160518ba9bd319b5475e5f3e578e4552d63818773c6f56a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/"
+        }
+      ],
+      "name": "rpds-py",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/rpds-py@0.17.1",
+      "type": "library",
+      "version": "0.17.1"
+    },
+    {
+      "bom-ref": "six==1.16.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "sortedcontainers==2.4.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/sortedcontainers/"
+        }
+      ],
+      "name": "sortedcontainers",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/sortedcontainers@2.4.0",
+      "type": "library",
+      "version": "2.4.0"
+    },
+    {
+      "bom-ref": "types-python-dateutil==2.8.19.20240106",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f8db221c3b98e6ca02ea83a58371b22c374f42ae5bbdf186db9c9a76581459f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "efbbdc54590d0f16152fa103c9879c7d4a00e82078f6e2cf01769042165acaa2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.20240106",
+      "type": "library",
+      "version": "2.8.19.20240106"
+    },
+    {
+      "bom-ref": "uri-template==1.3.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uri-template/"
+        }
+      ],
+      "name": "uri-template",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/uri-template@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "webcolors==1.13",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/webcolors/"
+        }
+      ],
+      "name": "webcolors",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/webcolors@1.13",
+      "type": "library",
+      "version": "1.13"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "arrow==1.3.0"
+    },
+    {
+      "ref": "attrs==23.2.0"
+    },
+    {
+      "ref": "boolean.py==4.0"
+    },
+    {
+      "ref": "cyclonedx-python-lib==5.1.1"
+    },
+    {
+      "ref": "defusedxml==0.7.1"
+    },
+    {
+      "ref": "fqdn==1.5.1"
+    },
+    {
+      "ref": "idna==3.6"
+    },
+    {
+      "ref": "isoduration==20.11.0"
+    },
+    {
+      "ref": "jsonpointer==2.4"
+    },
+    {
+      "ref": "jsonschema-specifications==2023.12.1"
+    },
+    {
+      "ref": "jsonschema==4.21.1"
+    },
+    {
+      "ref": "license-expression==30.2.0"
+    },
+    {
+      "ref": "lxml==4.9.4"
+    },
+    {
+      "ref": "packageurl-python==0.13.4"
+    },
+    {
+      "ref": "py-serializable==0.15.0"
+    },
+    {
+      "ref": "python-dateutil==2.8.2"
+    },
+    {
+      "ref": "referencing==0.33.0"
+    },
+    {
+      "ref": "rfc3339-validator==0.1.4"
+    },
+    {
+      "ref": "rfc3987==1.3.8"
+    },
+    {
+      "ref": "root-component"
+    },
+    {
+      "ref": "rpds-py==0.17.1"
+    },
+    {
+      "ref": "six==1.16.0"
+    },
+    {
+      "ref": "sortedcontainers==2.4.0"
+    },
+    {
+      "ref": "types-python-dateutil==2.8.19.20240106"
+    },
+    {
+      "ref": "uri-template==1.3.0"
+    },
+    {
+      "ref": "webcolors==1.13"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/pipenv/plain_with-extras_1.6.xml.bin
+++ b/tests/_data/snapshots/pipenv/plain_with-extras_1.6.xml.bin
@@ -1,0 +1,723 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow==1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="attrs==23.2.0">
+      <name>attrs</name>
+      <version>23.2.0</version>
+      <purl>pkg:pypi/attrs@23.2.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30</hash>
+            <hash alg="SHA-256">99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="boolean.py==4.0">
+      <name>boolean.py</name>
+      <version>4.0</version>
+      <purl>pkg:pypi/boolean.py@4.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/boolean.py/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">17b9a181630e43dde1851d42bef546d616d5d9b4480357514597e78b203d06e4</hash>
+            <hash alg="SHA-256">2876f2051d7d6394a531d82dc6eb407faa0b01a0a0b3083817ccd7323b8d96bd</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="cyclonedx-python-lib==5.1.1">
+      <name>cyclonedx-python-lib</name>
+      <version>5.1.1</version>
+      <purl>pkg:pypi/cyclonedx-python-lib@5.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/cyclonedx-python-lib/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">215a636a4e77385d2cf4c6c9801c9bad4791849634f2c6daa45ab2c6cb0a85f6</hash>
+            <hash alg="SHA-256">2989db0cd8bb4c0c442423d71ed7a84ae059e16a2d0f932cc4bf92da7385cdb3</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+        <property name="cdx:python:package:required-extra">json-validation</property>
+        <property name="cdx:python:package:required-extra">xml-validation</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="defusedxml==0.7.1">
+      <name>defusedxml</name>
+      <version>0.7.1</version>
+      <purl>pkg:pypi/defusedxml@0.7.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/defusedxml/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69</hash>
+            <hash alg="SHA-256">a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="fqdn==1.5.1">
+      <name>fqdn</name>
+      <version>1.5.1</version>
+      <purl>pkg:pypi/fqdn@1.5.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fqdn/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f</hash>
+            <hash alg="SHA-256">3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="idna==3.6">
+      <name>idna</name>
+      <version>3.6</version>
+      <purl>pkg:pypi/idna@3.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca</hash>
+            <hash alg="SHA-256">c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration==20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonpointer==2.4">
+      <name>jsonpointer</name>
+      <version>2.4</version>
+      <purl>pkg:pypi/jsonpointer@2.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonpointer/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a</hash>
+            <hash alg="SHA-256">585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema==4.21.1">
+      <name>jsonschema</name>
+      <version>4.21.1</version>
+      <purl>pkg:pypi/jsonschema@4.21.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">7996507afae316306f9e2290407761157c6f78002dcf7419acb99822143d1c6f</hash>
+            <hash alg="SHA-256">85727c00279f5fa6bedbe6238d2aa6403bedd8b4864ab11207d07df3cc1b2ee5</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+        <property name="cdx:python:package:required-extra">format</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema-specifications==2023.12.1">
+      <name>jsonschema-specifications</name>
+      <version>2023.12.1</version>
+      <purl>pkg:pypi/jsonschema-specifications@2023.12.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">48a76787b3e70f5ed53f1160d2b81f586e4ca6d1548c5de7085d1682674764cc</hash>
+            <hash alg="SHA-256">87e4fdf3a94858b8a2ba2778d9ba57d8a9cafca7c7489c46ba0d30a8bc6a9c3c</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="license-expression==30.2.0">
+      <name>license-expression</name>
+      <version>30.2.0</version>
+      <purl>pkg:pypi/license-expression@30.2.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/license-expression/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1a7dc2bb2d09cdc983d072e4f9adc787e107e09def84cbb3919baaaf4f8e6fa1</hash>
+            <hash alg="SHA-256">599928edd995c43fc335e0af342076144dc71cb858afa1ed9c1c30c4e81794f5</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="lxml==4.9.4">
+      <name>lxml</name>
+      <version>4.9.4</version>
+      <purl>pkg:pypi/lxml@4.9.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">00e91573183ad273e242db5585b52670eddf92bacad095ce25c1e682da14ed91</hash>
+            <hash alg="SHA-256">01bf1df1db327e748dcb152d17389cf6d0a8c5d533ef9bab781e9d5037619229</hash>
+            <hash alg="SHA-256">056a17eaaf3da87a05523472ae84246f87ac2f29a53306466c22e60282e54ff8</hash>
+            <hash alg="SHA-256">0a08c89b23117049ba171bf51d2f9c5f3abf507d65d016d6e0fa2f37e18c0fc5</hash>
+            <hash alg="SHA-256">1343df4e2e6e51182aad12162b23b0a4b3fd77f17527a78c53f0f23573663545</hash>
+            <hash alg="SHA-256">1449f9451cd53e0fd0a7ec2ff5ede4686add13ac7a7bfa6988ff6d75cff3ebe2</hash>
+            <hash alg="SHA-256">16b9ec51cc2feab009e800f2c6327338d6ee4e752c76e95a35c4465e80390ccd</hash>
+            <hash alg="SHA-256">1f10f250430a4caf84115b1e0f23f3615566ca2369d1962f82bef40dd99cd81a</hash>
+            <hash alg="SHA-256">231142459d32779b209aa4b4d460b175cadd604fed856f25c1571a9d78114771</hash>
+            <hash alg="SHA-256">232fd30903d3123be4c435fb5159938c6225ee8607b635a4d3fca847003134ba</hash>
+            <hash alg="SHA-256">23d891e5bdc12e2e506e7d225d6aa929e0a0368c9916c1fddefab88166e98b20</hash>
+            <hash alg="SHA-256">266f655d1baff9c47b52f529b5f6bec33f66042f65f7c56adde3fcf2ed62ae8b</hash>
+            <hash alg="SHA-256">273473d34462ae6e97c0f4e517bd1bf9588aa67a1d47d93f760a1282640e24ac</hash>
+            <hash alg="SHA-256">2bd9ac6e44f2db368ef8986f3989a4cad3de4cd55dbdda536e253000c801bcc7</hash>
+            <hash alg="SHA-256">33714fcf5af4ff7e70a49731a7cc8fd9ce910b9ac194f66eaa18c3cc0a4c02be</hash>
+            <hash alg="SHA-256">359a8b09d712df27849e0bcb62c6a3404e780b274b0b7e4c39a88826d1926c28</hash>
+            <hash alg="SHA-256">365005e8b0718ea6d64b374423e870648ab47c3a905356ab6e5a5ff03962b9a9</hash>
+            <hash alg="SHA-256">389d2b2e543b27962990ab529ac6720c3dded588cc6d0f6557eec153305a3622</hash>
+            <hash alg="SHA-256">3b505f2bbff50d261176e67be24e8909e54b5d9d08b12d4946344066d66b3e43</hash>
+            <hash alg="SHA-256">3d74d4a3c4b8f7a1f676cedf8e84bcc57705a6d7925e6daef7a1e54ae543a197</hash>
+            <hash alg="SHA-256">3f3f00a9061605725df1816f5713d10cd94636347ed651abdbc75828df302b20</hash>
+            <hash alg="SHA-256">43498ea734ccdfb92e1886dfedaebeb81178a241d39a79d5351ba2b671bff2b2</hash>
+            <hash alg="SHA-256">4855161013dfb2b762e02b3f4d4a21cc7c6aec13c69e3bffbf5022b3e708dd97</hash>
+            <hash alg="SHA-256">4d973729ce04784906a19108054e1fd476bc85279a403ea1a72fdb051c76fa48</hash>
+            <hash alg="SHA-256">4ece9cca4cd1c8ba889bfa67eae7f21d0d1a2e715b4d5045395113361e8c533d</hash>
+            <hash alg="SHA-256">506becdf2ecaebaf7f7995f776394fcc8bd8a78022772de66677c84fb02dd33d</hash>
+            <hash alg="SHA-256">520486f27f1d4ce9654154b4494cf9307b495527f3a2908ad4cb48e4f7ed7ef7</hash>
+            <hash alg="SHA-256">5557461f83bb7cc718bc9ee1f7156d50e31747e5b38d79cf40f79ab1447afd2d</hash>
+            <hash alg="SHA-256">562778586949be7e0d7435fcb24aca4810913771f845d99145a6cee64d5b67ca</hash>
+            <hash alg="SHA-256">59bb5979f9941c61e907ee571732219fa4774d5a18f3fa5ff2df963f5dfaa6bc</hash>
+            <hash alg="SHA-256">606d445feeb0856c2b424405236a01c71af7c97e5fe42fbc778634faef2b47e4</hash>
+            <hash alg="SHA-256">6197c3f3c0b960ad033b9b7d611db11285bb461fc6b802c1dd50d04ad715c225</hash>
+            <hash alg="SHA-256">647459b23594f370c1c01768edaa0ba0959afc39caeeb793b43158bb9bb6a663</hash>
+            <hash alg="SHA-256">647bfe88b1997d7ae8d45dabc7c868d8cb0c8412a6e730a7651050b8c7289cf2</hash>
+            <hash alg="SHA-256">6bee9c2e501d835f91460b2c904bc359f8433e96799f5c2ff20feebd9bb1e590</hash>
+            <hash alg="SHA-256">6dbdacf5752fbd78ccdb434698230c4f0f95df7dd956d5f205b5ed6911a1367c</hash>
+            <hash alg="SHA-256">701847a7aaefef121c5c0d855b2affa5f9bd45196ef00266724a80e439220e46</hash>
+            <hash alg="SHA-256">786d6b57026e7e04d184313c1359ac3d68002c33e4b1042ca58c362f1d09ff58</hash>
+            <hash alg="SHA-256">7b378847a09d6bd46047f5f3599cdc64fcb4cc5a5a2dd0a2af610361fbe77b16</hash>
+            <hash alg="SHA-256">7d1d6c9e74c70ddf524e3c09d9dc0522aba9370708c2cb58680ea40174800013</hash>
+            <hash alg="SHA-256">857d6565f9aa3464764c2cb6a2e3c2e75e1970e877c188f4aeae45954a314e0c</hash>
+            <hash alg="SHA-256">8671622256a0859f5089cbe0ce4693c2af407bc053dcc99aadff7f5310b4aa02</hash>
+            <hash alg="SHA-256">88f7c383071981c74ec1998ba9b437659e4fd02a3c4a4d3efc16774eb108d0ec</hash>
+            <hash alg="SHA-256">8aecb5a7f6f7f8fe9cac0bcadd39efaca8bbf8d1bf242e9f175cbe4c925116c3</hash>
+            <hash alg="SHA-256">91bbf398ac8bb7d65a5a52127407c05f75a18d7015a270fdd94bbcb04e65d573</hash>
+            <hash alg="SHA-256">936e8880cc00f839aa4173f94466a8406a96ddce814651075f95837316369899</hash>
+            <hash alg="SHA-256">953dd5481bd6252bd480d6ec431f61d7d87fdcbbb71b0d2bdcfc6ae00bb6fb10</hash>
+            <hash alg="SHA-256">95ae6c5a196e2f239150aa4a479967351df7f44800c93e5a975ec726fef005e2</hash>
+            <hash alg="SHA-256">9a2b5915c333e4364367140443b59f09feae42184459b913f0f41b9fed55794a</hash>
+            <hash alg="SHA-256">9ae6c3363261021144121427b1552b29e7b59de9d6a75bf51e03bc072efb3c37</hash>
+            <hash alg="SHA-256">9b556596c49fa1232b0fff4b0e69b9d4083a502e60e404b44341e2f8fb7187f5</hash>
+            <hash alg="SHA-256">9c131447768ed7bc05a02553d939e7f0e807e533441901dd504e217b76307745</hash>
+            <hash alg="SHA-256">9d9d5726474cbbef279fd709008f91a49c4f758bec9c062dfbba88eab00e3ff9</hash>
+            <hash alg="SHA-256">a1bdcbebd4e13446a14de4dd1825f1e778e099f17f79718b4aeaf2403624b0f7</hash>
+            <hash alg="SHA-256">a602ed9bd2c7d85bd58592c28e101bd9ff9c718fbde06545a70945ffd5d11868</hash>
+            <hash alg="SHA-256">a8edae5253efa75c2fc79a90068fe540b197d1c7ab5803b800fccfe240eed33c</hash>
+            <hash alg="SHA-256">a905affe76f1802edcac554e3ccf68188bea16546071d7583fb1b693f9cf756b</hash>
+            <hash alg="SHA-256">a9e7c6d89c77bb2770c9491d988f26a4b161d05c8ca58f63fb1f1b6b9a74be45</hash>
+            <hash alg="SHA-256">aa9b5abd07f71b081a33115d9758ef6077924082055005808f68feccb27616bd</hash>
+            <hash alg="SHA-256">aaa5c173a26960fe67daa69aa93d6d6a1cd714a6eb13802d4e4bd1d24a530644</hash>
+            <hash alg="SHA-256">ac7674d1638df129d9cb4503d20ffc3922bd463c865ef3cb412f2c926108e9a4</hash>
+            <hash alg="SHA-256">b1541e50b78e15fa06a2670157a1962ef06591d4c998b998047fff5e3236880e</hash>
+            <hash alg="SHA-256">b1980dbcaad634fe78e710c8587383e6e3f61dbe146bcbfd13a9c8ab2d7b1192</hash>
+            <hash alg="SHA-256">bafa65e3acae612a7799ada439bd202403414ebe23f52e5b17f6ffc2eb98c2be</hash>
+            <hash alg="SHA-256">bb5bd6212eb0edfd1e8f254585290ea1dadc3687dd8fd5e2fd9a87c31915cdab</hash>
+            <hash alg="SHA-256">bbdd69e20fe2943b51e2841fc1e6a3c1de460d630f65bde12452d8c97209464d</hash>
+            <hash alg="SHA-256">bc354b1393dce46026ab13075f77b30e40b61b1a53e852e99d3cc5dd1af4bc85</hash>
+            <hash alg="SHA-256">bcee502c649fa6351b44bb014b98c09cb00982a475a1912a9881ca28ab4f9cd9</hash>
+            <hash alg="SHA-256">bdd9abccd0927673cffe601d2c6cdad1c9321bf3437a2f507d6b037ef91ea307</hash>
+            <hash alg="SHA-256">c42ae7e010d7d6bc51875d768110c10e8a59494855c3d4c348b068f5fb81fdcd</hash>
+            <hash alg="SHA-256">c71b5b860c5215fdbaa56f715bc218e45a98477f816b46cfde4a84d25b13274e</hash>
+            <hash alg="SHA-256">c7721a3ef41591341388bb2265395ce522aba52f969d33dacd822da8f018aff8</hash>
+            <hash alg="SHA-256">ca8e44b5ba3edb682ea4e6185b49661fc22b230cf811b9c13963c9f982d1d964</hash>
+            <hash alg="SHA-256">cb53669442895763e61df5c995f0e8361b61662f26c1b04ee82899c2789c8f69</hash>
+            <hash alg="SHA-256">cc02c06e9e320869d7d1bd323df6dd4281e78ac2e7f8526835d3d48c69060683</hash>
+            <hash alg="SHA-256">d3caa09e613ece43ac292fbed513a4bce170681a447d25ffcbc1b647d45a39c5</hash>
+            <hash alg="SHA-256">d82411dbf4d3127b6cde7da0f9373e37ad3a43e89ef374965465928f01c2b979</hash>
+            <hash alg="SHA-256">dbcb2dc07308453db428a95a4d03259bd8caea97d7f0776842299f2d00c72fc8</hash>
+            <hash alg="SHA-256">dd4fda67f5faaef4f9ee5383435048ee3e11ad996901225ad7615bc92245bc8e</hash>
+            <hash alg="SHA-256">ddd92e18b783aeb86ad2132d84a4b795fc5ec612e3545c1b687e7747e66e2b53</hash>
+            <hash alg="SHA-256">de362ac8bc962408ad8fae28f3967ce1a262b5d63ab8cefb42662566737f1dc7</hash>
+            <hash alg="SHA-256">e214025e23db238805a600f1f37bf9f9a15413c7bf5f9d6ae194f84980c78722</hash>
+            <hash alg="SHA-256">e8f9f93a23634cfafbad6e46ad7d09e0f4a25a2400e4a64b1b7b7c0fbaa06d9d</hash>
+            <hash alg="SHA-256">e96a1788f24d03e8d61679f9881a883ecdf9c445a38f9ae3f3f193ab6c591c66</hash>
+            <hash alg="SHA-256">ec53a09aee61d45e7dbe7e91252ff0491b6b5fee3d85b2d45b173d8ab453efc1</hash>
+            <hash alg="SHA-256">f10250bb190fb0742e3e1958dd5c100524c2cc5096c67c8da51233f7448dc137</hash>
+            <hash alg="SHA-256">f1faee2a831fe249e1bae9cbc68d3cd8a30f7e37851deee4d7962b17c410dd56</hash>
+            <hash alg="SHA-256">f610d980e3fccf4394ab3806de6065682982f3d27c12d4ce3ee46a8183d64a6a</hash>
+            <hash alg="SHA-256">f6c35b2f87c004270fa2e703b872fcc984d714d430b305145c39d53074e1ffe0</hash>
+            <hash alg="SHA-256">f836f39678cb47c9541f04d8ed4545719dc31ad850bf1832d6b4171e30d65d23</hash>
+            <hash alg="SHA-256">f99768232f036b4776ce419d3244a04fe83784bce871b16d2c2e984c7fcea847</hash>
+            <hash alg="SHA-256">fd814847901df6e8de13ce69b84c31fc9b3fb591224d6762d0b256d510cbf382</hash>
+            <hash alg="SHA-256">fdb325b7fba1e2c40b9b1db407f85642e32404131c08480dd652110fc908561b</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="packageurl-python==0.13.4">
+      <name>packageurl-python</name>
+      <version>0.13.4</version>
+      <purl>pkg:pypi/packageurl-python@0.13.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/packageurl-python/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">62aa13d60a0082ff115784fefdfe73a12f310e455365cca7c6d362161067f35f</hash>
+            <hash alg="SHA-256">6eb5e995009cc73387095e0b507ab65df51357d25ddc5fce3d3545ad6dcbbee8</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="py-serializable==0.15.0">
+      <name>py-serializable</name>
+      <version>0.15.0</version>
+      <purl>pkg:pypi/py-serializable@0.15.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-serializable/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">8fc41457d8ee5f5c5a12f41fd87bf1a4f2ecf9da39fee92059b728e78f320771</hash>
+            <hash alg="SHA-256">d3f1201b33420c481aa83f7860c7bf2c2f036ba3ea82b6e15a96696457c36cd2</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil==2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="referencing==0.33.0">
+      <name>referencing</name>
+      <version>0.33.0</version>
+      <purl>pkg:pypi/referencing@0.33.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">39240f2ecc770258f28b642dd47fd74bc8b02484de54e1882b74b35ebd779bd5</hash>
+            <hash alg="SHA-256">c775fedf74bc0f9189c2a3be1c12fd03e8c23f4d371dce795df44e06c5b412f7</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rfc3339-validator==0.1.4">
+      <name>rfc3339-validator</name>
+      <version>0.1.4</version>
+      <purl>pkg:pypi/rfc3339-validator@0.1.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3339-validator/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b</hash>
+            <hash alg="SHA-256">24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rfc3987==1.3.8">
+      <name>rfc3987</name>
+      <version>1.3.8</version>
+      <purl>pkg:pypi/rfc3987@1.3.8</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3987/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53</hash>
+            <hash alg="SHA-256">d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rpds-py==0.17.1">
+      <name>rpds-py</name>
+      <version>0.17.1</version>
+      <purl>pkg:pypi/rpds-py@0.17.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">01f58a7306b64e0a4fe042047dd2b7d411ee82e54240284bab63e325762c1147</hash>
+            <hash alg="SHA-256">0210b2668f24c078307260bf88bdac9d6f1093635df5123789bfee4d8d7fc8e7</hash>
+            <hash alg="SHA-256">02866e060219514940342a1f84303a1ef7a1dad0ac311792fbbe19b521b489d2</hash>
+            <hash alg="SHA-256">0387ce69ba06e43df54e43968090f3626e231e4bc9150e4c3246947567695f68</hash>
+            <hash alg="SHA-256">060f412230d5f19fc8c8b75f315931b408d8ebf56aec33ef4168d1b9e54200b1</hash>
+            <hash alg="SHA-256">071bc28c589b86bc6351a339114fb7a029f5cddbaca34103aa573eba7b482382</hash>
+            <hash alg="SHA-256">0bfb09bf41fe7c51413f563373e5f537eaa653d7adc4830399d4e9bdc199959d</hash>
+            <hash alg="SHA-256">10162fe3f5f47c37ebf6d8ff5a2368508fe22007e3077bf25b9c7d803454d921</hash>
+            <hash alg="SHA-256">149c5cd24f729e3567b56e1795f74577aa3126c14c11e457bec1b1c90d212e38</hash>
+            <hash alg="SHA-256">1701fc54460ae2e5efc1dd6350eafd7a760f516df8dbe51d4a1c79d69472fbd4</hash>
+            <hash alg="SHA-256">1957a2ab607f9added64478a6982742eb29f109d89d065fa44e01691a20fc20a</hash>
+            <hash alg="SHA-256">1a746a6d49665058a5896000e8d9d2f1a6acba8a03b389c1e4c06e11e0b7f40d</hash>
+            <hash alg="SHA-256">1bfcad3109c1e5ba3cbe2f421614e70439f72897515a96c462ea657261b96518</hash>
+            <hash alg="SHA-256">1d36b2b59e8cc6e576f8f7b671e32f2ff43153f0ad6d0201250a7c07f25d570e</hash>
+            <hash alg="SHA-256">1db228102ab9d1ff4c64148c96320d0be7044fa28bd865a9ce628ce98da5973d</hash>
+            <hash alg="SHA-256">1dc29db3900cb1bb40353772417800f29c3d078dbc8024fd64655a04ee3c4bdf</hash>
+            <hash alg="SHA-256">1e626b365293a2142a62b9a614e1f8e331b28f3ca57b9f05ebbf4cf2a0f0bdc5</hash>
+            <hash alg="SHA-256">1f3c3461ebb4c4f1bbc70b15d20b565759f97a5aaf13af811fcefc892e9197ba</hash>
+            <hash alg="SHA-256">20de7b7179e2031a04042e85dc463a93a82bc177eeba5ddd13ff746325558aa6</hash>
+            <hash alg="SHA-256">24e4900a6643f87058a27320f81336d527ccfe503984528edde4bb660c8c8d59</hash>
+            <hash alg="SHA-256">2528ff96d09f12e638695f3a2e0c609c7b84c6df7c5ae9bfeb9252b6fa686253</hash>
+            <hash alg="SHA-256">25f071737dae674ca8937a73d0f43f5a52e92c2d178330b4c0bb6ab05586ffa6</hash>
+            <hash alg="SHA-256">270987bc22e7e5a962b1094953ae901395e8c1e1e83ad016c5cfcfff75a15a3f</hash>
+            <hash alg="SHA-256">292f7344a3301802e7c25c53792fae7d1593cb0e50964e7bcdcc5cf533d634e3</hash>
+            <hash alg="SHA-256">2953937f83820376b5979318840f3ee47477d94c17b940fe31d9458d79ae7eea</hash>
+            <hash alg="SHA-256">2a792b2e1d3038daa83fa474d559acfd6dc1e3650ee93b2662ddc17dbff20ad1</hash>
+            <hash alg="SHA-256">2a7b2f2f56a16a6d62e55354dd329d929560442bd92e87397b7a9586a32e3e76</hash>
+            <hash alg="SHA-256">2f4eb548daf4836e3b2c662033bfbfc551db58d30fd8fe660314f86bf8510b93</hash>
+            <hash alg="SHA-256">3664d126d3388a887db44c2e293f87d500c4184ec43d5d14d2d2babdb4c64cad</hash>
+            <hash alg="SHA-256">3677fcca7fb728c86a78660c7fb1b07b69b281964673f486ae72860e13f512ad</hash>
+            <hash alg="SHA-256">380e0df2e9d5d5d339803cfc6d183a5442ad7ab3c63c2a0982e8c824566c5ccc</hash>
+            <hash alg="SHA-256">3ac732390d529d8469b831949c78085b034bff67f584559340008d0f6041a049</hash>
+            <hash alg="SHA-256">4128980a14ed805e1b91a7ed551250282a8ddf8201a4e9f8f5b7e6225f54170d</hash>
+            <hash alg="SHA-256">4341bd7579611cf50e7b20bb8c2e23512a3dc79de987a1f411cb458ab670eb90</hash>
+            <hash alg="SHA-256">436474f17733c7dca0fbf096d36ae65277e8645039df12a0fa52445ca494729d</hash>
+            <hash alg="SHA-256">4dc889a9d8a34758d0fcc9ac86adb97bab3fb7f0c4d29794357eb147536483fd</hash>
+            <hash alg="SHA-256">4e21b76075c01d65d0f0f34302b5a7457d95721d5e0667aea65e5bb3ab415c25</hash>
+            <hash alg="SHA-256">516fb8c77805159e97a689e2f1c80655c7658f5af601c34ffdb916605598cda2</hash>
+            <hash alg="SHA-256">5576ee2f3a309d2bb403ec292d5958ce03953b0e57a11d224c1f134feaf8c40f</hash>
+            <hash alg="SHA-256">5a024fa96d541fd7edaa0e9d904601c6445e95a729a2900c5aec6555fe921ed6</hash>
+            <hash alg="SHA-256">5d0e8a6434a3fbf77d11448c9c25b2f25244226cfbec1a5159947cac5b8c5fa4</hash>
+            <hash alg="SHA-256">5e7d63ec01fe7c76c2dbb7e972fece45acbb8836e72682bde138e7e039906e2c</hash>
+            <hash alg="SHA-256">60e820ee1004327609b28db8307acc27f5f2e9a0b185b2064c5f23e815f248f8</hash>
+            <hash alg="SHA-256">637b802f3f069a64436d432117a7e58fab414b4e27a7e81049817ae94de45d8d</hash>
+            <hash alg="SHA-256">65dcf105c1943cba45d19207ef51b8bc46d232a381e94dd38719d52d3980015b</hash>
+            <hash alg="SHA-256">698ea95a60c8b16b58be9d854c9f993c639f5c214cf9ba782eca53a8789d6b19</hash>
+            <hash alg="SHA-256">70fcc6c2906cfa5c6a552ba7ae2ce64b6c32f437d8f3f8eea49925b278a61453</hash>
+            <hash alg="SHA-256">720215373a280f78a1814becb1312d4e4d1077b1202a56d2b0815e95ccb99ce9</hash>
+            <hash alg="SHA-256">7450dbd659fed6dd41d1a7d47ed767e893ba402af8ae664c157c255ec6067fde</hash>
+            <hash alg="SHA-256">7b7d9ca34542099b4e185b3c2a2b2eda2e318a7dbde0b0d83357a6d4421b5296</hash>
+            <hash alg="SHA-256">7fbd70cb8b54fe745301921b0816c08b6d917593429dfc437fd024b5ba713c58</hash>
+            <hash alg="SHA-256">81038ff87a4e04c22e1d81f947c6ac46f122e0c80460b9006e6517c4d842a6ec</hash>
+            <hash alg="SHA-256">810685321f4a304b2b55577c915bece4c4a06dfe38f6e62d9cc1d6ca8ee86b99</hash>
+            <hash alg="SHA-256">82ada4a8ed9e82e443fcef87e22a3eed3654dd3adf6e3b3a0deb70f03e86142a</hash>
+            <hash alg="SHA-256">841320e1841bb53fada91c9725e766bb25009cfd4144e92298db296fb6c894fb</hash>
+            <hash alg="SHA-256">8587fd64c2a91c33cdc39d0cebdaf30e79491cc029a37fcd458ba863f8815383</hash>
+            <hash alg="SHA-256">8ffe53e1d8ef2520ebcf0c9fec15bb721da59e8ef283b6ff3079613b1e30513d</hash>
+            <hash alg="SHA-256">9051e3d2af8f55b42061603e29e744724cb5f65b128a491446cc029b3e2ea896</hash>
+            <hash alg="SHA-256">91e5a8200e65aaac342a791272c564dffcf1281abd635d304d6c4e6b495f29dc</hash>
+            <hash alg="SHA-256">93432e747fb07fa567ad9cc7aaadd6e29710e515aabf939dfbed8046041346c6</hash>
+            <hash alg="SHA-256">938eab7323a736533f015e6069a7d53ef2dcc841e4e533b782c2bfb9fb12d84b</hash>
+            <hash alg="SHA-256">9584f8f52010295a4a417221861df9bea4c72d9632562b6e59b3c7b87a1522b7</hash>
+            <hash alg="SHA-256">9737bdaa0ad33d34c0efc718741abaafce62fadae72c8b251df9b0c823c63b22</hash>
+            <hash alg="SHA-256">99da0a4686ada4ed0f778120a0ea8d066de1a0a92ab0d13ae68492a437db78bf</hash>
+            <hash alg="SHA-256">99f567dae93e10be2daaa896e07513dd4bf9c2ecf0576e0533ac36ba3b1d5394</hash>
+            <hash alg="SHA-256">9bdf1303df671179eaf2cb41e8515a07fc78d9d00f111eadbe3e14262f59c3d0</hash>
+            <hash alg="SHA-256">9f0e4dc0f17dcea4ab9d13ac5c666b6b5337042b4d8f27e01b70fae41dd65c57</hash>
+            <hash alg="SHA-256">a000133a90eea274a6f28adc3084643263b1e7c1a5a66eb0a0a7a36aa757ed74</hash>
+            <hash alg="SHA-256">a3264e3e858de4fc601741498215835ff324ff2482fd4e4af61b46512dd7fc83</hash>
+            <hash alg="SHA-256">a71169d505af63bb4d20d23a8fbd4c6ce272e7bce6cc31f617152aa784436f29</hash>
+            <hash alg="SHA-256">a967dd6afda7715d911c25a6ba1517975acd8d1092b2f326718725461a3d33f9</hash>
+            <hash alg="SHA-256">aa5bfb13f1e89151ade0eb812f7b0d7a4d643406caaad65ce1cbabe0a66d695f</hash>
+            <hash alg="SHA-256">ae35e8e6801c5ab071b992cb2da958eee76340e6926ec693b5ff7d6381441745</hash>
+            <hash alg="SHA-256">b686f25377f9c006acbac63f61614416a6317133ab7fafe5de5f7dc8a06d42eb</hash>
+            <hash alg="SHA-256">b760a56e080a826c2e5af09002c1a037382ed21d03134eb6294812dda268c811</hash>
+            <hash alg="SHA-256">b86b21b348f7e5485fae740d845c65a880f5d1eda1e063bc59bef92d1f7d0c55</hash>
+            <hash alg="SHA-256">b9412abdf0ba70faa6e2ee6c0cc62a8defb772e78860cef419865917d86c7342</hash>
+            <hash alg="SHA-256">bd345a13ce06e94c753dab52f8e71e5252aec1e4f8022d24d56decd31e1b9b23</hash>
+            <hash alg="SHA-256">be22ae34d68544df293152b7e50895ba70d2a833ad9566932d750d3625918b82</hash>
+            <hash alg="SHA-256">bf046179d011e6114daf12a534d874958b039342b347348a78b7cdf0dd9d6041</hash>
+            <hash alg="SHA-256">c3d2010656999b63e628a3c694f23020322b4178c450dc478558a2b6ef3cb9bb</hash>
+            <hash alg="SHA-256">c64602e8be701c6cfe42064b71c84ce62ce66ddc6422c15463fd8127db3d8066</hash>
+            <hash alg="SHA-256">d65e6b4f1443048eb7e833c2accb4fa7ee67cc7d54f31b4f0555b474758bee55</hash>
+            <hash alg="SHA-256">d8bbd8e56f3ba25a7d0cf980fc42b34028848a53a0e36c9918550e0280b9d0b6</hash>
+            <hash alg="SHA-256">da1ead63368c04a9bded7904757dfcae01eba0e0f9bc41d3d7f57ebf1c04015a</hash>
+            <hash alg="SHA-256">dbbb95e6fc91ea3102505d111b327004d1c4ce98d56a4a02e82cd451f9f57140</hash>
+            <hash alg="SHA-256">dbc56680ecf585a384fbd93cd42bc82668b77cb525343170a2d86dafaed2a84b</hash>
+            <hash alg="SHA-256">df3b6f45ba4515632c5064e35ca7f31d51d13d1479673185ba8f9fefbbed58b9</hash>
+            <hash alg="SHA-256">dfe07308b311a8293a0d5ef4e61411c5c20f682db6b5e73de6c7c8824272c256</hash>
+            <hash alg="SHA-256">e796051f2070f47230c745d0a77a91088fbee2cc0502e9b796b9c6471983718c</hash>
+            <hash alg="SHA-256">efa767c220d94aa4ac3a6dd3aeb986e9f229eaf5bce92d8b1b3018d06bed3772</hash>
+            <hash alg="SHA-256">f0b8bf5b8db49d8fd40f54772a1dcf262e8be0ad2ab0206b5a2ec109c176c0a4</hash>
+            <hash alg="SHA-256">f175e95a197f6a4059b50757a3dca33b32b61691bdbd22c29e8a8d21d3914cae</hash>
+            <hash alg="SHA-256">f2f3b28b40fddcb6c1f1f6c88c6f3769cd933fa493ceb79da45968a21dccc920</hash>
+            <hash alg="SHA-256">f6c43b6f97209e370124baf2bf40bb1e8edc25311a158867eb1c3a5d449ebc7a</hash>
+            <hash alg="SHA-256">f7f4cb1f173385e8a39c29510dd11a78bf44e360fb75610594973f5ea141028b</hash>
+            <hash alg="SHA-256">fad059a4bd14c45776600d223ec194e77db6c20255578bb5bcdd7c18fd169361</hash>
+            <hash alg="SHA-256">ff1dcb8e8bc2261a088821b2595ef031c91d499a0c1b031c152d43fe0a6ecec8</hash>
+            <hash alg="SHA-256">ffee088ea9b593cc6160518ba9bd319b5475e5f3e578e4552d63818773c6f56a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six==1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="sortedcontainers==2.4.0">
+      <name>sortedcontainers</name>
+      <version>2.4.0</version>
+      <purl>pkg:pypi/sortedcontainers@2.4.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/sortedcontainers/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88</hash>
+            <hash alg="SHA-256">a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil==2.8.19.20240106">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.20240106</version>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.20240106</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1f8db221c3b98e6ca02ea83a58371b22c374f42ae5bbdf186db9c9a76581459f</hash>
+            <hash alg="SHA-256">efbbdc54590d0f16152fa103c9879c7d4a00e82078f6e2cf01769042165acaa2</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="uri-template==1.3.0">
+      <name>uri-template</name>
+      <version>1.3.0</version>
+      <purl>pkg:pypi/uri-template@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uri-template/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7</hash>
+            <hash alg="SHA-256">a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="webcolors==1.13">
+      <name>webcolors</name>
+      <version>1.13</version>
+      <purl>pkg:pypi/webcolors@1.13</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/webcolors/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf</hash>
+            <hash alg="SHA-256">c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow==1.3.0"/>
+    <dependency ref="attrs==23.2.0"/>
+    <dependency ref="boolean.py==4.0"/>
+    <dependency ref="cyclonedx-python-lib==5.1.1"/>
+    <dependency ref="defusedxml==0.7.1"/>
+    <dependency ref="fqdn==1.5.1"/>
+    <dependency ref="idna==3.6"/>
+    <dependency ref="isoduration==20.11.0"/>
+    <dependency ref="jsonpointer==2.4"/>
+    <dependency ref="jsonschema-specifications==2023.12.1"/>
+    <dependency ref="jsonschema==4.21.1"/>
+    <dependency ref="license-expression==30.2.0"/>
+    <dependency ref="lxml==4.9.4"/>
+    <dependency ref="packageurl-python==0.13.4"/>
+    <dependency ref="py-serializable==0.15.0"/>
+    <dependency ref="python-dateutil==2.8.2"/>
+    <dependency ref="referencing==0.33.0"/>
+    <dependency ref="rfc3339-validator==0.1.4"/>
+    <dependency ref="rfc3987==1.3.8"/>
+    <dependency ref="root-component"/>
+    <dependency ref="rpds-py==0.17.1"/>
+    <dependency ref="six==1.16.0"/>
+    <dependency ref="sortedcontainers==2.4.0"/>
+    <dependency ref="types-python-dateutil==2.8.19.20240106"/>
+    <dependency ref="uri-template==1.3.0"/>
+    <dependency ref="webcolors==1.13"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/plain_with-urls_1.6.json.bin
+++ b/tests/_data/snapshots/pipenv/plain_with-urls_1.6.json.bin
@@ -1,0 +1,575 @@
+{
+  "components": [
+    {
+      "bom-ref": "certifi==2023.11.17",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/"
+        }
+      ],
+      "name": "certifi",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/certifi@2023.11.17",
+      "type": "library",
+      "version": "2023.11.17"
+    },
+    {
+      "bom-ref": "charset-normalizer==3.3.2",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2127566c664442652f024c837091890cb1942c30937add288223dc895793f898"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/"
+        }
+      ],
+      "name": "charset-normalizer",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/charset-normalizer@3.3.2",
+      "type": "library",
+      "version": "3.3.2"
+    },
+    {
+      "bom-ref": "idna==3.6",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/"
+        }
+      ],
+      "name": "idna",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/idna@3.6",
+      "type": "library",
+      "version": "3.6"
+    },
+    {
+      "bom-ref": "pillow",
+      "externalReferences": [
+        {
+          "comment": "from git",
+          "type": "vcs",
+          "url": "git+https://github.com/python-pillow/Pillow.git#da59ad000d1405eaecd557175e29083a87d19f7c"
+        }
+      ],
+      "name": "pillow",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/pillow?vcs_url=git%2Bhttps://github.com/python-pillow/Pillow.git%40da59ad000d1405eaecd557175e29083a87d19f7c",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requests",
+      "externalReferences": [
+        {
+          "comment": "from git",
+          "type": "vcs",
+          "url": "git+https://github.com/requests/requests.git#96b22fa18c00831656ee4b286bf1c9062459b00a"
+        }
+      ],
+      "name": "requests",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%4096b22fa18c00831656ee4b286bf1c9062459b00a",
+      "type": "library"
+    },
+    {
+      "bom-ref": "six",
+      "externalReferences": [
+        {
+          "comment": "from git",
+          "type": "vcs",
+          "url": "git+ssh://git@github.com/benjaminp/six.git#65486e4383f9f411da95937451205d3c7b61b9e1"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/six?vcs_url=git%2Bssh://git%40github.com/benjaminp/six.git%4065486e4383f9f411da95937451205d3c7b61b9e1",
+      "type": "library"
+    },
+    {
+      "bom-ref": "urllib3",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "type": "distribution",
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
+        }
+      ],
+      "name": "urllib3",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "certifi==2023.11.17"
+    },
+    {
+      "ref": "charset-normalizer==3.3.2"
+    },
+    {
+      "ref": "idna==3.6"
+    },
+    {
+      "ref": "pillow"
+    },
+    {
+      "ref": "requests"
+    },
+    {
+      "ref": "root-component"
+    },
+    {
+      "ref": "six"
+    },
+    {
+      "ref": "urllib3"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "packages from direct urls",
+      "name": "with-urls",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/pipenv/plain_with-urls_1.6.xml.bin
+++ b/tests/_data/snapshots/pipenv/plain_with-urls_1.6.xml.bin
@@ -1,0 +1,258 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>with-urls</name>
+      <version>0.1.0</version>
+      <description>packages from direct urls</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="certifi==2023.11.17">
+      <name>certifi</name>
+      <version>2023.11.17</version>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</hash>
+            <hash alg="SHA-256">e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="charset-normalizer==3.3.2">
+      <name>charset-normalizer</name>
+      <version>3.3.2</version>
+      <purl>pkg:pypi/charset-normalizer@3.3.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027</hash>
+            <hash alg="SHA-256">06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087</hash>
+            <hash alg="SHA-256">0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786</hash>
+            <hash alg="SHA-256">0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8</hash>
+            <hash alg="SHA-256">10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09</hash>
+            <hash alg="SHA-256">122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185</hash>
+            <hash alg="SHA-256">1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574</hash>
+            <hash alg="SHA-256">1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e</hash>
+            <hash alg="SHA-256">1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519</hash>
+            <hash alg="SHA-256">2127566c664442652f024c837091890cb1942c30937add288223dc895793f898</hash>
+            <hash alg="SHA-256">22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269</hash>
+            <hash alg="SHA-256">25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3</hash>
+            <hash alg="SHA-256">2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f</hash>
+            <hash alg="SHA-256">3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6</hash>
+            <hash alg="SHA-256">34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8</hash>
+            <hash alg="SHA-256">37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a</hash>
+            <hash alg="SHA-256">3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73</hash>
+            <hash alg="SHA-256">3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc</hash>
+            <hash alg="SHA-256">42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714</hash>
+            <hash alg="SHA-256">45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2</hash>
+            <hash alg="SHA-256">4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc</hash>
+            <hash alg="SHA-256">4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce</hash>
+            <hash alg="SHA-256">4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d</hash>
+            <hash alg="SHA-256">549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e</hash>
+            <hash alg="SHA-256">55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6</hash>
+            <hash alg="SHA-256">572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269</hash>
+            <hash alg="SHA-256">573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96</hash>
+            <hash alg="SHA-256">5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d</hash>
+            <hash alg="SHA-256">6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a</hash>
+            <hash alg="SHA-256">65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4</hash>
+            <hash alg="SHA-256">663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77</hash>
+            <hash alg="SHA-256">6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d</hash>
+            <hash alg="SHA-256">68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0</hash>
+            <hash alg="SHA-256">6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed</hash>
+            <hash alg="SHA-256">6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068</hash>
+            <hash alg="SHA-256">6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac</hash>
+            <hash alg="SHA-256">6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25</hash>
+            <hash alg="SHA-256">753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8</hash>
+            <hash alg="SHA-256">7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab</hash>
+            <hash alg="SHA-256">7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26</hash>
+            <hash alg="SHA-256">7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2</hash>
+            <hash alg="SHA-256">802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db</hash>
+            <hash alg="SHA-256">80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f</hash>
+            <hash alg="SHA-256">8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5</hash>
+            <hash alg="SHA-256">86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99</hash>
+            <hash alg="SHA-256">87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c</hash>
+            <hash alg="SHA-256">8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d</hash>
+            <hash alg="SHA-256">8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811</hash>
+            <hash alg="SHA-256">8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa</hash>
+            <hash alg="SHA-256">8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a</hash>
+            <hash alg="SHA-256">9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03</hash>
+            <hash alg="SHA-256">90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b</hash>
+            <hash alg="SHA-256">923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04</hash>
+            <hash alg="SHA-256">95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c</hash>
+            <hash alg="SHA-256">96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001</hash>
+            <hash alg="SHA-256">9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458</hash>
+            <hash alg="SHA-256">a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389</hash>
+            <hash alg="SHA-256">a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99</hash>
+            <hash alg="SHA-256">a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985</hash>
+            <hash alg="SHA-256">a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537</hash>
+            <hash alg="SHA-256">ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238</hash>
+            <hash alg="SHA-256">aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f</hash>
+            <hash alg="SHA-256">b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d</hash>
+            <hash alg="SHA-256">b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796</hash>
+            <hash alg="SHA-256">b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a</hash>
+            <hash alg="SHA-256">b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143</hash>
+            <hash alg="SHA-256">bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8</hash>
+            <hash alg="SHA-256">beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c</hash>
+            <hash alg="SHA-256">c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5</hash>
+            <hash alg="SHA-256">c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5</hash>
+            <hash alg="SHA-256">c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711</hash>
+            <hash alg="SHA-256">c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4</hash>
+            <hash alg="SHA-256">cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6</hash>
+            <hash alg="SHA-256">d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c</hash>
+            <hash alg="SHA-256">d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7</hash>
+            <hash alg="SHA-256">db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4</hash>
+            <hash alg="SHA-256">ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b</hash>
+            <hash alg="SHA-256">deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae</hash>
+            <hash alg="SHA-256">e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12</hash>
+            <hash alg="SHA-256">e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c</hash>
+            <hash alg="SHA-256">e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae</hash>
+            <hash alg="SHA-256">eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8</hash>
+            <hash alg="SHA-256">eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887</hash>
+            <hash alg="SHA-256">eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b</hash>
+            <hash alg="SHA-256">efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4</hash>
+            <hash alg="SHA-256">f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f</hash>
+            <hash alg="SHA-256">f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5</hash>
+            <hash alg="SHA-256">fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33</hash>
+            <hash alg="SHA-256">fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519</hash>
+            <hash alg="SHA-256">ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="idna==3.6">
+      <name>idna</name>
+      <version>3.6</version>
+      <purl>pkg:pypi/idna@3.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca</hash>
+            <hash alg="SHA-256">c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pillow">
+      <name>pillow</name>
+      <purl>pkg:pypi/pillow?vcs_url=git%2Bhttps://github.com/python-pillow/Pillow.git%40da59ad000d1405eaecd557175e29083a87d19f7c</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/python-pillow/Pillow.git#da59ad000d1405eaecd557175e29083a87d19f7c</url>
+          <comment>from git</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="requests">
+      <name>requests</name>
+      <purl>pkg:pypi/requests?vcs_url=git%2Bhttps://github.com/requests/requests.git%4096b22fa18c00831656ee4b286bf1c9062459b00a</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/requests/requests.git#96b22fa18c00831656ee4b286bf1c9062459b00a</url>
+          <comment>from git</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six">
+      <name>six</name>
+      <purl>pkg:pypi/six?vcs_url=git%2Bssh://git%40github.com/benjaminp/six.git%4065486e4383f9f411da95937451205d3c7b61b9e1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+ssh://git@github.com/benjaminp/six.git#65486e4383f9f411da95937451205d3c7b61b9e1</url>
+          <comment>from git</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="urllib3">
+      <name>urllib3</name>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
+          <comment>from file</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="certifi==2023.11.17"/>
+    <dependency ref="charset-normalizer==3.3.2"/>
+    <dependency ref="idna==3.6"/>
+    <dependency ref="pillow"/>
+    <dependency ref="requests"/>
+    <dependency ref="root-component"/>
+    <dependency ref="six"/>
+    <dependency ref="urllib3"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/pypi-mirror_private-packages_1.6.json.bin
+++ b/tests/_data/snapshots/pipenv/pypi-mirror_private-packages_1.6.json.bin
@@ -1,0 +1,260 @@
+{
+  "components": [
+    {
+      "bom-ref": "numpy==1.26.2",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "06fa1ed84aa60ea6ef9f91ba57b5ed963c3729534e6e54055fc151fad0423f0a"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "174a8880739c16c925799c018f3f55b8130c1f7c8e75ab0a6fa9d41cab092fd6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1a13860fdcd95de7cf58bd6f8bc5a5ef81c0b0625eb2c9a783948847abbef2c2"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "1cc3d5029a30fb5f06704ad6b23b35e11309491c999838c31f124fee32107c79"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "22f8fc02fdbc829e7a8c578dd8d2e15a9074b630d4da29cda483337e300e3ee9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "26c9d33f8e8b846d5a65dd068c14e04018d05533b348d9eaeef6c1bd787f9919"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2b3fca8a5b00184828d12b073af4d0fc5fdd94b1632c2477526f6bd7842d700d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "2beef57fb031dcc0dc8fa4fe297a742027b954949cabb52a2a376c144e5e6060"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "36340109af8da8805d8851ef1d74761b3b88e81a9bd80b290bbfed61bd2b4f75"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3703fc9258a4a122d17043e57b35e5ef1c5a5837c3db8be396c82e04c1cf9b0f"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "3ced40d4e9e18242f70dd02d739e44698df3dcb010d31f495ff00a31ef6014fe"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4a06263321dfd3598cacb252f51e521a8cb4b6df471bb12a7ee5cbab20ea9167"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4eb8df4bf8d3d90d091e0146f6c28492b0be84da3e409ebef54349f71ed271ef"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "5d5244aabd6ed7f312268b9247be47343a654ebea52a60f002dc70c769048e75"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "64308ebc366a8ed63fd0bf426b6a9468060962f1a4339ab1074c228fa6ade8e3"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "6a3cdb4d9c70e6b8c0814239ead47da00934666f668426fc6e94cce869e13fd7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "854ab91a2906ef29dc3925a064fcd365c7b4da743f84b123002f6139bcb3f8a7"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "94cc3c222bb9fb5a12e334d0479b97bb2df446fbe622b470928f5284ffca3f8d"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "96ca5482c3dbdd051bcd1fce8034603d6ebfc125a7bd59f55b40d8f5d246832b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a2bbc29fcb1771cd7b7425f98b05307776a6baf43035d3b80c4b0f29e9545186"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a4cd6ed4a339c21f1d1b0fdf13426cb3b284555c27ac2f156dfdaaa7e16bfab0"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "aa18428111fb9a591d7a9cc1b48150097ba6a7e8299fb56bdf574df650e7d1f1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "aa317b2325f7aa0a9471663e6093c210cb2ae9c0ad824732b307d2c51983d5b6"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b04f5dc6b3efdaab541f7857351aac359e6ae3c126e2edb376929bd3b7f92d7e"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b272d4cecc32c9e19911891446b72e986157e6a1809b7b56518b4f3755267523"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b361d369fc7e5e1714cf827b731ca32bff8d411212fccd29ad98ad622449cc36"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b96e7b9c624ef3ae2ae0e04fa9b460f6b9f17ad8b4bec6d7756510f1f6c0c841"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "baf8aab04a2c0e859da118f0b38617e5ee65d75b83795055fb66c0d5e9e9b818"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bcc008217145b3d77abd3e4d5ef586e3bdfba8fe17940769f8aa09b99e856c00"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "bd3f0091e845164a20bd5a326860c840fe2af79fa12e0469a12768a3ec578d80"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "cc392fdcbd21d4be6ae1bb4475a03ce3b025cd49a9be5345d76d7585aea69440"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d73a3abcac238250091b11caef9ad12413dab01669511779bc9b29261dd50210"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f43740ab089277d403aa07567be138fc2a89d4d9892d113b76153e0e412409f8"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f79b231bf5c16b1f39c7f4875e1ded36abee1591e98742b05d8a0fb55d8a3eec"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "fe6b44fb8fcdf7eda4ef4461b97b3f63c466b27ab151bec2366db8b197387841"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypy-mirror.testing.acme.org/simple/numpy/"
+        }
+      ],
+      "name": "numpy",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/numpy@1.26.2?repository_url=https://pypy-mirror.testing.acme.org/simple",
+      "type": "library",
+      "version": "1.26.2"
+    },
+    {
+      "bom-ref": "six",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/six?download_url=https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl",
+      "type": "library"
+    },
+    {
+      "bom-ref": "toml==0.10.2",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pysrc1.acme.org",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/toml/"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "numpy==1.26.2"
+    },
+    {
+      "ref": "six"
+    },
+    {
+      "ref": "toml==0.10.2"
+    }
+  ],
+  "metadata": {
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/pipenv/pypi-mirror_private-packages_1.6.xml.bin
+++ b/tests/_data/snapshots/pipenv/pypi-mirror_private-packages_1.6.xml.bin
@@ -1,0 +1,141 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="numpy==1.26.2">
+      <name>numpy</name>
+      <version>1.26.2</version>
+      <purl>pkg:pypi/numpy@1.26.2?repository_url=https://pypy-mirror.testing.acme.org/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypy-mirror.testing.acme.org/simple/numpy/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">06fa1ed84aa60ea6ef9f91ba57b5ed963c3729534e6e54055fc151fad0423f0a</hash>
+            <hash alg="SHA-256">174a8880739c16c925799c018f3f55b8130c1f7c8e75ab0a6fa9d41cab092fd6</hash>
+            <hash alg="SHA-256">1a13860fdcd95de7cf58bd6f8bc5a5ef81c0b0625eb2c9a783948847abbef2c2</hash>
+            <hash alg="SHA-256">1cc3d5029a30fb5f06704ad6b23b35e11309491c999838c31f124fee32107c79</hash>
+            <hash alg="SHA-256">22f8fc02fdbc829e7a8c578dd8d2e15a9074b630d4da29cda483337e300e3ee9</hash>
+            <hash alg="SHA-256">26c9d33f8e8b846d5a65dd068c14e04018d05533b348d9eaeef6c1bd787f9919</hash>
+            <hash alg="SHA-256">2b3fca8a5b00184828d12b073af4d0fc5fdd94b1632c2477526f6bd7842d700d</hash>
+            <hash alg="SHA-256">2beef57fb031dcc0dc8fa4fe297a742027b954949cabb52a2a376c144e5e6060</hash>
+            <hash alg="SHA-256">36340109af8da8805d8851ef1d74761b3b88e81a9bd80b290bbfed61bd2b4f75</hash>
+            <hash alg="SHA-256">3703fc9258a4a122d17043e57b35e5ef1c5a5837c3db8be396c82e04c1cf9b0f</hash>
+            <hash alg="SHA-256">3ced40d4e9e18242f70dd02d739e44698df3dcb010d31f495ff00a31ef6014fe</hash>
+            <hash alg="SHA-256">4a06263321dfd3598cacb252f51e521a8cb4b6df471bb12a7ee5cbab20ea9167</hash>
+            <hash alg="SHA-256">4eb8df4bf8d3d90d091e0146f6c28492b0be84da3e409ebef54349f71ed271ef</hash>
+            <hash alg="SHA-256">5d5244aabd6ed7f312268b9247be47343a654ebea52a60f002dc70c769048e75</hash>
+            <hash alg="SHA-256">64308ebc366a8ed63fd0bf426b6a9468060962f1a4339ab1074c228fa6ade8e3</hash>
+            <hash alg="SHA-256">6a3cdb4d9c70e6b8c0814239ead47da00934666f668426fc6e94cce869e13fd7</hash>
+            <hash alg="SHA-256">854ab91a2906ef29dc3925a064fcd365c7b4da743f84b123002f6139bcb3f8a7</hash>
+            <hash alg="SHA-256">94cc3c222bb9fb5a12e334d0479b97bb2df446fbe622b470928f5284ffca3f8d</hash>
+            <hash alg="SHA-256">96ca5482c3dbdd051bcd1fce8034603d6ebfc125a7bd59f55b40d8f5d246832b</hash>
+            <hash alg="SHA-256">a2bbc29fcb1771cd7b7425f98b05307776a6baf43035d3b80c4b0f29e9545186</hash>
+            <hash alg="SHA-256">a4cd6ed4a339c21f1d1b0fdf13426cb3b284555c27ac2f156dfdaaa7e16bfab0</hash>
+            <hash alg="SHA-256">aa18428111fb9a591d7a9cc1b48150097ba6a7e8299fb56bdf574df650e7d1f1</hash>
+            <hash alg="SHA-256">aa317b2325f7aa0a9471663e6093c210cb2ae9c0ad824732b307d2c51983d5b6</hash>
+            <hash alg="SHA-256">b04f5dc6b3efdaab541f7857351aac359e6ae3c126e2edb376929bd3b7f92d7e</hash>
+            <hash alg="SHA-256">b272d4cecc32c9e19911891446b72e986157e6a1809b7b56518b4f3755267523</hash>
+            <hash alg="SHA-256">b361d369fc7e5e1714cf827b731ca32bff8d411212fccd29ad98ad622449cc36</hash>
+            <hash alg="SHA-256">b96e7b9c624ef3ae2ae0e04fa9b460f6b9f17ad8b4bec6d7756510f1f6c0c841</hash>
+            <hash alg="SHA-256">baf8aab04a2c0e859da118f0b38617e5ee65d75b83795055fb66c0d5e9e9b818</hash>
+            <hash alg="SHA-256">bcc008217145b3d77abd3e4d5ef586e3bdfba8fe17940769f8aa09b99e856c00</hash>
+            <hash alg="SHA-256">bd3f0091e845164a20bd5a326860c840fe2af79fa12e0469a12768a3ec578d80</hash>
+            <hash alg="SHA-256">cc392fdcbd21d4be6ae1bb4475a03ce3b025cd49a9be5345d76d7585aea69440</hash>
+            <hash alg="SHA-256">d73a3abcac238250091b11caef9ad12413dab01669511779bc9b29261dd50210</hash>
+            <hash alg="SHA-256">f43740ab089277d403aa07567be138fc2a89d4d9892d113b76153e0e412409f8</hash>
+            <hash alg="SHA-256">f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea</hash>
+            <hash alg="SHA-256">f79b231bf5c16b1f39c7f4875e1ded36abee1591e98742b05d8a0fb55d8a3eec</hash>
+            <hash alg="SHA-256">fe6b44fb8fcdf7eda4ef4461b97b3f63c466b27ab151bec2366db8b197387841</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six">
+      <name>six</name>
+      <purl>pkg:pypi/six?download_url=https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml==0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <purl>pkg:pypi/toml@0.10.2?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/toml/</url>
+          <comment>from explicit index: pysrc1.acme.org</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="numpy==1.26.2"/>
+    <dependency ref="six"/>
+    <dependency ref="toml==0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/some-categories_category-deps_1.6.json.bin
+++ b/tests/_data/snapshots/pipenv/some-categories_category-deps_1.6.json.bin
@@ -1,0 +1,294 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow==1.3.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "colorama==0.4.6",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "categoryB"
+        },
+        {
+          "name": "cdx:pipenv:category",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "ddt==1.7.0",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a0719acde99dd32767cff64e653ef99c01ad5b042ff265f2ebecd28796ffd114"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d178d115abf25a1b8327e94f85a03ef09b1d7b0ca256f6203284b024f2fc70df"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ddt/"
+        }
+      ],
+      "name": "ddt",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "develop"
+        }
+      ],
+      "purl": "pkg:pypi/ddt@1.7.0",
+      "type": "library",
+      "version": "1.7.0"
+    },
+    {
+      "bom-ref": "isoduration==20.11.0",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil==2.8.2",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six==1.16.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml==0.10.2",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil==2.8.19.14",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "arrow==1.3.0"
+    },
+    {
+      "ref": "colorama==0.4.6"
+    },
+    {
+      "ref": "ddt==1.7.0"
+    },
+    {
+      "ref": "isoduration==20.11.0"
+    },
+    {
+      "ref": "python-dateutil==2.8.2"
+    },
+    {
+      "ref": "six==1.16.0"
+    },
+    {
+      "ref": "toml==0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil==2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/pipenv/some-categories_category-deps_1.6.xml.bin
+++ b/tests/_data/snapshots/pipenv/some-categories_category-deps_1.6.xml.bin
@@ -1,0 +1,204 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow==1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorama==0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">categoryB</property>
+        <property name="cdx:pipenv:category">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="ddt==1.7.0">
+      <name>ddt</name>
+      <version>1.7.0</version>
+      <purl>pkg:pypi/ddt@1.7.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ddt/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">a0719acde99dd32767cff64e653ef99c01ad5b042ff265f2ebecd28796ffd114</hash>
+            <hash alg="SHA-256">d178d115abf25a1b8327e94f85a03ef09b1d7b0ca256f6203284b024f2fc70df</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">develop</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration==20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil==2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six==1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml==0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil==2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">groupA</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow==1.3.0"/>
+    <dependency ref="colorama==0.4.6"/>
+    <dependency ref="ddt==1.7.0"/>
+    <dependency ref="isoduration==20.11.0"/>
+    <dependency ref="python-dateutil==2.8.2"/>
+    <dependency ref="six==1.16.0"/>
+    <dependency ref="toml==0.10.2"/>
+    <dependency ref="types-python-dateutil==2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/pipenv/with-dev_default-and-dev_1.6.json.bin
+++ b/tests/_data/snapshots/pipenv/with-dev_default-and-dev_1.6.json.bin
@@ -1,0 +1,257 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow==1.3.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "develop"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "colorama==0.4.6",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "isoduration==20.11.0",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "develop"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil==2.8.2",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "develop"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six==1.16.0",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "develop"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml==0.10.2",
+      "externalReferences": [
+        {
+          "comment": "from explicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "default"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil==2.8.19.14",
+      "externalReferences": [
+        {
+          "comment": "from implicit index: pypi",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:pipenv:category",
+          "value": "develop"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "arrow==1.3.0"
+    },
+    {
+      "ref": "colorama==0.4.6"
+    },
+    {
+      "ref": "isoduration==20.11.0"
+    },
+    {
+      "ref": "python-dateutil==2.8.2"
+    },
+    {
+      "ref": "six==1.16.0"
+    },
+    {
+      "ref": "toml==0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil==2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/pipenv/with-dev_default-and-dev_1.6.xml.bin
+++ b/tests/_data/snapshots/pipenv/with-dev_default-and-dev_1.6.xml.bin
@@ -1,0 +1,184 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow==1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">develop</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorama==0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration==20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">develop</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil==2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">develop</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six==1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">develop</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml==0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/</url>
+          <comment>from explicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">default</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil==2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/</url>
+          <comment>from implicit index: pypi</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:pipenv:category">develop</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow==1.3.0"/>
+    <dependency ref="colorama==0.4.6"/>
+    <dependency ref="isoduration==20.11.0"/>
+    <dependency ref="python-dateutil==2.8.2"/>
+    <dependency ref="six==1.16.0"/>
+    <dependency ref="toml==0.10.2"/>
+    <dependency ref="types-python-dateutil==2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/all-extras_with-extras_lock10_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/all-extras_with-extras_lock10_1.6.json.bin
@@ -1,0 +1,191 @@
+{
+  "components": [
+    {
+      "bom-ref": "boolean.py@4.0",
+      "description": "Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.",
+      "name": "boolean.py",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/boolean.py@4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.0"
+    },
+    {
+      "bom-ref": "cyclonedx-python-lib@5.1.1",
+      "description": "Python library for CycloneDX",
+      "name": "cyclonedx-python-lib",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "json-validation"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "xml-validation"
+        }
+      ],
+      "purl": "pkg:pypi/cyclonedx-python-lib@5.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "5.1.1"
+    },
+    {
+      "bom-ref": "defusedxml@0.7.1",
+      "description": "XML bomb protection for Python stdlib modules",
+      "name": "defusedxml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/defusedxml@0.7.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.7.1"
+    },
+    {
+      "bom-ref": "license-expression@30.1.1",
+      "description": "license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.",
+      "name": "license-expression",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/license-expression@30.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "30.1.1"
+    },
+    {
+      "bom-ref": "packageurl-python@0.11.2",
+      "description": "A purl aka. Package URL parser and builder",
+      "name": "packageurl-python",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/packageurl-python@0.11.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.11.2"
+    },
+    {
+      "bom-ref": "py-serializable@0.15.0",
+      "description": "Library for serializing and deserializing Python Objects to and from JSON and XML.",
+      "name": "py-serializable",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/py-serializable@0.15.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.15.0"
+    },
+    {
+      "bom-ref": "sortedcontainers@2.4.0",
+      "description": "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set",
+      "name": "sortedcontainers",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/sortedcontainers@2.4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.4.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "boolean.py@4.0"
+    },
+    {
+      "dependsOn": [
+        "license-expression@30.1.1",
+        "packageurl-python@0.11.2",
+        "py-serializable@0.15.0",
+        "sortedcontainers@2.4.0"
+      ],
+      "ref": "cyclonedx-python-lib@5.1.1"
+    },
+    {
+      "ref": "defusedxml@0.7.1"
+    },
+    {
+      "dependsOn": [
+        "boolean.py@4.0"
+      ],
+      "ref": "license-expression@30.1.1"
+    },
+    {
+      "ref": "packageurl-python@0.11.2"
+    },
+    {
+      "dependsOn": [
+        "defusedxml@0.7.1"
+      ],
+      "ref": "py-serializable@0.15.0"
+    },
+    {
+      "ref": "sortedcontainers@2.4.0"
+    },
+    {
+      "dependsOn": [
+        "cyclonedx-python-lib@5.1.1"
+      ],
+      "ref": "with-extras"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "with-extras",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "properties": [
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "my-extra"
+        }
+      ],
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/all-extras_with-extras_lock10_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/all-extras_with-extras_lock10_1.6.xml.bin
@@ -1,0 +1,150 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-extras">
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+      <properties>
+        <property name="cdx:python:package:required-extra">my-extra</property>
+      </properties>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="boolean.py@4.0">
+      <name>boolean.py</name>
+      <version>4.0</version>
+      <description>Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/boolean.py@4.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="cyclonedx-python-lib@5.1.1">
+      <name>cyclonedx-python-lib</name>
+      <version>5.1.1</version>
+      <description>Python library for CycloneDX</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/cyclonedx-python-lib@5.1.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:required-extra">json-validation</property>
+        <property name="cdx:python:package:required-extra">xml-validation</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="defusedxml@0.7.1">
+      <name>defusedxml</name>
+      <version>0.7.1</version>
+      <description>XML bomb protection for Python stdlib modules</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/defusedxml@0.7.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="license-expression@30.1.1">
+      <name>license-expression</name>
+      <version>30.1.1</version>
+      <description>license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/license-expression@30.1.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="packageurl-python@0.11.2">
+      <name>packageurl-python</name>
+      <version>0.11.2</version>
+      <description>A purl aka. Package URL parser and builder</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/packageurl-python@0.11.2</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="py-serializable@0.15.0">
+      <name>py-serializable</name>
+      <version>0.15.0</version>
+      <description>Library for serializing and deserializing Python Objects to and from JSON and XML.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/py-serializable@0.15.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="sortedcontainers@2.4.0">
+      <name>sortedcontainers</name>
+      <version>2.4.0</version>
+      <description>Sorted Containers -- Sorted List, Sorted Dict, Sorted Set</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/sortedcontainers@2.4.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="boolean.py@4.0"/>
+    <dependency ref="cyclonedx-python-lib@5.1.1">
+      <dependency ref="license-expression@30.1.1"/>
+      <dependency ref="packageurl-python@0.11.2"/>
+      <dependency ref="py-serializable@0.15.0"/>
+      <dependency ref="sortedcontainers@2.4.0"/>
+    </dependency>
+    <dependency ref="defusedxml@0.7.1"/>
+    <dependency ref="license-expression@30.1.1">
+      <dependency ref="boolean.py@4.0"/>
+    </dependency>
+    <dependency ref="packageurl-python@0.11.2"/>
+    <dependency ref="py-serializable@0.15.0">
+      <dependency ref="defusedxml@0.7.1"/>
+    </dependency>
+    <dependency ref="sortedcontainers@2.4.0"/>
+    <dependency ref="with-extras">
+      <dependency ref="cyclonedx-python-lib@5.1.1"/>
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/all-extras_with-extras_lock11_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/all-extras_with-extras_lock11_1.6.json.bin
@@ -1,0 +1,2138 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "attrs@23.1.0",
+      "description": "Classes Without Boilerplate",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/#attrs-23.1.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/#attrs-23.1.0.tar.gz"
+        }
+      ],
+      "name": "attrs",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/attrs@23.1.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "23.1.0"
+    },
+    {
+      "bom-ref": "boolean.py@4.0",
+      "description": "Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.",
+      "name": "boolean.py",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/boolean.py@4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.0"
+    },
+    {
+      "bom-ref": "cyclonedx-python-lib@5.1.1",
+      "description": "Python library for CycloneDX",
+      "name": "cyclonedx-python-lib",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "json-validation"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "xml-validation"
+        }
+      ],
+      "purl": "pkg:pypi/cyclonedx-python-lib@5.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "5.1.1"
+    },
+    {
+      "bom-ref": "defusedxml@0.7.1",
+      "description": "XML bomb protection for Python stdlib modules",
+      "name": "defusedxml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/defusedxml@0.7.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.7.1"
+    },
+    {
+      "bom-ref": "fqdn@1.5.1",
+      "description": "Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fqdn/#fqdn-1.5.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fqdn/#fqdn-1.5.1.tar.gz"
+        }
+      ],
+      "name": "fqdn",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/fqdn@1.5.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.5.1"
+    },
+    {
+      "bom-ref": "idna@3.4",
+      "description": "Internationalized Domain Names in Applications (IDNA)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/#idna-3.4-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/#idna-3.4.tar.gz"
+        }
+      ],
+      "name": "idna",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/idna@3.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "3.4"
+    },
+    {
+      "bom-ref": "importlib-resources@6.1.1",
+      "description": "Read resources from Python packages",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e8bf90d8213b486f428c9c39714b920041cb02c184686a3dee24905aaa8105d6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1.tar.gz"
+        }
+      ],
+      "name": "importlib-resources",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/importlib-resources@6.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "6.1.1"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "jsonpointer@2.4",
+      "description": "Identify specific nodes in a JSON document (RFC 6901)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonpointer/#jsonpointer-2.4-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonpointer/#jsonpointer-2.4.tar.gz"
+        }
+      ],
+      "name": "jsonpointer",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/jsonpointer@2.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.4"
+    },
+    {
+      "bom-ref": "jsonschema@4.19.2",
+      "description": "An implementation of JSON Schema validation for Python",
+      "name": "jsonschema",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "format"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema@4.19.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.19.2"
+    },
+    {
+      "bom-ref": "jsonschema-specifications@2023.7.1",
+      "description": "The JSON Schema meta-schemas and vocabularies, exposed as a Registry",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05adf340b659828a004220a9613be00fa3f223f2b82002e273dee62fd50524b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c91a50404e88a1f6ba40636778e2ee08f6e24c5613fe4c53ac24578a5a7f72bb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1.tar.gz"
+        }
+      ],
+      "name": "jsonschema-specifications",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema-specifications@2023.7.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "2023.7.1"
+    },
+    {
+      "bom-ref": "license-expression@30.1.1",
+      "description": "license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.",
+      "name": "license-expression",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/license-expression@30.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "30.1.1"
+    },
+    {
+      "bom-ref": "lxml@4.9.3",
+      "description": "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.",
+      "name": "lxml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/lxml@4.9.3",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.9.3"
+    },
+    {
+      "bom-ref": "packageurl-python@0.11.2",
+      "description": "A purl aka. Package URL parser and builder",
+      "name": "packageurl-python",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/packageurl-python@0.11.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.11.2"
+    },
+    {
+      "bom-ref": "pkgutil-resolve-name@1.3.10",
+      "description": "Resolve a name to an object.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10.tar.gz"
+        }
+      ],
+      "name": "pkgutil-resolve-name",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pkgutil-resolve-name@1.3.10",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.10"
+    },
+    {
+      "bom-ref": "py-serializable@0.15.0",
+      "description": "Library for serializing and deserializing Python Objects to and from JSON and XML.",
+      "name": "py-serializable",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/py-serializable@0.15.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.15.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "referencing@0.30.2",
+      "description": "JSON Referencing + Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "449b6669b6121a9e96a7f9e410b245d471e8d48964c67113ce9afe50c8dd7bdf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/#referencing-0.30.2-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "794ad8003c65938edcdbc027f1933215e0d0ccc0291e3ce20a4d87432b59efc0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/#referencing-0.30.2.tar.gz"
+        }
+      ],
+      "name": "referencing",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/referencing@0.30.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.30.2"
+    },
+    {
+      "bom-ref": "rfc3339-validator@0.1.4",
+      "description": "A pure python RFC3339 validator",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4.tar.gz"
+        }
+      ],
+      "name": "rfc3339-validator",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/rfc3339-validator@0.1.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.1.4"
+    },
+    {
+      "bom-ref": "rfc3987@1.3.8",
+      "description": "Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3987/#rfc3987-1.3.8-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3987/#rfc3987-1.3.8.tar.gz"
+        }
+      ],
+      "name": "rfc3987",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/rfc3987@1.3.8",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.8"
+    },
+    {
+      "bom-ref": "rpds-py@0.12.0",
+      "description": "Python bindings to Rust's persistent data structures (rpds)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c694bee70ece3b232df4678448fdda245fd3b1bb4ba481fb6cd20e13bb784c46"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "30e5ce9f501fb1f970e4a59098028cf20676dee64fc496d55c33e04bbbee097d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d72a4315514e5a0b9837a086cb433b004eea630afb0cc129de76d77654a9606f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eebaf8c76c39604d52852366249ab807fe6f7a3ffb0dd5484b9944917244cdbe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a239303acb0315091d54c7ff36712dba24554993b9a93941cf301391d8a997ee"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ced40cdbb6dd47a032725a038896cceae9ce267d340f59508b23537f05455431"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3c8c0226c71bd0ce9892eaf6afa77ae8f43a3d9313124a03df0b389c01f832de"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b8e11715178f3608874508f08e990d3771e0b8c66c73eb4e183038d600a9b274"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5210a0018c7e09c75fa788648617ebba861ae242944111d3079034e14498223f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "171d9a159f1b2f42a42a64a985e4ba46fc7268c78299272ceba970743a67ee50"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "57ec6baec231bb19bb5fd5fc7bae21231860a1605174b11585660236627e390e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7188ddc1a8887194f984fa4110d5a3d5b9b5cd35f6bafdff1b649049cbc0ce29"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e04581c6117ad9479b6cfae313e212fe0dfa226ac727755f0d539cd54792963"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0a38612d07a36138507d69646c470aedbfe2b75b43a4643f7bd8e51e52779624"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f12d69d568f5647ec503b64932874dade5a20255736c89936bf690951a5e79f5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f8a1d990dc198a6c68ec3d9a637ba1ce489b38cbfb65440a27901afbc5df575"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8c567c664fc2f44130a20edac73e0a867f8e012bf7370276f15c6adc3586c37c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e9e976e0dbed4f51c56db10831c9623d0fd67aac02853fe5476262e5a22acb7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efddca2d02254a52078c35cadad34762adbae3ff01c6b0c7787b59d038b63e0d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d9e7f29c00577aff6b318681e730a519b235af292732a149337f6aaa4d1c5e31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "389c0e38358fdc4e38e9995e7291269a3aead7acfcf8942010ee7bc5baee091c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "33ab498f9ac30598b6406e2be1b45fd231195b83d948ebd4bd77f337cb6a2bff"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d56b1cd606ba4cedd64bb43479d56580e147c6ef3f5d1c5e64203a1adab784a2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1fa73ed22c40a1bec98d7c93b5659cd35abcfa5a0a95ce876b91adbda170537c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dbc25baa6abb205766fb8606f8263b02c3503a55957fcb4576a6bb0a59d37d10"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c6b52b7028b547866c2413f614ee306c2d4eafdd444b1ff656bf3295bf1484aa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9620650c364c01ed5b497dcae7c3d4b948daeae6e1883ae185fef1c927b6b534"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2124f9e645a94ab7c853bc0a3644e0ca8ffbe5bb2d72db49aef8f9ec1c285733"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "281c8b219d4f4b3581b918b816764098d04964915b2f272d1476654143801aa2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27ccc93c7457ef890b0dd31564d2a05e1aca330623c942b7e818e9e7c2669ee4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d1c562a9bb72244fa767d1c1ab55ca1d92dd5f7c4d77878fee5483a22ffac808"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e57919c32ee295a2fca458bb73e4b20b05c115627f96f95a10f9f5acbd61172d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fa35ad36440aaf1ac8332b4a4a433d4acd28f1613f0d480995f5cfd3580e90b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e6aea5c0eb5b0faf52c7b5c4a47c8bb64437173be97227c819ffa31801fa4e34"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81cf9d306c04df1b45971c13167dc3bad625808aa01281d55f3cf852dde0e206"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08e6e7ff286254016b945e1ab632ee843e43d45e40683b66dd12b73791366dd1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d0a675a7acbbc16179188d8c6d0afb8628604fc1241faf41007255957335a0b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2287c09482949e0ca0c0eb68b2aca6cf57f8af8c6dfd29dcd3bc45f17b57978"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8015835494b21aa7abd3b43fdea0614ee35ef6b03db7ecba9beb58eadf01c24f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6174d6ad6b58a6bcf67afbbf1723420a53d06c4b89f4c50763d6fa0a6ac9afd2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a689e1ded7137552bea36305a7a16ad2b40be511740b80748d3140614993db98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f45321224144c25a62052035ce96cbcf264667bcb0d81823b1bbc22c4addd194"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aa32205358a76bf578854bf31698a86dc8b2cb591fd1d79a833283f4a403f04b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "91bd2b7cf0f4d252eec8b7046fa6a43cee17e8acdfc00eaa8b3dbf2f9a59d061"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3acadbab8b59f63b87b518e09c4c64b142e7286b9ca7a208107d6f9f4c393c5c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "429349a510da82c85431f0f3e66212d83efe9fd2850f50f339341b6532c62fe4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05942656cb2cb4989cd50ced52df16be94d344eae5097e8583966a1d27da73a5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0c5441b7626c29dbd54a3f6f3713ec8e956b009f419ffdaaa3c80eaf98ddb523"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b6b0e17d39d21698185097652c611f9cf30f7c56ccec189789920e3e7f1cee56"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3b7a64d43e2a1fa2dd46b678e00cabd9a49ebb123b339ce799204c44a593ae1c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e5bbe011a2cea9060fef1bb3d668a2fd8432b8888e6d92e74c9c794d3c101595"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bec29b801b4adbf388314c0d050e851d53762ab424af22657021ce4b6eb41543"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1096ca0bf2d3426cbe79d4ccc91dc5aaa73629b08ea2d8467375fad8447ce11a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48aa98987d54a46e13e6954880056c204700c65616af4395d1f0639eba11764b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7979d90ee2190d000129598c2b0c82f13053dba432b94e45e68253b09bb1f0f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "88857060b690a57d2ea8569bca58758143c8faa4639fb17d745ce60ff84c867e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4eb74d44776b0fb0782560ea84d986dffec8ddd94947f383eba2284b0f32e35e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f62581d7e884dd01ee1707b7c21148f61f2febb7de092ae2f108743fcbef5985"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6f5dcb658d597410bb7c967c1d24eaf9377b0d621358cbe9d2ff804e5dd12e81"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9bf9acce44e967a5103fcd820fc7580c7b0ab8583eec4e2051aec560f7b31a63"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "240687b5be0f91fbde4936a329c9b7589d9259742766f74de575e1b2046575e4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25740fb56e8bd37692ed380e15ec734be44d7c71974d8993f452b4527814601e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a54917b7e9cd3a67e429a630e237a90b096e0ba18897bfb99ee8bd1068a5fea0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b92aafcfab3d41580d54aca35a8057341f1cfc7c9af9e8bdfc652f83a20ced31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd316dbcc74c76266ba94eb021b0cc090b97cca122f50bd7a845f587ff4bf03f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0853da3d5e9bc6a07b2486054a410b7b03f34046c123c6561b535bb48cc509e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cb41ad20064e18a900dd427d7cf41cfaec83bcd1184001f3d91a1f76b3fcea4e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b710bf7e7ae61957d5c4026b486be593ed3ec3dca3e5be15e0f6d8cf5d0a4990"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a952ae3eb460c6712388ac2ec706d24b0e651b9396d90c9a9e0a69eb27737fdc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0bedd91ae1dd142a4dc15970ed2c729ff6c73f33a40fa84ed0cdbf55de87c777"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "761531076df51309075133a6bc1db02d98ec7f66e22b064b1d513bc909f29743"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a2baa6be130e8a00b6cbb9f18a33611ec150b4537f8563bddadb54c1b74b8193"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f05450fa1cd7c525c0b9d1a7916e595d3041ac0afbed2ff6926e5afb6a781b7f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81c4d1a3a564775c44732b94135d06e33417e829ff25226c164664f4a1046213"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e888be685fa42d8b8a3d3911d5604d14db87538aa7d0b29b1a7ea80d354c732d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6f8d7fe73d1816eeb5378409adc658f9525ecbfaf9e1ede1e2d67a338b0c7348"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0831d3ecdea22e4559cc1793f22e77067c9d8c451d55ae6a75bf1d116a8e7f42"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "513ccbf7420c30e283c25c82d5a8f439d625a838d3ba69e79a110c260c46813f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "301bd744a1adaa2f6a5e06c98f1ac2b6f8dc31a5c23b838f862d65e32fca0d4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f8832a4f83d4782a8f5a7b831c47e8ffe164e43c2c148c8160ed9a6d630bc02a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b2416ed743ec5debcf61e1242e012652a4348de14ecc7df3512da072b074440"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "35585a8cb5917161f42c2104567bb83a1d96194095fc54a543113ed5df9fa436"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d389ff1e95b6e46ebedccf7fd1fadd10559add595ac6a7c2ea730268325f832c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9b007c2444705a2dc4a525964fd4dd28c3320b19b3410da6517cab28716f27d3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "188912b22b6c8225f4c4ffa020a2baa6ad8fabb3c141a12dbe6edbb34e7f1425"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b4cf9ab9a0ae0cb122685209806d3f1dcb63b9fccdf1424fb42a129dc8c2faa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2d34a5450a402b00d20aeb7632489ffa2556ca7b26f4a63c35f6fccae1977427"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "466030a42724780794dea71eb32db83cc51214d66ab3fb3156edd88b9c8f0d78"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "68172622a5a57deb079a2c78511c40f91193548e8ab342c31e8cb0764d362459"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54cdfcda59251b9c2f87a05d038c2ae02121219a04d4a1e6fc345794295bdc07"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b75b912a0baa033350367a8a07a8b2d44fd5b90c890bfbd063a8a5f945f644b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "47aeceb4363851d17f63069318ba5721ae695d9da55d599b4d6fb31508595278"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0525847f83f506aa1e28eb2057b696fe38217e12931c8b1b02198cfe6975e142"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efbe0b5e0fd078ed7b005faa0170da4f72666360f66f0bb2d7f73526ecfd99f9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0fadfdda275c838cba5102c7f90a20f2abd7727bf8f4a2b654a5b617529c5c18"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "56dd500411d03c5e9927a1eb55621e906837a83b02350a9dc401247d0353717c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6915fc9fa6b3ec3569566832e1bb03bd801c12cea030200e68663b9a87974e76"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5f1519b080d8ce0a814f17ad9fb49fb3a1d4d7ce5891f5c85fc38631ca3a8dc4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7036316cc26b93e401cedd781a579be606dad174829e6ad9e9c5a0da6e036f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0.tar.gz"
+        }
+      ],
+      "name": "rpds-py",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/rpds-py@0.12.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.12.0"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "sortedcontainers@2.4.0",
+      "description": "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set",
+      "name": "sortedcontainers",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/sortedcontainers@2.4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.4.0"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.8.19.14"
+    },
+    {
+      "bom-ref": "uri-template@1.3.0",
+      "description": "RFC 6570 URI Template Processor",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uri-template/#uri-template-1.3.0.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uri-template/#uri_template-1.3.0-py3-none-any.whl"
+        }
+      ],
+      "name": "uri-template",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/uri-template@1.3.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "webcolors@1.13",
+      "description": "A library for working with the color formats defined by HTML and CSS.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/webcolors/#webcolors-1.13-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/webcolors/#webcolors-1.13.tar.gz"
+        }
+      ],
+      "name": "webcolors",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/webcolors@1.13",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.13"
+    },
+    {
+      "bom-ref": "zipp@3.17.0",
+      "description": "Backport of pathlib-compatible object wrapper for zip files",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/zipp/#zipp-3.17.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/zipp/#zipp-3.17.0.tar.gz"
+        }
+      ],
+      "name": "zipp",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/zipp@3.17.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "3.17.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "attrs@23.1.0"
+    },
+    {
+      "ref": "boolean.py@4.0"
+    },
+    {
+      "dependsOn": [
+        "jsonschema@4.19.2",
+        "license-expression@30.1.1",
+        "lxml@4.9.3",
+        "packageurl-python@0.11.2",
+        "py-serializable@0.15.0",
+        "sortedcontainers@2.4.0"
+      ],
+      "ref": "cyclonedx-python-lib@5.1.1"
+    },
+    {
+      "ref": "defusedxml@0.7.1"
+    },
+    {
+      "ref": "fqdn@1.5.1"
+    },
+    {
+      "ref": "idna@3.4"
+    },
+    {
+      "dependsOn": [
+        "zipp@3.17.0"
+      ],
+      "ref": "importlib-resources@6.1.1"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "ref": "jsonpointer@2.4"
+    },
+    {
+      "dependsOn": [
+        "importlib-resources@6.1.1",
+        "referencing@0.30.2"
+      ],
+      "ref": "jsonschema-specifications@2023.7.1"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.1.0",
+        "fqdn@1.5.1",
+        "idna@3.4",
+        "importlib-resources@6.1.1",
+        "isoduration@20.11.0",
+        "jsonpointer@2.4",
+        "jsonschema-specifications@2023.7.1",
+        "pkgutil-resolve-name@1.3.10",
+        "referencing@0.30.2",
+        "rfc3339-validator@0.1.4",
+        "rfc3987@1.3.8",
+        "rpds-py@0.12.0",
+        "uri-template@1.3.0",
+        "webcolors@1.13"
+      ],
+      "ref": "jsonschema@4.19.2"
+    },
+    {
+      "dependsOn": [
+        "boolean.py@4.0"
+      ],
+      "ref": "license-expression@30.1.1"
+    },
+    {
+      "ref": "lxml@4.9.3"
+    },
+    {
+      "ref": "packageurl-python@0.11.2"
+    },
+    {
+      "ref": "pkgutil-resolve-name@1.3.10"
+    },
+    {
+      "dependsOn": [
+        "defusedxml@0.7.1"
+      ],
+      "ref": "py-serializable@0.15.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.1.0",
+        "rpds-py@0.12.0"
+      ],
+      "ref": "referencing@0.30.2"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "rfc3339-validator@0.1.4"
+    },
+    {
+      "ref": "rfc3987@1.3.8"
+    },
+    {
+      "ref": "rpds-py@0.12.0"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "sortedcontainers@2.4.0"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    },
+    {
+      "ref": "uri-template@1.3.0"
+    },
+    {
+      "ref": "webcolors@1.13"
+    },
+    {
+      "dependsOn": [
+        "cyclonedx-python-lib@5.1.1"
+      ],
+      "ref": "with-extras"
+    },
+    {
+      "ref": "zipp@3.17.0"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "with-extras",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "properties": [
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "my-extra"
+        }
+      ],
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/all-extras_with-extras_lock11_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/all-extras_with-extras_lock11_1.6.xml.bin
@@ -1,0 +1,1399 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-extras">
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+      <properties>
+        <property name="cdx:python:package:required-extra">my-extra</property>
+      </properties>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="attrs@23.1.0">
+      <name>attrs</name>
+      <version>23.1.0</version>
+      <description>Classes Without Boilerplate</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/attrs@23.1.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/#attrs-23.1.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/#attrs-23.1.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="boolean.py@4.0">
+      <name>boolean.py</name>
+      <version>4.0</version>
+      <description>Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/boolean.py@4.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="cyclonedx-python-lib@5.1.1">
+      <name>cyclonedx-python-lib</name>
+      <version>5.1.1</version>
+      <description>Python library for CycloneDX</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/cyclonedx-python-lib@5.1.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:required-extra">json-validation</property>
+        <property name="cdx:python:package:required-extra">xml-validation</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="defusedxml@0.7.1">
+      <name>defusedxml</name>
+      <version>0.7.1</version>
+      <description>XML bomb protection for Python stdlib modules</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/defusedxml@0.7.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="fqdn@1.5.1">
+      <name>fqdn</name>
+      <version>1.5.1</version>
+      <description>Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/fqdn@1.5.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fqdn/#fqdn-1.5.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fqdn/#fqdn-1.5.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="idna@3.4">
+      <name>idna</name>
+      <version>3.4</version>
+      <description>Internationalized Domain Names in Applications (IDNA)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/idna@3.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/#idna-3.4-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/#idna-3.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="importlib-resources@6.1.1">
+      <name>importlib-resources</name>
+      <version>6.1.1</version>
+      <description>Read resources from Python packages</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/importlib-resources@6.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e8bf90d8213b486f428c9c39714b920041cb02c184686a3dee24905aaa8105d6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonpointer@2.4">
+      <name>jsonpointer</name>
+      <version>2.4</version>
+      <description>Identify specific nodes in a JSON document (RFC 6901)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonpointer@2.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonpointer/#jsonpointer-2.4-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonpointer/#jsonpointer-2.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema@4.19.2">
+      <name>jsonschema</name>
+      <version>4.19.2</version>
+      <description>An implementation of JSON Schema validation for Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonschema@4.19.2</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:required-extra">format</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema-specifications@2023.7.1">
+      <name>jsonschema-specifications</name>
+      <version>2023.7.1</version>
+      <description>The JSON Schema meta-schemas and vocabularies, exposed as a Registry</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonschema-specifications@2023.7.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">05adf340b659828a004220a9613be00fa3f223f2b82002e273dee62fd50524b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c91a50404e88a1f6ba40636778e2ee08f6e24c5613fe4c53ac24578a5a7f72bb</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="license-expression@30.1.1">
+      <name>license-expression</name>
+      <version>30.1.1</version>
+      <description>license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/license-expression@30.1.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="lxml@4.9.3">
+      <name>lxml</name>
+      <version>4.9.3</version>
+      <description>Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/lxml@4.9.3</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="packageurl-python@0.11.2">
+      <name>packageurl-python</name>
+      <version>0.11.2</version>
+      <description>A purl aka. Package URL parser and builder</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/packageurl-python@0.11.2</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pkgutil-resolve-name@1.3.10">
+      <name>pkgutil-resolve-name</name>
+      <version>1.3.10</version>
+      <description>Resolve a name to an object.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/pkgutil-resolve-name@1.3.10</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="py-serializable@0.15.0">
+      <name>py-serializable</name>
+      <version>0.15.0</version>
+      <description>Library for serializing and deserializing Python Objects to and from JSON and XML.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/py-serializable@0.15.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="referencing@0.30.2">
+      <name>referencing</name>
+      <version>0.30.2</version>
+      <description>JSON Referencing + Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/referencing@0.30.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/#referencing-0.30.2-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">449b6669b6121a9e96a7f9e410b245d471e8d48964c67113ce9afe50c8dd7bdf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/#referencing-0.30.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">794ad8003c65938edcdbc027f1933215e0d0ccc0291e3ce20a4d87432b59efc0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rfc3339-validator@0.1.4">
+      <name>rfc3339-validator</name>
+      <version>0.1.4</version>
+      <description>A pure python RFC3339 validator</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rfc3339-validator@0.1.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rfc3987@1.3.8">
+      <name>rfc3987</name>
+      <version>1.3.8</version>
+      <description>Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rfc3987@1.3.8</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3987/#rfc3987-1.3.8-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3987/#rfc3987-1.3.8.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rpds-py@0.12.0">
+      <name>rpds-py</name>
+      <version>0.12.0</version>
+      <description>Python bindings to Rust's persistent data structures (rpds)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rpds-py@0.12.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c694bee70ece3b232df4678448fdda245fd3b1bb4ba481fb6cd20e13bb784c46</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">30e5ce9f501fb1f970e4a59098028cf20676dee64fc496d55c33e04bbbee097d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d72a4315514e5a0b9837a086cb433b004eea630afb0cc129de76d77654a9606f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eebaf8c76c39604d52852366249ab807fe6f7a3ffb0dd5484b9944917244cdbe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a239303acb0315091d54c7ff36712dba24554993b9a93941cf301391d8a997ee</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ced40cdbb6dd47a032725a038896cceae9ce267d340f59508b23537f05455431</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3c8c0226c71bd0ce9892eaf6afa77ae8f43a3d9313124a03df0b389c01f832de</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b8e11715178f3608874508f08e990d3771e0b8c66c73eb4e183038d600a9b274</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5210a0018c7e09c75fa788648617ebba861ae242944111d3079034e14498223f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">171d9a159f1b2f42a42a64a985e4ba46fc7268c78299272ceba970743a67ee50</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">57ec6baec231bb19bb5fd5fc7bae21231860a1605174b11585660236627e390e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7188ddc1a8887194f984fa4110d5a3d5b9b5cd35f6bafdff1b649049cbc0ce29</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e04581c6117ad9479b6cfae313e212fe0dfa226ac727755f0d539cd54792963</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0a38612d07a36138507d69646c470aedbfe2b75b43a4643f7bd8e51e52779624</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f12d69d568f5647ec503b64932874dade5a20255736c89936bf690951a5e79f5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f8a1d990dc198a6c68ec3d9a637ba1ce489b38cbfb65440a27901afbc5df575</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8c567c664fc2f44130a20edac73e0a867f8e012bf7370276f15c6adc3586c37c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e9e976e0dbed4f51c56db10831c9623d0fd67aac02853fe5476262e5a22acb7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efddca2d02254a52078c35cadad34762adbae3ff01c6b0c7787b59d038b63e0d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d9e7f29c00577aff6b318681e730a519b235af292732a149337f6aaa4d1c5e31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">389c0e38358fdc4e38e9995e7291269a3aead7acfcf8942010ee7bc5baee091c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">33ab498f9ac30598b6406e2be1b45fd231195b83d948ebd4bd77f337cb6a2bff</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d56b1cd606ba4cedd64bb43479d56580e147c6ef3f5d1c5e64203a1adab784a2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1fa73ed22c40a1bec98d7c93b5659cd35abcfa5a0a95ce876b91adbda170537c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dbc25baa6abb205766fb8606f8263b02c3503a55957fcb4576a6bb0a59d37d10</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c6b52b7028b547866c2413f614ee306c2d4eafdd444b1ff656bf3295bf1484aa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9620650c364c01ed5b497dcae7c3d4b948daeae6e1883ae185fef1c927b6b534</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2124f9e645a94ab7c853bc0a3644e0ca8ffbe5bb2d72db49aef8f9ec1c285733</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">281c8b219d4f4b3581b918b816764098d04964915b2f272d1476654143801aa2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">27ccc93c7457ef890b0dd31564d2a05e1aca330623c942b7e818e9e7c2669ee4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d1c562a9bb72244fa767d1c1ab55ca1d92dd5f7c4d77878fee5483a22ffac808</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e57919c32ee295a2fca458bb73e4b20b05c115627f96f95a10f9f5acbd61172d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fa35ad36440aaf1ac8332b4a4a433d4acd28f1613f0d480995f5cfd3580e90b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e6aea5c0eb5b0faf52c7b5c4a47c8bb64437173be97227c819ffa31801fa4e34</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">81cf9d306c04df1b45971c13167dc3bad625808aa01281d55f3cf852dde0e206</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08e6e7ff286254016b945e1ab632ee843e43d45e40683b66dd12b73791366dd1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d0a675a7acbbc16179188d8c6d0afb8628604fc1241faf41007255957335a0b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2287c09482949e0ca0c0eb68b2aca6cf57f8af8c6dfd29dcd3bc45f17b57978</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8015835494b21aa7abd3b43fdea0614ee35ef6b03db7ecba9beb58eadf01c24f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6174d6ad6b58a6bcf67afbbf1723420a53d06c4b89f4c50763d6fa0a6ac9afd2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a689e1ded7137552bea36305a7a16ad2b40be511740b80748d3140614993db98</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f45321224144c25a62052035ce96cbcf264667bcb0d81823b1bbc22c4addd194</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aa32205358a76bf578854bf31698a86dc8b2cb591fd1d79a833283f4a403f04b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">91bd2b7cf0f4d252eec8b7046fa6a43cee17e8acdfc00eaa8b3dbf2f9a59d061</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3acadbab8b59f63b87b518e09c4c64b142e7286b9ca7a208107d6f9f4c393c5c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">429349a510da82c85431f0f3e66212d83efe9fd2850f50f339341b6532c62fe4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">05942656cb2cb4989cd50ced52df16be94d344eae5097e8583966a1d27da73a5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0c5441b7626c29dbd54a3f6f3713ec8e956b009f419ffdaaa3c80eaf98ddb523</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b6b0e17d39d21698185097652c611f9cf30f7c56ccec189789920e3e7f1cee56</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3b7a64d43e2a1fa2dd46b678e00cabd9a49ebb123b339ce799204c44a593ae1c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e5bbe011a2cea9060fef1bb3d668a2fd8432b8888e6d92e74c9c794d3c101595</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bec29b801b4adbf388314c0d050e851d53762ab424af22657021ce4b6eb41543</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1096ca0bf2d3426cbe79d4ccc91dc5aaa73629b08ea2d8467375fad8447ce11a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48aa98987d54a46e13e6954880056c204700c65616af4395d1f0639eba11764b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7979d90ee2190d000129598c2b0c82f13053dba432b94e45e68253b09bb1f0f6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">88857060b690a57d2ea8569bca58758143c8faa4639fb17d745ce60ff84c867e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4eb74d44776b0fb0782560ea84d986dffec8ddd94947f383eba2284b0f32e35e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f62581d7e884dd01ee1707b7c21148f61f2febb7de092ae2f108743fcbef5985</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6f5dcb658d597410bb7c967c1d24eaf9377b0d621358cbe9d2ff804e5dd12e81</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9bf9acce44e967a5103fcd820fc7580c7b0ab8583eec4e2051aec560f7b31a63</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">240687b5be0f91fbde4936a329c9b7589d9259742766f74de575e1b2046575e4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">25740fb56e8bd37692ed380e15ec734be44d7c71974d8993f452b4527814601e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a54917b7e9cd3a67e429a630e237a90b096e0ba18897bfb99ee8bd1068a5fea0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b92aafcfab3d41580d54aca35a8057341f1cfc7c9af9e8bdfc652f83a20ced31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd316dbcc74c76266ba94eb021b0cc090b97cca122f50bd7a845f587ff4bf03f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0853da3d5e9bc6a07b2486054a410b7b03f34046c123c6561b535bb48cc509e1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cb41ad20064e18a900dd427d7cf41cfaec83bcd1184001f3d91a1f76b3fcea4e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b710bf7e7ae61957d5c4026b486be593ed3ec3dca3e5be15e0f6d8cf5d0a4990</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a952ae3eb460c6712388ac2ec706d24b0e651b9396d90c9a9e0a69eb27737fdc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0bedd91ae1dd142a4dc15970ed2c729ff6c73f33a40fa84ed0cdbf55de87c777</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">761531076df51309075133a6bc1db02d98ec7f66e22b064b1d513bc909f29743</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a2baa6be130e8a00b6cbb9f18a33611ec150b4537f8563bddadb54c1b74b8193</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f05450fa1cd7c525c0b9d1a7916e595d3041ac0afbed2ff6926e5afb6a781b7f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">81c4d1a3a564775c44732b94135d06e33417e829ff25226c164664f4a1046213</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e888be685fa42d8b8a3d3911d5604d14db87538aa7d0b29b1a7ea80d354c732d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6f8d7fe73d1816eeb5378409adc658f9525ecbfaf9e1ede1e2d67a338b0c7348</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0831d3ecdea22e4559cc1793f22e77067c9d8c451d55ae6a75bf1d116a8e7f42</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">513ccbf7420c30e283c25c82d5a8f439d625a838d3ba69e79a110c260c46813f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">301bd744a1adaa2f6a5e06c98f1ac2b6f8dc31a5c23b838f862d65e32fca0d4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f8832a4f83d4782a8f5a7b831c47e8ffe164e43c2c148c8160ed9a6d630bc02a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4b2416ed743ec5debcf61e1242e012652a4348de14ecc7df3512da072b074440</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">35585a8cb5917161f42c2104567bb83a1d96194095fc54a543113ed5df9fa436</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d389ff1e95b6e46ebedccf7fd1fadd10559add595ac6a7c2ea730268325f832c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9b007c2444705a2dc4a525964fd4dd28c3320b19b3410da6517cab28716f27d3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">188912b22b6c8225f4c4ffa020a2baa6ad8fabb3c141a12dbe6edbb34e7f1425</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1b4cf9ab9a0ae0cb122685209806d3f1dcb63b9fccdf1424fb42a129dc8c2faa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2d34a5450a402b00d20aeb7632489ffa2556ca7b26f4a63c35f6fccae1977427</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">466030a42724780794dea71eb32db83cc51214d66ab3fb3156edd88b9c8f0d78</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">68172622a5a57deb079a2c78511c40f91193548e8ab342c31e8cb0764d362459</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">54cdfcda59251b9c2f87a05d038c2ae02121219a04d4a1e6fc345794295bdc07</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b75b912a0baa033350367a8a07a8b2d44fd5b90c890bfbd063a8a5f945f644b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">47aeceb4363851d17f63069318ba5721ae695d9da55d599b4d6fb31508595278</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0525847f83f506aa1e28eb2057b696fe38217e12931c8b1b02198cfe6975e142</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efbe0b5e0fd078ed7b005faa0170da4f72666360f66f0bb2d7f73526ecfd99f9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0fadfdda275c838cba5102c7f90a20f2abd7727bf8f4a2b654a5b617529c5c18</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">56dd500411d03c5e9927a1eb55621e906837a83b02350a9dc401247d0353717c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6915fc9fa6b3ec3569566832e1bb03bd801c12cea030200e68663b9a87974e76</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5f1519b080d8ce0a814f17ad9fb49fb3a1d4d7ce5891f5c85fc38631ca3a8dc4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7036316cc26b93e401cedd781a579be606dad174829e6ad9e9c5a0da6e036f80</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="sortedcontainers@2.4.0">
+      <name>sortedcontainers</name>
+      <version>2.4.0</version>
+      <description>Sorted Containers -- Sorted List, Sorted Dict, Sorted Set</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/sortedcontainers@2.4.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="uri-template@1.3.0">
+      <name>uri-template</name>
+      <version>1.3.0</version>
+      <description>RFC 6570 URI Template Processor</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/uri-template@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uri-template/#uri-template-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uri-template/#uri_template-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="webcolors@1.13">
+      <name>webcolors</name>
+      <version>1.13</version>
+      <description>A library for working with the color formats defined by HTML and CSS.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/webcolors@1.13</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/webcolors/#webcolors-1.13-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/webcolors/#webcolors-1.13.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="zipp@3.17.0">
+      <name>zipp</name>
+      <version>3.17.0</version>
+      <description>Backport of pathlib-compatible object wrapper for zip files</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/zipp@3.17.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/zipp/#zipp-3.17.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/zipp/#zipp-3.17.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="attrs@23.1.0"/>
+    <dependency ref="boolean.py@4.0"/>
+    <dependency ref="cyclonedx-python-lib@5.1.1">
+      <dependency ref="jsonschema@4.19.2"/>
+      <dependency ref="license-expression@30.1.1"/>
+      <dependency ref="lxml@4.9.3"/>
+      <dependency ref="packageurl-python@0.11.2"/>
+      <dependency ref="py-serializable@0.15.0"/>
+      <dependency ref="sortedcontainers@2.4.0"/>
+    </dependency>
+    <dependency ref="defusedxml@0.7.1"/>
+    <dependency ref="fqdn@1.5.1"/>
+    <dependency ref="idna@3.4"/>
+    <dependency ref="importlib-resources@6.1.1">
+      <dependency ref="zipp@3.17.0"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="jsonpointer@2.4"/>
+    <dependency ref="jsonschema-specifications@2023.7.1">
+      <dependency ref="importlib-resources@6.1.1"/>
+      <dependency ref="referencing@0.30.2"/>
+    </dependency>
+    <dependency ref="jsonschema@4.19.2">
+      <dependency ref="attrs@23.1.0"/>
+      <dependency ref="fqdn@1.5.1"/>
+      <dependency ref="idna@3.4"/>
+      <dependency ref="importlib-resources@6.1.1"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="jsonpointer@2.4"/>
+      <dependency ref="jsonschema-specifications@2023.7.1"/>
+      <dependency ref="pkgutil-resolve-name@1.3.10"/>
+      <dependency ref="referencing@0.30.2"/>
+      <dependency ref="rfc3339-validator@0.1.4"/>
+      <dependency ref="rfc3987@1.3.8"/>
+      <dependency ref="rpds-py@0.12.0"/>
+      <dependency ref="uri-template@1.3.0"/>
+      <dependency ref="webcolors@1.13"/>
+    </dependency>
+    <dependency ref="license-expression@30.1.1">
+      <dependency ref="boolean.py@4.0"/>
+    </dependency>
+    <dependency ref="lxml@4.9.3"/>
+    <dependency ref="packageurl-python@0.11.2"/>
+    <dependency ref="pkgutil-resolve-name@1.3.10"/>
+    <dependency ref="py-serializable@0.15.0">
+      <dependency ref="defusedxml@0.7.1"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="referencing@0.30.2">
+      <dependency ref="attrs@23.1.0"/>
+      <dependency ref="rpds-py@0.12.0"/>
+    </dependency>
+    <dependency ref="rfc3339-validator@0.1.4">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="rfc3987@1.3.8"/>
+    <dependency ref="rpds-py@0.12.0"/>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="sortedcontainers@2.4.0"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+    <dependency ref="uri-template@1.3.0"/>
+    <dependency ref="webcolors@1.13"/>
+    <dependency ref="with-extras">
+      <dependency ref="cyclonedx-python-lib@5.1.1"/>
+    </dependency>
+    <dependency ref="zipp@3.17.0"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/all-extras_with-extras_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/all-extras_with-extras_lock20_1.6.json.bin
@@ -1,0 +1,3184 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "attrs@23.1.0",
+      "description": "Classes Without Boilerplate",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/#attrs-23.1.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/#attrs-23.1.0.tar.gz"
+        }
+      ],
+      "name": "attrs",
+      "purl": "pkg:pypi/attrs@23.1.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "23.1.0"
+    },
+    {
+      "bom-ref": "boolean-py@4.0",
+      "description": "Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2876f2051d7d6394a531d82dc6eb407faa0b01a0a0b3083817ccd7323b8d96bd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/boolean-py/#boolean.py-4.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "17b9a181630e43dde1851d42bef546d616d5d9b4480357514597e78b203d06e4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/boolean-py/#boolean.py-4.0.tar.gz"
+        }
+      ],
+      "name": "boolean-py",
+      "purl": "pkg:pypi/boolean-py@4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.0"
+    },
+    {
+      "bom-ref": "cyclonedx-python-lib@5.1.1",
+      "description": "Python library for CycloneDX",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2989db0cd8bb4c0c442423d71ed7a84ae059e16a2d0f932cc4bf92da7385cdb3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/cyclonedx-python-lib/#cyclonedx_python_lib-5.1.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "215a636a4e77385d2cf4c6c9801c9bad4791849634f2c6daa45ab2c6cb0a85f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/cyclonedx-python-lib/#cyclonedx_python_lib-5.1.1.tar.gz"
+        }
+      ],
+      "name": "cyclonedx-python-lib",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "json-validation"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "xml-validation"
+        }
+      ],
+      "purl": "pkg:pypi/cyclonedx-python-lib@5.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "5.1.1"
+    },
+    {
+      "bom-ref": "defusedxml@0.7.1",
+      "description": "XML bomb protection for Python stdlib modules",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/defusedxml/#defusedxml-0.7.1-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/defusedxml/#defusedxml-0.7.1.tar.gz"
+        }
+      ],
+      "name": "defusedxml",
+      "purl": "pkg:pypi/defusedxml@0.7.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.7.1"
+    },
+    {
+      "bom-ref": "fqdn@1.5.1",
+      "description": "Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fqdn/#fqdn-1.5.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fqdn/#fqdn-1.5.1.tar.gz"
+        }
+      ],
+      "name": "fqdn",
+      "purl": "pkg:pypi/fqdn@1.5.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.5.1"
+    },
+    {
+      "bom-ref": "idna@3.4",
+      "description": "Internationalized Domain Names in Applications (IDNA)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/#idna-3.4-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/#idna-3.4.tar.gz"
+        }
+      ],
+      "name": "idna",
+      "purl": "pkg:pypi/idna@3.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "3.4"
+    },
+    {
+      "bom-ref": "importlib-resources@6.1.1",
+      "description": "Read resources from Python packages",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e8bf90d8213b486f428c9c39714b920041cb02c184686a3dee24905aaa8105d6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1.tar.gz"
+        }
+      ],
+      "name": "importlib-resources",
+      "purl": "pkg:pypi/importlib-resources@6.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "6.1.1"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "jsonpointer@2.4",
+      "description": "Identify specific nodes in a JSON document (RFC 6901)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonpointer/#jsonpointer-2.4-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonpointer/#jsonpointer-2.4.tar.gz"
+        }
+      ],
+      "name": "jsonpointer",
+      "purl": "pkg:pypi/jsonpointer@2.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.4"
+    },
+    {
+      "bom-ref": "jsonschema@4.19.2",
+      "description": "An implementation of JSON Schema validation for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eee9e502c788e89cb166d4d37f43084e3b64ab405c795c03d343a4dbc2c810fc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema/#jsonschema-4.19.2-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c9ff4d7447eed9592c23a12ccee508baf0dd0d59650615e847feb6cdca74f392"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema/#jsonschema-4.19.2.tar.gz"
+        }
+      ],
+      "name": "jsonschema",
+      "properties": [
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "format"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema@4.19.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.19.2"
+    },
+    {
+      "bom-ref": "jsonschema-specifications@2023.7.1",
+      "description": "The JSON Schema meta-schemas and vocabularies, exposed as a Registry",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05adf340b659828a004220a9613be00fa3f223f2b82002e273dee62fd50524b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c91a50404e88a1f6ba40636778e2ee08f6e24c5613fe4c53ac24578a5a7f72bb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1.tar.gz"
+        }
+      ],
+      "name": "jsonschema-specifications",
+      "purl": "pkg:pypi/jsonschema-specifications@2023.7.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "2023.7.1"
+    },
+    {
+      "bom-ref": "license-expression@30.1.1",
+      "description": "license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "42375df653ad85e6f5b4b0385138b2dbea1f5d66360783d8625c3e4f97f11f0c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/license-expression/#license-expression-30.1.1.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d7e5e2de0d04fc104a4f952c440e8f08a5ba63480a0dad015b294770b7e58ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/license-expression/#license_expression-30.1.1-py3-none-any.whl"
+        }
+      ],
+      "name": "license-expression",
+      "purl": "pkg:pypi/license-expression@30.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "30.1.1"
+    },
+    {
+      "bom-ref": "lxml@4.9.3",
+      "description": "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b0a545b46b526d418eb91754565ba5b63b1c0b12f9bd2f808c852d9b4b2f9b5c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "075b731ddd9e7f68ad24c635374211376aa05a281673ede86cbe1d1b3455279d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e224d5755dba2f4a9498e150c43792392ac9b5380aa1b845f98a1618c94eeef"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2c74524e179f2ad6d2a4f7caf70e2d96639c0954c943ad601a9e146c76408ed7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1026bc732b6a7f96369f7bfe1a4f2290fb34dce00d8644bc3036fb351a4ca1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c0781a98ff5e6586926293e59480b64ddd46282953203c76ae15dbbbf302e8bb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cef2502e7e8a96fe5ad686d60b49e1ab03e438bd9123987994528febd569868e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b86164d2cff4d3aaa1f04a14685cbc072efd0b4f99ca5708b2ad1b9b5988a991"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "42871176e7896d5d45138f6d28751053c711ed4d48d8e30b498da155af39aebd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ae8b9c6deb1e634ba4f1930eb67ef6e6bf6a44b6eb5ad605642b2d6d5ed9ce3c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "411007c0d88188d9f621b11d252cce90c4a2d1a49db6c068e3c16422f306eab8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd47b4a0d41d2afa3e58e5bf1f62069255aa2fd6ff5ee41604418ca925911d76"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e2cb47860da1f7e9a5256254b74ae331687b9672dfa780eed355c4c9c3dbd23"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1247694b26342a7bf47c02e513d32225ededd18045264d40758abeb3c838a51f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cdb650fc86227eba20de1a29d4b2c1bfe139dc75a0669270033cb2ea3d391b85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "97047f0d25cd4bcae81f9ec9dc290ca3e15927c192df17331b53bebe0e3ff96d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f447ea5429b54f9582d4b955f5f1985f278ce5cf169f72eea8afd9502973dd5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-macosx_11_0_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "57d6ba0ca2b0c462f339640d22882acc711de224d769edf29962b09f77129cbf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9767e79108424fb6c3edf8f81e6730666a50feb01a328f4a016464a5893f835a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "71c52db65e4b56b8ddc5bb89fb2e66c558ed9d1a74a45ceb7dcb20c191c3df2f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d73d8ecf8ecf10a3bd007f2192725a34bd62898e8da27eb9d32a58084f93962b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0a3d3487f07c1d7f150894c238299934a2a074ef590b583103a45002035be120"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9e28c51fa0ce5674be9f560c6761c1b441631901993f76700b1b30ca6c8378d6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0bfd0767c5c1de2551a120673b72e5d4b628737cb05414f03c3277bf9bed3305"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25f32acefac14ef7bd53e4218fe93b804ef6f6b92ffdb4322bb6d49d94cad2bc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d3ff32724f98fbbbfa9f49d82852b159e9784d6094983d9a8b7f2ddaebb063d4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-macosx_11_0_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48d6ed886b343d11493129e019da91d4039826794a3e3027321c56d9e71505be"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9a92d3faef50658dd2c5470af249985782bf754c4e18e15afb67d3ab06233f13"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b4e4bc18382088514ebde9328da057775055940a1f2e18f6ad2d78aa0f3ec5b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fc9b106a1bf918db68619fdcd6d5ad4f972fdd19c01d19bdb6bf63f3589a9ec5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d37017287a7adb6ab77e1c5bee9bcf9660f90ff445042b790402a654d2ad81d8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "56dc1f1ebccc656d1b3ed288f11e27172a01503fc016bcabdcbc0978b19352b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "578695735c5a3f51569810dfebd05dd6f888147a34f0f98d4bb27e92b76e05c2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "704f61ba8c1283c71b16135caf697557f5ecf3e74d9e453233e4771d68a1f42d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c41bfca0bd3532d53d16fd34d20806d5c2b1ace22a2f2e4c0008570bf2c58833"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "64f479d719dc9f4c813ad9bb6b28f8390360660b73b2e4beb4cb0ae7104f1c12"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dd708cf4ee4408cf46a48b108fb9427bfa00b9b85812a9262b5c668af2533ea5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c31c7462abdf8f2ac0577d9f05279727e698f97ecbb02f17939ea99ae8daa98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e3cd95e10c2610c360154afdc2f1480aea394f4a4f1ea0a5eacce49640c9b190"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4930be26af26ac545c3dffb662521d4e6268352866956672231887d18f0eaab2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4aec80cde9197340bc353d2768e2a75f5f60bacda2bab72ab1dc499589b3878c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "14e019fd83b831b2e61baed40cab76222139926b1fb5ed0e79225bc0cae14584"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0c0850c8b02c298d3c7006b23e98249515ac57430e16a166873fc47a5d549287"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aca086dc5f9ef98c512bac8efea4483eb84abbf926eaeedf7b91479feb092458"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "50baa9c1c47efcaef189f31e3d00d697c6d4afda5c3cde0302d063492ff9b477"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bef4e656f7d98aaa3486d2627e7d2df1157d7e88e7efd43a65aa5dd4714916cf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "46f409a2d60f634fe550f7133ed30ad5321ae2e6630f13657fb9479506b00601"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4c28a9144688aef80d6ea666c809b4b0e50010a2aca784c97f5e6bf143d9f129"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "141f1d1a9b663c679dc524af3ea1773e618907e96075262726c7612c02b149a4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "53ace1c1fd5a74ef662f844a0413446c0629d151055340e9893da958a374f70d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "17a753023436a18e27dd7769e798ce302963c236bc4114ceee5b25c18c52c693"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7d298a1bd60c067ea75d9f684f5f3992c9d6766fadbc0bcedd39750bf344c2f4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "081d32421db5df44c41b7f08a334a090a545c54ba977e47fd7cc2deece78809a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "23eed6d7b1a3336ad92d8e39d4bfe09073c31bfe502f20ca5116b2a334f8ec02"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1509dd12b773c02acd154582088820893109f6ca27ef7291b003d0e81666109f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "120fa9349a24c7043854c53cae8cec227e1f79195a7493e09e0c12e29f918e52"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d2d1edbca80b510443f51afd8496be95529db04a509bc8faee49c7b0fb6d2cc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d7e43bd40f65f7d97ad8ef5c9b1778943d02f04febef12def25f7583d19baac"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "71d66ee82e7417828af6ecd7db817913cb0cf9d4e61aa0ac1fde0583d84358db"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6fc3c450eaa0b56f815c7b62f2b7fba7266c4779adcf1cece9e6deb1de7305ce"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "65299ea57d82fb91c7f019300d24050c4ddeb7c5a190e076b5f48a2b43d19c42"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eadfbbbfb41b44034a4c757fd5d70baccd43296fb894dba0295606a7cf3124aa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e9bdd30efde2b9ccfa9cb5768ba04fe71b018a25ea093379c857c9dad262c40"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fcdd00edfd0a3001e0181eab3e63bd5c74ad3e67152c84f93f13769a40e073a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "57aba1bbdf450b726d58b2aea5fe47c7875f5afb2c4a23784ed78f19a0462574"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "92af161ecbdb2883c4593d5ed4815ea71b31fafd7fd05789b23100d081ecac96"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9bb6ad405121241e99a86efff22d3ef469024ce22875a7ae045896ad23ba2340"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8ed74706b26ad100433da4b9d807eae371efaa266ffc3e9191ea436087a9d6a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fbf521479bcac1e25a663df882c46a641a9bff6b56dc8b0fafaebd2f66fb231b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "303bf1edce6ced16bf67a18a1cf8339d0db79577eec5d9a6d4a80f0fb10aa2da"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5515edd2a6d1a5a70bfcdee23b42ec33425e405c5b351478ab7dc9347228f96e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "690dafd0b187ed38583a648076865d8c229661ed20e48f2335d68e2cf7dc829d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b6420a005548ad52154c8ceab4a1290ff78d757f9e5cbc68f8c77089acd3c432"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bb3bb49c7a6ad9d981d734ef7c7193bc349ac338776a0360cc671eaee89bcf69"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d27be7405547d1f958b60837dc4c1007da90b8b23f54ba1f8b728c78fdb19d50"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8df133a2ea5e74eef5e8fc6f19b9e085f758768a16e9877a60aec455ed2609b2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4dd9a263e845a72eacb60d12401e37c616438ea2e5442885f65082c276dfb2b2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6689a3d7fd13dc687e9102a27e98ef33730ac4fe37795d5036d18b4d527abd35"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f6bdac493b949141b733c5345b6ba8f87a226029cbabc7e9e121a413e49441e0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05186a0f1346ae12553d66df1cfce6f251589fea3ad3da4f3ef4e34b2d58c6a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c2006f5c8d28dee289f7020f721354362fa304acbaaf9745751ac4006650254b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c245b783db29c4e4fbbbfc9c5a78be496c9fea25517f90606aa1f6b2b3d5f7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4fb960a632a49f2f089d522f70496640fdf1218f1243889da3822e0a9f5f3ba7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "50670615eaf97227d5dc60de2dc99fb134a7130d310d783314e7724bf163f75d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9719fe17307a9e814580af1f5c6e05ca593b12fb7e44fe62450a5384dbf61b4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3331bece23c9ee066e0fb3f96c61322b9e0f54d775fccefff4c38ca488de283a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ed667f49b11360951e201453fc3967344d0d0263aa415e1619e85ae7fd17b4e0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8b77946fd508cbf0fccd8e400a7f71d4ac0e1595812e66025bac475a8e811694"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e4da8ca0c0c0aea88fd46be8e44bd49716772358d648cce45fe387f7b92374a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fe4bda6bd4340caa6e5cf95e73f8fea5c4bfc55763dd42f1b50a94c1b4a2fbd4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f3df3db1d336b9356dd3112eae5f5c2b8b377f3bc826848567f10bfddfee77e9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48628bd53a426c9eb9bc066a923acaa0878d1e86129fd5359aee99285f4eed9c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3.tar.gz"
+        }
+      ],
+      "name": "lxml",
+      "purl": "pkg:pypi/lxml@4.9.3",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.9.3"
+    },
+    {
+      "bom-ref": "packageurl-python@0.11.2",
+      "description": "A purl aka. Package URL parser and builder",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "01fbf74a41ef85cf413f1ede529a1411f658bda66ed22d45d27280ad9ceba471"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/packageurl-python/#packageurl-python-0.11.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "799acfe8d9e6e3534bbc19660be97d5b66754bc033e62c39f1e2f16323fcfa84"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/packageurl-python/#packageurl_python-0.11.2-py3-none-any.whl"
+        }
+      ],
+      "name": "packageurl-python",
+      "purl": "pkg:pypi/packageurl-python@0.11.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.11.2"
+    },
+    {
+      "bom-ref": "pkgutil-resolve-name@1.3.10",
+      "description": "Resolve a name to an object.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10.tar.gz"
+        }
+      ],
+      "name": "pkgutil-resolve-name",
+      "purl": "pkg:pypi/pkgutil-resolve-name@1.3.10",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.10"
+    },
+    {
+      "bom-ref": "py-serializable@0.15.0",
+      "description": "Library for serializing and deserializing Python Objects to and from JSON and XML.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8fc41457d8ee5f5c5a12f41fd87bf1a4f2ecf9da39fee92059b728e78f320771"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-serializable/#py-serializable-0.15.0.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d3f1201b33420c481aa83f7860c7bf2c2f036ba3ea82b6e15a96696457c36cd2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-serializable/#py_serializable-0.15.0-py3-none-any.whl"
+        }
+      ],
+      "name": "py-serializable",
+      "purl": "pkg:pypi/py-serializable@0.15.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.15.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "referencing@0.30.2",
+      "description": "JSON Referencing + Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "449b6669b6121a9e96a7f9e410b245d471e8d48964c67113ce9afe50c8dd7bdf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/#referencing-0.30.2-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "794ad8003c65938edcdbc027f1933215e0d0ccc0291e3ce20a4d87432b59efc0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/#referencing-0.30.2.tar.gz"
+        }
+      ],
+      "name": "referencing",
+      "purl": "pkg:pypi/referencing@0.30.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.30.2"
+    },
+    {
+      "bom-ref": "rfc3339-validator@0.1.4",
+      "description": "A pure python RFC3339 validator",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4.tar.gz"
+        }
+      ],
+      "name": "rfc3339-validator",
+      "purl": "pkg:pypi/rfc3339-validator@0.1.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.1.4"
+    },
+    {
+      "bom-ref": "rfc3987@1.3.8",
+      "description": "Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3987/#rfc3987-1.3.8-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3987/#rfc3987-1.3.8.tar.gz"
+        }
+      ],
+      "name": "rfc3987",
+      "purl": "pkg:pypi/rfc3987@1.3.8",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.8"
+    },
+    {
+      "bom-ref": "rpds-py@0.12.0",
+      "description": "Python bindings to Rust's persistent data structures (rpds)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c694bee70ece3b232df4678448fdda245fd3b1bb4ba481fb6cd20e13bb784c46"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "30e5ce9f501fb1f970e4a59098028cf20676dee64fc496d55c33e04bbbee097d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d72a4315514e5a0b9837a086cb433b004eea630afb0cc129de76d77654a9606f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eebaf8c76c39604d52852366249ab807fe6f7a3ffb0dd5484b9944917244cdbe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a239303acb0315091d54c7ff36712dba24554993b9a93941cf301391d8a997ee"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ced40cdbb6dd47a032725a038896cceae9ce267d340f59508b23537f05455431"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3c8c0226c71bd0ce9892eaf6afa77ae8f43a3d9313124a03df0b389c01f832de"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b8e11715178f3608874508f08e990d3771e0b8c66c73eb4e183038d600a9b274"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5210a0018c7e09c75fa788648617ebba861ae242944111d3079034e14498223f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "171d9a159f1b2f42a42a64a985e4ba46fc7268c78299272ceba970743a67ee50"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "57ec6baec231bb19bb5fd5fc7bae21231860a1605174b11585660236627e390e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7188ddc1a8887194f984fa4110d5a3d5b9b5cd35f6bafdff1b649049cbc0ce29"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e04581c6117ad9479b6cfae313e212fe0dfa226ac727755f0d539cd54792963"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0a38612d07a36138507d69646c470aedbfe2b75b43a4643f7bd8e51e52779624"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f12d69d568f5647ec503b64932874dade5a20255736c89936bf690951a5e79f5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f8a1d990dc198a6c68ec3d9a637ba1ce489b38cbfb65440a27901afbc5df575"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8c567c664fc2f44130a20edac73e0a867f8e012bf7370276f15c6adc3586c37c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e9e976e0dbed4f51c56db10831c9623d0fd67aac02853fe5476262e5a22acb7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efddca2d02254a52078c35cadad34762adbae3ff01c6b0c7787b59d038b63e0d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d9e7f29c00577aff6b318681e730a519b235af292732a149337f6aaa4d1c5e31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "389c0e38358fdc4e38e9995e7291269a3aead7acfcf8942010ee7bc5baee091c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "33ab498f9ac30598b6406e2be1b45fd231195b83d948ebd4bd77f337cb6a2bff"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d56b1cd606ba4cedd64bb43479d56580e147c6ef3f5d1c5e64203a1adab784a2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1fa73ed22c40a1bec98d7c93b5659cd35abcfa5a0a95ce876b91adbda170537c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dbc25baa6abb205766fb8606f8263b02c3503a55957fcb4576a6bb0a59d37d10"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c6b52b7028b547866c2413f614ee306c2d4eafdd444b1ff656bf3295bf1484aa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9620650c364c01ed5b497dcae7c3d4b948daeae6e1883ae185fef1c927b6b534"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2124f9e645a94ab7c853bc0a3644e0ca8ffbe5bb2d72db49aef8f9ec1c285733"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "281c8b219d4f4b3581b918b816764098d04964915b2f272d1476654143801aa2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27ccc93c7457ef890b0dd31564d2a05e1aca330623c942b7e818e9e7c2669ee4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d1c562a9bb72244fa767d1c1ab55ca1d92dd5f7c4d77878fee5483a22ffac808"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e57919c32ee295a2fca458bb73e4b20b05c115627f96f95a10f9f5acbd61172d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fa35ad36440aaf1ac8332b4a4a433d4acd28f1613f0d480995f5cfd3580e90b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e6aea5c0eb5b0faf52c7b5c4a47c8bb64437173be97227c819ffa31801fa4e34"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81cf9d306c04df1b45971c13167dc3bad625808aa01281d55f3cf852dde0e206"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08e6e7ff286254016b945e1ab632ee843e43d45e40683b66dd12b73791366dd1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d0a675a7acbbc16179188d8c6d0afb8628604fc1241faf41007255957335a0b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2287c09482949e0ca0c0eb68b2aca6cf57f8af8c6dfd29dcd3bc45f17b57978"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8015835494b21aa7abd3b43fdea0614ee35ef6b03db7ecba9beb58eadf01c24f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6174d6ad6b58a6bcf67afbbf1723420a53d06c4b89f4c50763d6fa0a6ac9afd2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a689e1ded7137552bea36305a7a16ad2b40be511740b80748d3140614993db98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f45321224144c25a62052035ce96cbcf264667bcb0d81823b1bbc22c4addd194"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aa32205358a76bf578854bf31698a86dc8b2cb591fd1d79a833283f4a403f04b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "91bd2b7cf0f4d252eec8b7046fa6a43cee17e8acdfc00eaa8b3dbf2f9a59d061"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3acadbab8b59f63b87b518e09c4c64b142e7286b9ca7a208107d6f9f4c393c5c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "429349a510da82c85431f0f3e66212d83efe9fd2850f50f339341b6532c62fe4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05942656cb2cb4989cd50ced52df16be94d344eae5097e8583966a1d27da73a5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0c5441b7626c29dbd54a3f6f3713ec8e956b009f419ffdaaa3c80eaf98ddb523"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b6b0e17d39d21698185097652c611f9cf30f7c56ccec189789920e3e7f1cee56"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3b7a64d43e2a1fa2dd46b678e00cabd9a49ebb123b339ce799204c44a593ae1c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e5bbe011a2cea9060fef1bb3d668a2fd8432b8888e6d92e74c9c794d3c101595"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bec29b801b4adbf388314c0d050e851d53762ab424af22657021ce4b6eb41543"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1096ca0bf2d3426cbe79d4ccc91dc5aaa73629b08ea2d8467375fad8447ce11a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48aa98987d54a46e13e6954880056c204700c65616af4395d1f0639eba11764b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7979d90ee2190d000129598c2b0c82f13053dba432b94e45e68253b09bb1f0f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "88857060b690a57d2ea8569bca58758143c8faa4639fb17d745ce60ff84c867e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4eb74d44776b0fb0782560ea84d986dffec8ddd94947f383eba2284b0f32e35e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f62581d7e884dd01ee1707b7c21148f61f2febb7de092ae2f108743fcbef5985"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6f5dcb658d597410bb7c967c1d24eaf9377b0d621358cbe9d2ff804e5dd12e81"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9bf9acce44e967a5103fcd820fc7580c7b0ab8583eec4e2051aec560f7b31a63"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "240687b5be0f91fbde4936a329c9b7589d9259742766f74de575e1b2046575e4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25740fb56e8bd37692ed380e15ec734be44d7c71974d8993f452b4527814601e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a54917b7e9cd3a67e429a630e237a90b096e0ba18897bfb99ee8bd1068a5fea0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b92aafcfab3d41580d54aca35a8057341f1cfc7c9af9e8bdfc652f83a20ced31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd316dbcc74c76266ba94eb021b0cc090b97cca122f50bd7a845f587ff4bf03f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0853da3d5e9bc6a07b2486054a410b7b03f34046c123c6561b535bb48cc509e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cb41ad20064e18a900dd427d7cf41cfaec83bcd1184001f3d91a1f76b3fcea4e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b710bf7e7ae61957d5c4026b486be593ed3ec3dca3e5be15e0f6d8cf5d0a4990"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a952ae3eb460c6712388ac2ec706d24b0e651b9396d90c9a9e0a69eb27737fdc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0bedd91ae1dd142a4dc15970ed2c729ff6c73f33a40fa84ed0cdbf55de87c777"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "761531076df51309075133a6bc1db02d98ec7f66e22b064b1d513bc909f29743"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a2baa6be130e8a00b6cbb9f18a33611ec150b4537f8563bddadb54c1b74b8193"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f05450fa1cd7c525c0b9d1a7916e595d3041ac0afbed2ff6926e5afb6a781b7f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81c4d1a3a564775c44732b94135d06e33417e829ff25226c164664f4a1046213"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e888be685fa42d8b8a3d3911d5604d14db87538aa7d0b29b1a7ea80d354c732d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6f8d7fe73d1816eeb5378409adc658f9525ecbfaf9e1ede1e2d67a338b0c7348"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0831d3ecdea22e4559cc1793f22e77067c9d8c451d55ae6a75bf1d116a8e7f42"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "513ccbf7420c30e283c25c82d5a8f439d625a838d3ba69e79a110c260c46813f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "301bd744a1adaa2f6a5e06c98f1ac2b6f8dc31a5c23b838f862d65e32fca0d4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f8832a4f83d4782a8f5a7b831c47e8ffe164e43c2c148c8160ed9a6d630bc02a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b2416ed743ec5debcf61e1242e012652a4348de14ecc7df3512da072b074440"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "35585a8cb5917161f42c2104567bb83a1d96194095fc54a543113ed5df9fa436"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d389ff1e95b6e46ebedccf7fd1fadd10559add595ac6a7c2ea730268325f832c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9b007c2444705a2dc4a525964fd4dd28c3320b19b3410da6517cab28716f27d3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "188912b22b6c8225f4c4ffa020a2baa6ad8fabb3c141a12dbe6edbb34e7f1425"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b4cf9ab9a0ae0cb122685209806d3f1dcb63b9fccdf1424fb42a129dc8c2faa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2d34a5450a402b00d20aeb7632489ffa2556ca7b26f4a63c35f6fccae1977427"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "466030a42724780794dea71eb32db83cc51214d66ab3fb3156edd88b9c8f0d78"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "68172622a5a57deb079a2c78511c40f91193548e8ab342c31e8cb0764d362459"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54cdfcda59251b9c2f87a05d038c2ae02121219a04d4a1e6fc345794295bdc07"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b75b912a0baa033350367a8a07a8b2d44fd5b90c890bfbd063a8a5f945f644b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "47aeceb4363851d17f63069318ba5721ae695d9da55d599b4d6fb31508595278"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0525847f83f506aa1e28eb2057b696fe38217e12931c8b1b02198cfe6975e142"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efbe0b5e0fd078ed7b005faa0170da4f72666360f66f0bb2d7f73526ecfd99f9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0fadfdda275c838cba5102c7f90a20f2abd7727bf8f4a2b654a5b617529c5c18"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "56dd500411d03c5e9927a1eb55621e906837a83b02350a9dc401247d0353717c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6915fc9fa6b3ec3569566832e1bb03bd801c12cea030200e68663b9a87974e76"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5f1519b080d8ce0a814f17ad9fb49fb3a1d4d7ce5891f5c85fc38631ca3a8dc4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7036316cc26b93e401cedd781a579be606dad174829e6ad9e9c5a0da6e036f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0.tar.gz"
+        }
+      ],
+      "name": "rpds-py",
+      "purl": "pkg:pypi/rpds-py@0.12.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.12.0"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "sortedcontainers@2.4.0",
+      "description": "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/sortedcontainers/#sortedcontainers-2.4.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/sortedcontainers/#sortedcontainers-2.4.0.tar.gz"
+        }
+      ],
+      "name": "sortedcontainers",
+      "purl": "pkg:pypi/sortedcontainers@2.4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.4.0"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.8.19.14"
+    },
+    {
+      "bom-ref": "uri-template@1.3.0",
+      "description": "RFC 6570 URI Template Processor",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uri-template/#uri-template-1.3.0.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uri-template/#uri_template-1.3.0-py3-none-any.whl"
+        }
+      ],
+      "name": "uri-template",
+      "purl": "pkg:pypi/uri-template@1.3.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "webcolors@1.13",
+      "description": "A library for working with the color formats defined by HTML and CSS.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/webcolors/#webcolors-1.13-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/webcolors/#webcolors-1.13.tar.gz"
+        }
+      ],
+      "name": "webcolors",
+      "purl": "pkg:pypi/webcolors@1.13",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.13"
+    },
+    {
+      "bom-ref": "zipp@3.17.0",
+      "description": "Backport of pathlib-compatible object wrapper for zip files",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/zipp/#zipp-3.17.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/zipp/#zipp-3.17.0.tar.gz"
+        }
+      ],
+      "name": "zipp",
+      "purl": "pkg:pypi/zipp@3.17.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "3.17.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "attrs@23.1.0"
+    },
+    {
+      "ref": "boolean-py@4.0"
+    },
+    {
+      "dependsOn": [
+        "jsonschema@4.19.2",
+        "license-expression@30.1.1",
+        "lxml@4.9.3",
+        "packageurl-python@0.11.2",
+        "py-serializable@0.15.0",
+        "sortedcontainers@2.4.0"
+      ],
+      "ref": "cyclonedx-python-lib@5.1.1"
+    },
+    {
+      "ref": "defusedxml@0.7.1"
+    },
+    {
+      "ref": "fqdn@1.5.1"
+    },
+    {
+      "ref": "idna@3.4"
+    },
+    {
+      "dependsOn": [
+        "zipp@3.17.0"
+      ],
+      "ref": "importlib-resources@6.1.1"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "ref": "jsonpointer@2.4"
+    },
+    {
+      "dependsOn": [
+        "importlib-resources@6.1.1",
+        "referencing@0.30.2"
+      ],
+      "ref": "jsonschema-specifications@2023.7.1"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.1.0",
+        "fqdn@1.5.1",
+        "idna@3.4",
+        "importlib-resources@6.1.1",
+        "isoduration@20.11.0",
+        "jsonpointer@2.4",
+        "jsonschema-specifications@2023.7.1",
+        "pkgutil-resolve-name@1.3.10",
+        "referencing@0.30.2",
+        "rfc3339-validator@0.1.4",
+        "rfc3987@1.3.8",
+        "rpds-py@0.12.0",
+        "uri-template@1.3.0",
+        "webcolors@1.13"
+      ],
+      "ref": "jsonschema@4.19.2"
+    },
+    {
+      "dependsOn": [
+        "boolean-py@4.0"
+      ],
+      "ref": "license-expression@30.1.1"
+    },
+    {
+      "ref": "lxml@4.9.3"
+    },
+    {
+      "ref": "packageurl-python@0.11.2"
+    },
+    {
+      "ref": "pkgutil-resolve-name@1.3.10"
+    },
+    {
+      "dependsOn": [
+        "defusedxml@0.7.1"
+      ],
+      "ref": "py-serializable@0.15.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.1.0",
+        "rpds-py@0.12.0"
+      ],
+      "ref": "referencing@0.30.2"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "rfc3339-validator@0.1.4"
+    },
+    {
+      "ref": "rfc3987@1.3.8"
+    },
+    {
+      "ref": "rpds-py@0.12.0"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "sortedcontainers@2.4.0"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    },
+    {
+      "ref": "uri-template@1.3.0"
+    },
+    {
+      "ref": "webcolors@1.13"
+    },
+    {
+      "dependsOn": [
+        "cyclonedx-python-lib@5.1.1"
+      ],
+      "ref": "with-extras"
+    },
+    {
+      "ref": "zipp@3.17.0"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "with-extras",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "properties": [
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "my-extra"
+        }
+      ],
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/all-extras_with-extras_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/all-extras_with-extras_lock20_1.6.xml.bin
@@ -1,0 +1,2094 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-extras">
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+      <properties>
+        <property name="cdx:python:package:required-extra">my-extra</property>
+      </properties>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="attrs@23.1.0">
+      <name>attrs</name>
+      <version>23.1.0</version>
+      <description>Classes Without Boilerplate</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/attrs@23.1.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/#attrs-23.1.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/#attrs-23.1.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="boolean-py@4.0">
+      <name>boolean-py</name>
+      <version>4.0</version>
+      <description>Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/boolean-py@4.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/boolean-py/#boolean.py-4.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2876f2051d7d6394a531d82dc6eb407faa0b01a0a0b3083817ccd7323b8d96bd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/boolean-py/#boolean.py-4.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">17b9a181630e43dde1851d42bef546d616d5d9b4480357514597e78b203d06e4</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="cyclonedx-python-lib@5.1.1">
+      <name>cyclonedx-python-lib</name>
+      <version>5.1.1</version>
+      <description>Python library for CycloneDX</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/cyclonedx-python-lib@5.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/cyclonedx-python-lib/#cyclonedx_python_lib-5.1.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2989db0cd8bb4c0c442423d71ed7a84ae059e16a2d0f932cc4bf92da7385cdb3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/cyclonedx-python-lib/#cyclonedx_python_lib-5.1.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">215a636a4e77385d2cf4c6c9801c9bad4791849634f2c6daa45ab2c6cb0a85f6</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:required-extra">json-validation</property>
+        <property name="cdx:python:package:required-extra">xml-validation</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="defusedxml@0.7.1">
+      <name>defusedxml</name>
+      <version>0.7.1</version>
+      <description>XML bomb protection for Python stdlib modules</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/defusedxml@0.7.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/defusedxml/#defusedxml-0.7.1-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/defusedxml/#defusedxml-0.7.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="fqdn@1.5.1">
+      <name>fqdn</name>
+      <version>1.5.1</version>
+      <description>Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/fqdn@1.5.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fqdn/#fqdn-1.5.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fqdn/#fqdn-1.5.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="idna@3.4">
+      <name>idna</name>
+      <version>3.4</version>
+      <description>Internationalized Domain Names in Applications (IDNA)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/idna@3.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/#idna-3.4-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/#idna-3.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="importlib-resources@6.1.1">
+      <name>importlib-resources</name>
+      <version>6.1.1</version>
+      <description>Read resources from Python packages</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/importlib-resources@6.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e8bf90d8213b486f428c9c39714b920041cb02c184686a3dee24905aaa8105d6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="jsonpointer@2.4">
+      <name>jsonpointer</name>
+      <version>2.4</version>
+      <description>Identify specific nodes in a JSON document (RFC 6901)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonpointer@2.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonpointer/#jsonpointer-2.4-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonpointer/#jsonpointer-2.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="jsonschema@4.19.2">
+      <name>jsonschema</name>
+      <version>4.19.2</version>
+      <description>An implementation of JSON Schema validation for Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonschema@4.19.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema/#jsonschema-4.19.2-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eee9e502c788e89cb166d4d37f43084e3b64ab405c795c03d343a4dbc2c810fc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema/#jsonschema-4.19.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c9ff4d7447eed9592c23a12ccee508baf0dd0d59650615e847feb6cdca74f392</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:python:package:required-extra">format</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema-specifications@2023.7.1">
+      <name>jsonschema-specifications</name>
+      <version>2023.7.1</version>
+      <description>The JSON Schema meta-schemas and vocabularies, exposed as a Registry</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonschema-specifications@2023.7.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">05adf340b659828a004220a9613be00fa3f223f2b82002e273dee62fd50524b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c91a50404e88a1f6ba40636778e2ee08f6e24c5613fe4c53ac24578a5a7f72bb</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="license-expression@30.1.1">
+      <name>license-expression</name>
+      <version>30.1.1</version>
+      <description>license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/license-expression@30.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/license-expression/#license-expression-30.1.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">42375df653ad85e6f5b4b0385138b2dbea1f5d66360783d8625c3e4f97f11f0c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/license-expression/#license_expression-30.1.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8d7e5e2de0d04fc104a4f952c440e8f08a5ba63480a0dad015b294770b7e58ec</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="lxml@4.9.3">
+      <name>lxml</name>
+      <version>4.9.3</version>
+      <description>Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/lxml@4.9.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b0a545b46b526d418eb91754565ba5b63b1c0b12f9bd2f808c852d9b4b2f9b5c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">075b731ddd9e7f68ad24c635374211376aa05a281673ede86cbe1d1b3455279d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e224d5755dba2f4a9498e150c43792392ac9b5380aa1b845f98a1618c94eeef</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2c74524e179f2ad6d2a4f7caf70e2d96639c0954c943ad601a9e146c76408ed7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1026bc732b6a7f96369f7bfe1a4f2290fb34dce00d8644bc3036fb351a4ca1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c0781a98ff5e6586926293e59480b64ddd46282953203c76ae15dbbbf302e8bb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cef2502e7e8a96fe5ad686d60b49e1ab03e438bd9123987994528febd569868e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b86164d2cff4d3aaa1f04a14685cbc072efd0b4f99ca5708b2ad1b9b5988a991</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">42871176e7896d5d45138f6d28751053c711ed4d48d8e30b498da155af39aebd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ae8b9c6deb1e634ba4f1930eb67ef6e6bf6a44b6eb5ad605642b2d6d5ed9ce3c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_28_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">411007c0d88188d9f621b11d252cce90c4a2d1a49db6c068e3c16422f306eab8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd47b4a0d41d2afa3e58e5bf1f62069255aa2fd6ff5ee41604418ca925911d76</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e2cb47860da1f7e9a5256254b74ae331687b9672dfa780eed355c4c9c3dbd23</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1247694b26342a7bf47c02e513d32225ededd18045264d40758abeb3c838a51f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cdb650fc86227eba20de1a29d4b2c1bfe139dc75a0669270033cb2ea3d391b85</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">97047f0d25cd4bcae81f9ec9dc290ca3e15927c192df17331b53bebe0e3ff96d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-macosx_11_0_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f447ea5429b54f9582d4b955f5f1985f278ce5cf169f72eea8afd9502973dd5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">57d6ba0ca2b0c462f339640d22882acc711de224d769edf29962b09f77129cbf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9767e79108424fb6c3edf8f81e6730666a50feb01a328f4a016464a5893f835a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_28_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">71c52db65e4b56b8ddc5bb89fb2e66c558ed9d1a74a45ceb7dcb20c191c3df2f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d73d8ecf8ecf10a3bd007f2192725a34bd62898e8da27eb9d32a58084f93962b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0a3d3487f07c1d7f150894c238299934a2a074ef590b583103a45002035be120</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9e28c51fa0ce5674be9f560c6761c1b441631901993f76700b1b30ca6c8378d6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0bfd0767c5c1de2551a120673b72e5d4b628737cb05414f03c3277bf9bed3305</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">25f32acefac14ef7bd53e4218fe93b804ef6f6b92ffdb4322bb6d49d94cad2bc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-macosx_11_0_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d3ff32724f98fbbbfa9f49d82852b159e9784d6094983d9a8b7f2ddaebb063d4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-manylinux_2_28_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48d6ed886b343d11493129e019da91d4039826794a3e3027321c56d9e71505be</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9a92d3faef50658dd2c5470af249985782bf754c4e18e15afb67d3ab06233f13</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b4e4bc18382088514ebde9328da057775055940a1f2e18f6ad2d78aa0f3ec5b9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fc9b106a1bf918db68619fdcd6d5ad4f972fdd19c01d19bdb6bf63f3589a9ec5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d37017287a7adb6ab77e1c5bee9bcf9660f90ff445042b790402a654d2ad81d8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">56dc1f1ebccc656d1b3ed288f11e27172a01503fc016bcabdcbc0978b19352b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">578695735c5a3f51569810dfebd05dd6f888147a34f0f98d4bb27e92b76e05c2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">704f61ba8c1283c71b16135caf697557f5ecf3e74d9e453233e4771d68a1f42d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c41bfca0bd3532d53d16fd34d20806d5c2b1ace22a2f2e4c0008570bf2c58833</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">64f479d719dc9f4c813ad9bb6b28f8390360660b73b2e4beb4cb0ae7104f1c12</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dd708cf4ee4408cf46a48b108fb9427bfa00b9b85812a9262b5c668af2533ea5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5c31c7462abdf8f2ac0577d9f05279727e698f97ecbb02f17939ea99ae8daa98</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e3cd95e10c2610c360154afdc2f1480aea394f4a4f1ea0a5eacce49640c9b190</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4930be26af26ac545c3dffb662521d4e6268352866956672231887d18f0eaab2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4aec80cde9197340bc353d2768e2a75f5f60bacda2bab72ab1dc499589b3878c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">14e019fd83b831b2e61baed40cab76222139926b1fb5ed0e79225bc0cae14584</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0c0850c8b02c298d3c7006b23e98249515ac57430e16a166873fc47a5d549287</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aca086dc5f9ef98c512bac8efea4483eb84abbf926eaeedf7b91479feb092458</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">50baa9c1c47efcaef189f31e3d00d697c6d4afda5c3cde0302d063492ff9b477</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bef4e656f7d98aaa3486d2627e7d2df1157d7e88e7efd43a65aa5dd4714916cf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">46f409a2d60f634fe550f7133ed30ad5321ae2e6630f13657fb9479506b00601</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4c28a9144688aef80d6ea666c809b4b0e50010a2aca784c97f5e6bf143d9f129</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">141f1d1a9b663c679dc524af3ea1773e618907e96075262726c7612c02b149a4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">53ace1c1fd5a74ef662f844a0413446c0629d151055340e9893da958a374f70d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">17a753023436a18e27dd7769e798ce302963c236bc4114ceee5b25c18c52c693</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7d298a1bd60c067ea75d9f684f5f3992c9d6766fadbc0bcedd39750bf344c2f4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">081d32421db5df44c41b7f08a334a090a545c54ba977e47fd7cc2deece78809a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">23eed6d7b1a3336ad92d8e39d4bfe09073c31bfe502f20ca5116b2a334f8ec02</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1509dd12b773c02acd154582088820893109f6ca27ef7291b003d0e81666109f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">120fa9349a24c7043854c53cae8cec227e1f79195a7493e09e0c12e29f918e52</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d2d1edbca80b510443f51afd8496be95529db04a509bc8faee49c7b0fb6d2cc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8d7e43bd40f65f7d97ad8ef5c9b1778943d02f04febef12def25f7583d19baac</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">71d66ee82e7417828af6ecd7db817913cb0cf9d4e61aa0ac1fde0583d84358db</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6fc3c450eaa0b56f815c7b62f2b7fba7266c4779adcf1cece9e6deb1de7305ce</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">65299ea57d82fb91c7f019300d24050c4ddeb7c5a190e076b5f48a2b43d19c42</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eadfbbbfb41b44034a4c757fd5d70baccd43296fb894dba0295606a7cf3124aa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3e9bdd30efde2b9ccfa9cb5768ba04fe71b018a25ea093379c857c9dad262c40</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fcdd00edfd0a3001e0181eab3e63bd5c74ad3e67152c84f93f13769a40e073a7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">57aba1bbdf450b726d58b2aea5fe47c7875f5afb2c4a23784ed78f19a0462574</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">92af161ecbdb2883c4593d5ed4815ea71b31fafd7fd05789b23100d081ecac96</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9bb6ad405121241e99a86efff22d3ef469024ce22875a7ae045896ad23ba2340</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8ed74706b26ad100433da4b9d807eae371efaa266ffc3e9191ea436087a9d6a7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fbf521479bcac1e25a663df882c46a641a9bff6b56dc8b0fafaebd2f66fb231b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_28_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">303bf1edce6ced16bf67a18a1cf8339d0db79577eec5d9a6d4a80f0fb10aa2da</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5515edd2a6d1a5a70bfcdee23b42ec33425e405c5b351478ab7dc9347228f96e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">690dafd0b187ed38583a648076865d8c229661ed20e48f2335d68e2cf7dc829d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b6420a005548ad52154c8ceab4a1290ff78d757f9e5cbc68f8c77089acd3c432</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bb3bb49c7a6ad9d981d734ef7c7193bc349ac338776a0360cc671eaee89bcf69</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d27be7405547d1f958b60837dc4c1007da90b8b23f54ba1f8b728c78fdb19d50</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8df133a2ea5e74eef5e8fc6f19b9e085f758768a16e9877a60aec455ed2609b2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4dd9a263e845a72eacb60d12401e37c616438ea2e5442885f65082c276dfb2b2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6689a3d7fd13dc687e9102a27e98ef33730ac4fe37795d5036d18b4d527abd35</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f6bdac493b949141b733c5345b6ba8f87a226029cbabc7e9e121a413e49441e0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">05186a0f1346ae12553d66df1cfce6f251589fea3ad3da4f3ef4e34b2d58c6a3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c2006f5c8d28dee289f7020f721354362fa304acbaaf9745751ac4006650254b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5c245b783db29c4e4fbbbfc9c5a78be496c9fea25517f90606aa1f6b2b3d5f7b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4fb960a632a49f2f089d522f70496640fdf1218f1243889da3822e0a9f5f3ba7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">50670615eaf97227d5dc60de2dc99fb134a7130d310d783314e7724bf163f75d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9719fe17307a9e814580af1f5c6e05ca593b12fb7e44fe62450a5384dbf61b4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3331bece23c9ee066e0fb3f96c61322b9e0f54d775fccefff4c38ca488de283a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ed667f49b11360951e201453fc3967344d0d0263aa415e1619e85ae7fd17b4e0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8b77946fd508cbf0fccd8e400a7f71d4ac0e1595812e66025bac475a8e811694</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e4da8ca0c0c0aea88fd46be8e44bd49716772358d648cce45fe387f7b92374a7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fe4bda6bd4340caa6e5cf95e73f8fea5c4bfc55763dd42f1b50a94c1b4a2fbd4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f3df3db1d336b9356dd3112eae5f5c2b8b377f3bc826848567f10bfddfee77e9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48628bd53a426c9eb9bc066a923acaa0878d1e86129fd5359aee99285f4eed9c</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="packageurl-python@0.11.2">
+      <name>packageurl-python</name>
+      <version>0.11.2</version>
+      <description>A purl aka. Package URL parser and builder</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/packageurl-python@0.11.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/packageurl-python/#packageurl-python-0.11.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">01fbf74a41ef85cf413f1ede529a1411f658bda66ed22d45d27280ad9ceba471</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/packageurl-python/#packageurl_python-0.11.2-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">799acfe8d9e6e3534bbc19660be97d5b66754bc033e62c39f1e2f16323fcfa84</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkgutil-resolve-name@1.3.10">
+      <name>pkgutil-resolve-name</name>
+      <version>1.3.10</version>
+      <description>Resolve a name to an object.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/pkgutil-resolve-name@1.3.10</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="py-serializable@0.15.0">
+      <name>py-serializable</name>
+      <version>0.15.0</version>
+      <description>Library for serializing and deserializing Python Objects to and from JSON and XML.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/py-serializable@0.15.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-serializable/#py-serializable-0.15.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8fc41457d8ee5f5c5a12f41fd87bf1a4f2ecf9da39fee92059b728e78f320771</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-serializable/#py_serializable-0.15.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d3f1201b33420c481aa83f7860c7bf2c2f036ba3ea82b6e15a96696457c36cd2</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="referencing@0.30.2">
+      <name>referencing</name>
+      <version>0.30.2</version>
+      <description>JSON Referencing + Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/referencing@0.30.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/#referencing-0.30.2-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">449b6669b6121a9e96a7f9e410b245d471e8d48964c67113ce9afe50c8dd7bdf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/#referencing-0.30.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">794ad8003c65938edcdbc027f1933215e0d0ccc0291e3ce20a4d87432b59efc0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="rfc3339-validator@0.1.4">
+      <name>rfc3339-validator</name>
+      <version>0.1.4</version>
+      <description>A pure python RFC3339 validator</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rfc3339-validator@0.1.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="rfc3987@1.3.8">
+      <name>rfc3987</name>
+      <version>1.3.8</version>
+      <description>Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rfc3987@1.3.8</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3987/#rfc3987-1.3.8-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3987/#rfc3987-1.3.8.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="rpds-py@0.12.0">
+      <name>rpds-py</name>
+      <version>0.12.0</version>
+      <description>Python bindings to Rust's persistent data structures (rpds)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rpds-py@0.12.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c694bee70ece3b232df4678448fdda245fd3b1bb4ba481fb6cd20e13bb784c46</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">30e5ce9f501fb1f970e4a59098028cf20676dee64fc496d55c33e04bbbee097d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d72a4315514e5a0b9837a086cb433b004eea630afb0cc129de76d77654a9606f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eebaf8c76c39604d52852366249ab807fe6f7a3ffb0dd5484b9944917244cdbe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a239303acb0315091d54c7ff36712dba24554993b9a93941cf301391d8a997ee</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ced40cdbb6dd47a032725a038896cceae9ce267d340f59508b23537f05455431</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3c8c0226c71bd0ce9892eaf6afa77ae8f43a3d9313124a03df0b389c01f832de</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b8e11715178f3608874508f08e990d3771e0b8c66c73eb4e183038d600a9b274</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5210a0018c7e09c75fa788648617ebba861ae242944111d3079034e14498223f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">171d9a159f1b2f42a42a64a985e4ba46fc7268c78299272ceba970743a67ee50</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">57ec6baec231bb19bb5fd5fc7bae21231860a1605174b11585660236627e390e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7188ddc1a8887194f984fa4110d5a3d5b9b5cd35f6bafdff1b649049cbc0ce29</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e04581c6117ad9479b6cfae313e212fe0dfa226ac727755f0d539cd54792963</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0a38612d07a36138507d69646c470aedbfe2b75b43a4643f7bd8e51e52779624</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f12d69d568f5647ec503b64932874dade5a20255736c89936bf690951a5e79f5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f8a1d990dc198a6c68ec3d9a637ba1ce489b38cbfb65440a27901afbc5df575</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8c567c664fc2f44130a20edac73e0a867f8e012bf7370276f15c6adc3586c37c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e9e976e0dbed4f51c56db10831c9623d0fd67aac02853fe5476262e5a22acb7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efddca2d02254a52078c35cadad34762adbae3ff01c6b0c7787b59d038b63e0d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d9e7f29c00577aff6b318681e730a519b235af292732a149337f6aaa4d1c5e31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">389c0e38358fdc4e38e9995e7291269a3aead7acfcf8942010ee7bc5baee091c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">33ab498f9ac30598b6406e2be1b45fd231195b83d948ebd4bd77f337cb6a2bff</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d56b1cd606ba4cedd64bb43479d56580e147c6ef3f5d1c5e64203a1adab784a2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1fa73ed22c40a1bec98d7c93b5659cd35abcfa5a0a95ce876b91adbda170537c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dbc25baa6abb205766fb8606f8263b02c3503a55957fcb4576a6bb0a59d37d10</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c6b52b7028b547866c2413f614ee306c2d4eafdd444b1ff656bf3295bf1484aa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9620650c364c01ed5b497dcae7c3d4b948daeae6e1883ae185fef1c927b6b534</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2124f9e645a94ab7c853bc0a3644e0ca8ffbe5bb2d72db49aef8f9ec1c285733</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">281c8b219d4f4b3581b918b816764098d04964915b2f272d1476654143801aa2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">27ccc93c7457ef890b0dd31564d2a05e1aca330623c942b7e818e9e7c2669ee4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d1c562a9bb72244fa767d1c1ab55ca1d92dd5f7c4d77878fee5483a22ffac808</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e57919c32ee295a2fca458bb73e4b20b05c115627f96f95a10f9f5acbd61172d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fa35ad36440aaf1ac8332b4a4a433d4acd28f1613f0d480995f5cfd3580e90b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e6aea5c0eb5b0faf52c7b5c4a47c8bb64437173be97227c819ffa31801fa4e34</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">81cf9d306c04df1b45971c13167dc3bad625808aa01281d55f3cf852dde0e206</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08e6e7ff286254016b945e1ab632ee843e43d45e40683b66dd12b73791366dd1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d0a675a7acbbc16179188d8c6d0afb8628604fc1241faf41007255957335a0b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2287c09482949e0ca0c0eb68b2aca6cf57f8af8c6dfd29dcd3bc45f17b57978</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8015835494b21aa7abd3b43fdea0614ee35ef6b03db7ecba9beb58eadf01c24f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6174d6ad6b58a6bcf67afbbf1723420a53d06c4b89f4c50763d6fa0a6ac9afd2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a689e1ded7137552bea36305a7a16ad2b40be511740b80748d3140614993db98</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f45321224144c25a62052035ce96cbcf264667bcb0d81823b1bbc22c4addd194</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aa32205358a76bf578854bf31698a86dc8b2cb591fd1d79a833283f4a403f04b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">91bd2b7cf0f4d252eec8b7046fa6a43cee17e8acdfc00eaa8b3dbf2f9a59d061</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3acadbab8b59f63b87b518e09c4c64b142e7286b9ca7a208107d6f9f4c393c5c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">429349a510da82c85431f0f3e66212d83efe9fd2850f50f339341b6532c62fe4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">05942656cb2cb4989cd50ced52df16be94d344eae5097e8583966a1d27da73a5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0c5441b7626c29dbd54a3f6f3713ec8e956b009f419ffdaaa3c80eaf98ddb523</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b6b0e17d39d21698185097652c611f9cf30f7c56ccec189789920e3e7f1cee56</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3b7a64d43e2a1fa2dd46b678e00cabd9a49ebb123b339ce799204c44a593ae1c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e5bbe011a2cea9060fef1bb3d668a2fd8432b8888e6d92e74c9c794d3c101595</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bec29b801b4adbf388314c0d050e851d53762ab424af22657021ce4b6eb41543</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1096ca0bf2d3426cbe79d4ccc91dc5aaa73629b08ea2d8467375fad8447ce11a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48aa98987d54a46e13e6954880056c204700c65616af4395d1f0639eba11764b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7979d90ee2190d000129598c2b0c82f13053dba432b94e45e68253b09bb1f0f6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">88857060b690a57d2ea8569bca58758143c8faa4639fb17d745ce60ff84c867e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4eb74d44776b0fb0782560ea84d986dffec8ddd94947f383eba2284b0f32e35e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f62581d7e884dd01ee1707b7c21148f61f2febb7de092ae2f108743fcbef5985</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6f5dcb658d597410bb7c967c1d24eaf9377b0d621358cbe9d2ff804e5dd12e81</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9bf9acce44e967a5103fcd820fc7580c7b0ab8583eec4e2051aec560f7b31a63</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">240687b5be0f91fbde4936a329c9b7589d9259742766f74de575e1b2046575e4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">25740fb56e8bd37692ed380e15ec734be44d7c71974d8993f452b4527814601e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a54917b7e9cd3a67e429a630e237a90b096e0ba18897bfb99ee8bd1068a5fea0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b92aafcfab3d41580d54aca35a8057341f1cfc7c9af9e8bdfc652f83a20ced31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd316dbcc74c76266ba94eb021b0cc090b97cca122f50bd7a845f587ff4bf03f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0853da3d5e9bc6a07b2486054a410b7b03f34046c123c6561b535bb48cc509e1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cb41ad20064e18a900dd427d7cf41cfaec83bcd1184001f3d91a1f76b3fcea4e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b710bf7e7ae61957d5c4026b486be593ed3ec3dca3e5be15e0f6d8cf5d0a4990</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a952ae3eb460c6712388ac2ec706d24b0e651b9396d90c9a9e0a69eb27737fdc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0bedd91ae1dd142a4dc15970ed2c729ff6c73f33a40fa84ed0cdbf55de87c777</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">761531076df51309075133a6bc1db02d98ec7f66e22b064b1d513bc909f29743</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a2baa6be130e8a00b6cbb9f18a33611ec150b4537f8563bddadb54c1b74b8193</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f05450fa1cd7c525c0b9d1a7916e595d3041ac0afbed2ff6926e5afb6a781b7f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">81c4d1a3a564775c44732b94135d06e33417e829ff25226c164664f4a1046213</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e888be685fa42d8b8a3d3911d5604d14db87538aa7d0b29b1a7ea80d354c732d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6f8d7fe73d1816eeb5378409adc658f9525ecbfaf9e1ede1e2d67a338b0c7348</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0831d3ecdea22e4559cc1793f22e77067c9d8c451d55ae6a75bf1d116a8e7f42</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">513ccbf7420c30e283c25c82d5a8f439d625a838d3ba69e79a110c260c46813f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">301bd744a1adaa2f6a5e06c98f1ac2b6f8dc31a5c23b838f862d65e32fca0d4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f8832a4f83d4782a8f5a7b831c47e8ffe164e43c2c148c8160ed9a6d630bc02a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4b2416ed743ec5debcf61e1242e012652a4348de14ecc7df3512da072b074440</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">35585a8cb5917161f42c2104567bb83a1d96194095fc54a543113ed5df9fa436</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d389ff1e95b6e46ebedccf7fd1fadd10559add595ac6a7c2ea730268325f832c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9b007c2444705a2dc4a525964fd4dd28c3320b19b3410da6517cab28716f27d3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">188912b22b6c8225f4c4ffa020a2baa6ad8fabb3c141a12dbe6edbb34e7f1425</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1b4cf9ab9a0ae0cb122685209806d3f1dcb63b9fccdf1424fb42a129dc8c2faa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2d34a5450a402b00d20aeb7632489ffa2556ca7b26f4a63c35f6fccae1977427</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">466030a42724780794dea71eb32db83cc51214d66ab3fb3156edd88b9c8f0d78</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">68172622a5a57deb079a2c78511c40f91193548e8ab342c31e8cb0764d362459</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">54cdfcda59251b9c2f87a05d038c2ae02121219a04d4a1e6fc345794295bdc07</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b75b912a0baa033350367a8a07a8b2d44fd5b90c890bfbd063a8a5f945f644b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">47aeceb4363851d17f63069318ba5721ae695d9da55d599b4d6fb31508595278</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0525847f83f506aa1e28eb2057b696fe38217e12931c8b1b02198cfe6975e142</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efbe0b5e0fd078ed7b005faa0170da4f72666360f66f0bb2d7f73526ecfd99f9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0fadfdda275c838cba5102c7f90a20f2abd7727bf8f4a2b654a5b617529c5c18</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">56dd500411d03c5e9927a1eb55621e906837a83b02350a9dc401247d0353717c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6915fc9fa6b3ec3569566832e1bb03bd801c12cea030200e68663b9a87974e76</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5f1519b080d8ce0a814f17ad9fb49fb3a1d4d7ce5891f5c85fc38631ca3a8dc4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7036316cc26b93e401cedd781a579be606dad174829e6ad9e9c5a0da6e036f80</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="sortedcontainers@2.4.0">
+      <name>sortedcontainers</name>
+      <version>2.4.0</version>
+      <description>Sorted Containers -- Sorted List, Sorted Dict, Sorted Set</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/sortedcontainers@2.4.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/sortedcontainers/#sortedcontainers-2.4.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/sortedcontainers/#sortedcontainers-2.4.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="uri-template@1.3.0">
+      <name>uri-template</name>
+      <version>1.3.0</version>
+      <description>RFC 6570 URI Template Processor</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/uri-template@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uri-template/#uri-template-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uri-template/#uri_template-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="webcolors@1.13">
+      <name>webcolors</name>
+      <version>1.13</version>
+      <description>A library for working with the color formats defined by HTML and CSS.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/webcolors@1.13</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/webcolors/#webcolors-1.13-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/webcolors/#webcolors-1.13.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="zipp@3.17.0">
+      <name>zipp</name>
+      <version>3.17.0</version>
+      <description>Backport of pathlib-compatible object wrapper for zip files</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/zipp@3.17.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/zipp/#zipp-3.17.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/zipp/#zipp-3.17.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="attrs@23.1.0"/>
+    <dependency ref="boolean-py@4.0"/>
+    <dependency ref="cyclonedx-python-lib@5.1.1">
+      <dependency ref="jsonschema@4.19.2"/>
+      <dependency ref="license-expression@30.1.1"/>
+      <dependency ref="lxml@4.9.3"/>
+      <dependency ref="packageurl-python@0.11.2"/>
+      <dependency ref="py-serializable@0.15.0"/>
+      <dependency ref="sortedcontainers@2.4.0"/>
+    </dependency>
+    <dependency ref="defusedxml@0.7.1"/>
+    <dependency ref="fqdn@1.5.1"/>
+    <dependency ref="idna@3.4"/>
+    <dependency ref="importlib-resources@6.1.1">
+      <dependency ref="zipp@3.17.0"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="jsonpointer@2.4"/>
+    <dependency ref="jsonschema-specifications@2023.7.1">
+      <dependency ref="importlib-resources@6.1.1"/>
+      <dependency ref="referencing@0.30.2"/>
+    </dependency>
+    <dependency ref="jsonschema@4.19.2">
+      <dependency ref="attrs@23.1.0"/>
+      <dependency ref="fqdn@1.5.1"/>
+      <dependency ref="idna@3.4"/>
+      <dependency ref="importlib-resources@6.1.1"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="jsonpointer@2.4"/>
+      <dependency ref="jsonschema-specifications@2023.7.1"/>
+      <dependency ref="pkgutil-resolve-name@1.3.10"/>
+      <dependency ref="referencing@0.30.2"/>
+      <dependency ref="rfc3339-validator@0.1.4"/>
+      <dependency ref="rfc3987@1.3.8"/>
+      <dependency ref="rpds-py@0.12.0"/>
+      <dependency ref="uri-template@1.3.0"/>
+      <dependency ref="webcolors@1.13"/>
+    </dependency>
+    <dependency ref="license-expression@30.1.1">
+      <dependency ref="boolean-py@4.0"/>
+    </dependency>
+    <dependency ref="lxml@4.9.3"/>
+    <dependency ref="packageurl-python@0.11.2"/>
+    <dependency ref="pkgutil-resolve-name@1.3.10"/>
+    <dependency ref="py-serializable@0.15.0">
+      <dependency ref="defusedxml@0.7.1"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="referencing@0.30.2">
+      <dependency ref="attrs@23.1.0"/>
+      <dependency ref="rpds-py@0.12.0"/>
+    </dependency>
+    <dependency ref="rfc3339-validator@0.1.4">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="rfc3987@1.3.8"/>
+    <dependency ref="rpds-py@0.12.0"/>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="sortedcontainers@2.4.0"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+    <dependency ref="uri-template@1.3.0"/>
+    <dependency ref="webcolors@1.13"/>
+    <dependency ref="with-extras">
+      <dependency ref="cyclonedx-python-lib@5.1.1"/>
+    </dependency>
+    <dependency ref="zipp@3.17.0"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/no-dev_group-deps_lock11_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/no-dev_group-deps_lock11_1.6.json.bin
@@ -1,0 +1,80 @@
+{
+  "components": [
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "toml@0.10.2"
+      ],
+      "ref": "group-deps"
+    },
+    {
+      "ref": "toml@0.10.2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "group-deps",
+      "description": "dependencies organized in groups",
+      "name": "group-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/no-dev_group-deps_lock11_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/no-dev_group-deps_lock11_1.6.xml.bin
@@ -1,0 +1,85 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="group-deps">
+      <name>group-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="group-deps">
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="toml@0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/no-dev_group-deps_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/no-dev_group-deps_lock20_1.6.json.bin
@@ -1,0 +1,80 @@
+{
+  "components": [
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "toml@0.10.2"
+      ],
+      "ref": "group-deps"
+    },
+    {
+      "ref": "toml@0.10.2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "group-deps",
+      "description": "dependencies organized in groups",
+      "name": "group-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/no-dev_group-deps_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/no-dev_group-deps_lock20_1.6.xml.bin
@@ -1,0 +1,85 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="group-deps">
+      <name>group-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="group-deps">
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="toml@0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/no-dev_main-and-dev_lock10_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/no-dev_main-and-dev_lock10_1.6.json.bin
@@ -1,0 +1,294 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.20240106",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f8db221c3b98e6ca02ea83a58371b22c374f42ae5bbdf186db9c9a76581459f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.20240106.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efbbdc54590d0f16152fa103c9879c7d4a00e82078f6e2cf01769042165acaa2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.20240106-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.20240106",
+      "type": "library",
+      "version": "2.8.19.20240106"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.20240106"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0",
+        "colorama@0.4.6",
+        "toml@0.10.2"
+      ],
+      "ref": "main-and-dev"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.20240106"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "main-and-dev",
+      "description": "main and dev depenndencies",
+      "name": "main-and-dev",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/no-dev_main-and-dev_lock10_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/no-dev_main-and-dev_lock10_1.6.xml.bin
@@ -1,0 +1,222 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="main-and-dev">
+      <name>main-and-dev</name>
+      <version>0.1.0</version>
+      <description>main and dev depenndencies</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.20240106">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.20240106</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.20240106</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.20240106.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f8db221c3b98e6ca02ea83a58371b22c374f42ae5bbdf186db9c9a76581459f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.20240106-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efbbdc54590d0f16152fa103c9879c7d4a00e82078f6e2cf01769042165acaa2</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.20240106"/>
+    </dependency>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="main-and-dev">
+      <dependency ref="arrow@1.3.0"/>
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="types-python-dateutil@2.8.19.20240106"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/no-dev_main-and-dev_lock11_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/no-dev_main-and-dev_lock11_1.6.json.bin
@@ -1,0 +1,294 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.20240106",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f8db221c3b98e6ca02ea83a58371b22c374f42ae5bbdf186db9c9a76581459f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.20240106.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efbbdc54590d0f16152fa103c9879c7d4a00e82078f6e2cf01769042165acaa2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.20240106-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.20240106",
+      "type": "library",
+      "version": "2.8.19.20240106"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.20240106"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0",
+        "colorama@0.4.6",
+        "toml@0.10.2"
+      ],
+      "ref": "main-and-dev"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.20240106"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "main-and-dev",
+      "description": "main and dev depenndencies",
+      "name": "main-and-dev",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/no-dev_main-and-dev_lock11_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/no-dev_main-and-dev_lock11_1.6.xml.bin
@@ -1,0 +1,222 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="main-and-dev">
+      <name>main-and-dev</name>
+      <version>0.1.0</version>
+      <description>main and dev depenndencies</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.20240106">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.20240106</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.20240106</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.20240106.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f8db221c3b98e6ca02ea83a58371b22c374f42ae5bbdf186db9c9a76581459f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.20240106-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efbbdc54590d0f16152fa103c9879c7d4a00e82078f6e2cf01769042165acaa2</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.20240106"/>
+    </dependency>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="main-and-dev">
+      <dependency ref="arrow@1.3.0"/>
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="types-python-dateutil@2.8.19.20240106"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/no-dev_main-and-dev_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/no-dev_main-and-dev_lock20_1.6.json.bin
@@ -1,0 +1,276 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.20240106",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f8db221c3b98e6ca02ea83a58371b22c374f42ae5bbdf186db9c9a76581459f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.20240106.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efbbdc54590d0f16152fa103c9879c7d4a00e82078f6e2cf01769042165acaa2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.20240106-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.20240106",
+      "type": "library",
+      "version": "2.8.19.20240106"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.20240106"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0",
+        "colorama@0.4.6",
+        "toml@0.10.2"
+      ],
+      "ref": "main-and-dev"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.20240106"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "main-and-dev",
+      "description": "main and dev depenndencies",
+      "name": "main-and-dev",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/no-dev_main-and-dev_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/no-dev_main-and-dev_lock20_1.6.xml.bin
@@ -1,0 +1,213 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="main-and-dev">
+      <name>main-and-dev</name>
+      <version>0.1.0</version>
+      <description>main and dev depenndencies</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.20240106">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.20240106</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.20240106</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.20240106.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f8db221c3b98e6ca02ea83a58371b22c374f42ae5bbdf186db9c9a76581459f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.20240106-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efbbdc54590d0f16152fa103c9879c7d4a00e82078f6e2cf01769042165acaa2</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.20240106"/>
+    </dependency>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="main-and-dev">
+      <dependency ref="arrow@1.3.0"/>
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="types-python-dateutil@2.8.19.20240106"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/only-groups_group-deps_lock11_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/only-groups_group-deps_lock11_1.6.json.bin
@@ -1,0 +1,258 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        },
+        {
+          "name": "cdx:poetry:group",
+          "value": "groupB"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "dependsOn": [
+        "isoduration@20.11.0"
+      ],
+      "ref": "group-deps"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "group-deps",
+      "description": "dependencies organized in groups",
+      "name": "group-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/only-groups_group-deps_lock11_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/only-groups_group-deps_lock11_1.6.xml.bin
@@ -1,0 +1,197 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="group-deps">
+      <name>group-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+        <property name="cdx:poetry:group">groupB</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="group-deps">
+      <dependency ref="isoduration@20.11.0"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/only-groups_group-deps_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/only-groups_group-deps_lock20_1.6.json.bin
@@ -1,0 +1,230 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "groupB"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "dependsOn": [
+        "isoduration@20.11.0"
+      ],
+      "ref": "group-deps"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "group-deps",
+      "description": "dependencies organized in groups",
+      "name": "group-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/only-groups_group-deps_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/only-groups_group-deps_lock20_1.6.xml.bin
@@ -1,0 +1,184 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="group-deps">
+      <name>group-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">groupB</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="group-deps">
+      <dependency ref="isoduration@20.11.0"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_group-deps_lock11_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_group-deps_lock11_1.6.json.bin
@@ -1,0 +1,342 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "ddt@1.7.0",
+      "description": "Data-Driven/Decorated Tests",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a0719acde99dd32767cff64e653ef99c01ad5b042ff265f2ebecd28796ffd114"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ddt/#ddt-1.7.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d178d115abf25a1b8327e94f85a03ef09b1d7b0ca256f6203284b024f2fc70df"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ddt/#ddt-1.7.0.tar.gz"
+        }
+      ],
+      "name": "ddt",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/ddt@1.7.0",
+      "type": "library",
+      "version": "1.7.0"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        },
+        {
+          "name": "cdx:poetry:group",
+          "value": "groupB"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "ddt@1.7.0"
+    },
+    {
+      "dependsOn": [
+        "ddt@1.7.0",
+        "isoduration@20.11.0",
+        "toml@0.10.2"
+      ],
+      "ref": "group-deps"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "group-deps",
+      "description": "dependencies organized in groups",
+      "name": "group-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_group-deps_lock11_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_group-deps_lock11_1.6.xml.bin
@@ -1,0 +1,251 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="group-deps">
+      <name>group-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="ddt@1.7.0">
+      <name>ddt</name>
+      <version>1.7.0</version>
+      <description>Data-Driven/Decorated Tests</description>
+      <purl>pkg:pypi/ddt@1.7.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ddt/#ddt-1.7.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a0719acde99dd32767cff64e653ef99c01ad5b042ff265f2ebecd28796ffd114</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ddt/#ddt-1.7.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d178d115abf25a1b8327e94f85a03ef09b1d7b0ca256f6203284b024f2fc70df</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+        <property name="cdx:poetry:group">groupB</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="ddt@1.7.0"/>
+    <dependency ref="group-deps">
+      <dependency ref="ddt@1.7.0"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_group-deps_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_group-deps_lock20_1.6.json.bin
@@ -1,0 +1,314 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "ddt@1.7.0",
+      "description": "Data-Driven/Decorated Tests",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a0719acde99dd32767cff64e653ef99c01ad5b042ff265f2ebecd28796ffd114"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ddt/#ddt-1.7.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d178d115abf25a1b8327e94f85a03ef09b1d7b0ca256f6203284b024f2fc70df"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ddt/#ddt-1.7.0.tar.gz"
+        }
+      ],
+      "name": "ddt",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/ddt@1.7.0",
+      "type": "library",
+      "version": "1.7.0"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "groupB"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "ddt@1.7.0"
+    },
+    {
+      "dependsOn": [
+        "ddt@1.7.0",
+        "isoduration@20.11.0",
+        "toml@0.10.2"
+      ],
+      "ref": "group-deps"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "group-deps",
+      "description": "dependencies organized in groups",
+      "name": "group-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_group-deps_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_group-deps_lock20_1.6.xml.bin
@@ -1,0 +1,238 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="group-deps">
+      <name>group-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="ddt@1.7.0">
+      <name>ddt</name>
+      <version>1.7.0</version>
+      <description>Data-Driven/Decorated Tests</description>
+      <purl>pkg:pypi/ddt@1.7.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ddt/#ddt-1.7.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a0719acde99dd32767cff64e653ef99c01ad5b042ff265f2ebecd28796ffd114</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ddt/#ddt-1.7.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d178d115abf25a1b8327e94f85a03ef09b1d7b0ca256f6203284b024f2fc70df</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">groupB</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="ddt@1.7.0"/>
+    <dependency ref="group-deps">
+      <dependency ref="ddt@1.7.0"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_local_lock10_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_local_lock10_1.6.json.bin
@@ -1,0 +1,98 @@
+{
+  "components": [
+    {
+      "bom-ref": "package-a@23.42",
+      "description": "some package A",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3869fe3f4a6cca5b203b2e2cd8858c834f651e1b0fa76d5c0232e36472199592"
+            }
+          ],
+          "type": "distribution",
+          "url": "../../../_helpers/local_pckages/a/dist/package-a-23.42.tar.gz"
+        }
+      ],
+      "name": "package-a",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "type": "library",
+      "version": "23.42"
+    },
+    {
+      "bom-ref": "package-b@23.42",
+      "description": "some package B",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4aacda53fa274f5ff7eed71a9916904ffb3a11b05dc5ca529d7ddb78ae2dc602"
+            }
+          ],
+          "type": "distribution",
+          "url": "../../../_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl"
+        }
+      ],
+      "name": "package-b",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "type": "library",
+      "version": "23.42"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "package-a@23.42",
+        "package-b@23.42"
+      ],
+      "ref": "local"
+    },
+    {
+      "ref": "package-a@23.42"
+    },
+    {
+      "ref": "package-b@23.42"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "local",
+      "description": "packages from local paths",
+      "name": "local",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_local_lock10_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_local_lock10_1.6.xml.bin
@@ -1,0 +1,96 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="local">
+      <name>local</name>
+      <version>0.1.0</version>
+      <description>packages from local paths</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="package-a@23.42">
+      <name>package-a</name>
+      <version>23.42</version>
+      <description>some package A</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../../_helpers/local_pckages/a/dist/package-a-23.42.tar.gz</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">3869fe3f4a6cca5b203b2e2cd8858c834f651e1b0fa76d5c0232e36472199592</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="package-b@23.42">
+      <name>package-b</name>
+      <version>23.42</version>
+      <description>some package B</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../../_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">4aacda53fa274f5ff7eed71a9916904ffb3a11b05dc5ca529d7ddb78ae2dc602</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="local">
+      <dependency ref="package-a@23.42"/>
+      <dependency ref="package-b@23.42"/>
+    </dependency>
+    <dependency ref="package-a@23.42"/>
+    <dependency ref="package-b@23.42"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_local_lock11_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_local_lock11_1.6.json.bin
@@ -1,0 +1,122 @@
+{
+  "components": [
+    {
+      "bom-ref": "package-a@23.42",
+      "description": "some package A",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3869fe3f4a6cca5b203b2e2cd8858c834f651e1b0fa76d5c0232e36472199592"
+            }
+          ],
+          "type": "distribution",
+          "url": "../../../_helpers/local_pckages/a/dist/package-a-23.42.tar.gz"
+        }
+      ],
+      "name": "package-a",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "type": "library",
+      "version": "23.42"
+    },
+    {
+      "bom-ref": "package-b@23.42",
+      "description": "some package B",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4aacda53fa274f5ff7eed71a9916904ffb3a11b05dc5ca529d7ddb78ae2dc602"
+            }
+          ],
+          "type": "distribution",
+          "url": "../../../_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl"
+        }
+      ],
+      "name": "package-b",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "type": "library",
+      "version": "23.42"
+    },
+    {
+      "bom-ref": "package-c@23.42",
+      "description": "some package C",
+      "externalReferences": [
+        {
+          "comment": "from directory",
+          "type": "distribution",
+          "url": "../../../_helpers/local_pckages/c"
+        }
+      ],
+      "name": "package-c",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "type": "library",
+      "version": "23.42"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "package-a@23.42",
+        "package-b@23.42",
+        "package-c@23.42"
+      ],
+      "ref": "local"
+    },
+    {
+      "ref": "package-a@23.42"
+    },
+    {
+      "ref": "package-b@23.42"
+    },
+    {
+      "ref": "package-c@23.42"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "local",
+      "description": "packages from local paths",
+      "name": "local",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_local_lock11_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_local_lock11_1.6.xml.bin
@@ -1,0 +1,112 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="local">
+      <name>local</name>
+      <version>0.1.0</version>
+      <description>packages from local paths</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="package-a@23.42">
+      <name>package-a</name>
+      <version>23.42</version>
+      <description>some package A</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../../_helpers/local_pckages/a/dist/package-a-23.42.tar.gz</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">3869fe3f4a6cca5b203b2e2cd8858c834f651e1b0fa76d5c0232e36472199592</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="package-b@23.42">
+      <name>package-b</name>
+      <version>23.42</version>
+      <description>some package B</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../../_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">4aacda53fa274f5ff7eed71a9916904ffb3a11b05dc5ca529d7ddb78ae2dc602</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="package-c@23.42">
+      <name>package-c</name>
+      <version>23.42</version>
+      <description>some package C</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../../_helpers/local_pckages/c</url>
+          <comment>from directory</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="local">
+      <dependency ref="package-a@23.42"/>
+      <dependency ref="package-b@23.42"/>
+      <dependency ref="package-c@23.42"/>
+    </dependency>
+    <dependency ref="package-a@23.42"/>
+    <dependency ref="package-b@23.42"/>
+    <dependency ref="package-c@23.42"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_local_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_local_lock20_1.6.json.bin
@@ -1,0 +1,122 @@
+{
+  "components": [
+    {
+      "bom-ref": "package-a@23.42",
+      "description": "some package A",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3869fe3f4a6cca5b203b2e2cd8858c834f651e1b0fa76d5c0232e36472199592"
+            }
+          ],
+          "type": "distribution",
+          "url": "../../../_helpers/local_pckages/a/dist/package-a-23.42.tar.gz"
+        }
+      ],
+      "name": "package-a",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "type": "library",
+      "version": "23.42"
+    },
+    {
+      "bom-ref": "package-b@23.42",
+      "description": "some package B",
+      "externalReferences": [
+        {
+          "comment": "from file",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4aacda53fa274f5ff7eed71a9916904ffb3a11b05dc5ca529d7ddb78ae2dc602"
+            }
+          ],
+          "type": "distribution",
+          "url": "../../../_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl"
+        }
+      ],
+      "name": "package-b",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "type": "library",
+      "version": "23.42"
+    },
+    {
+      "bom-ref": "package-c@23.42",
+      "description": "some package C",
+      "externalReferences": [
+        {
+          "comment": "from directory",
+          "type": "distribution",
+          "url": "../../../_helpers/local_pckages/c"
+        }
+      ],
+      "name": "package-c",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "type": "library",
+      "version": "23.42"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "package-a@23.42",
+        "package-b@23.42",
+        "package-c@23.42"
+      ],
+      "ref": "local"
+    },
+    {
+      "ref": "package-a@23.42"
+    },
+    {
+      "ref": "package-b@23.42"
+    },
+    {
+      "ref": "package-c@23.42"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "local",
+      "description": "packages from local paths",
+      "name": "local",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_local_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_local_lock20_1.6.xml.bin
@@ -1,0 +1,112 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="local">
+      <name>local</name>
+      <version>0.1.0</version>
+      <description>packages from local paths</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="package-a@23.42">
+      <name>package-a</name>
+      <version>23.42</version>
+      <description>some package A</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../../_helpers/local_pckages/a/dist/package-a-23.42.tar.gz</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">3869fe3f4a6cca5b203b2e2cd8858c834f651e1b0fa76d5c0232e36472199592</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="package-b@23.42">
+      <name>package-b</name>
+      <version>23.42</version>
+      <description>some package B</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../../_helpers/local_pckages/b/dist/package_b-23.42-py3-none-any.whl</url>
+          <comment>from file</comment>
+          <hashes>
+            <hash alg="SHA-256">4aacda53fa274f5ff7eed71a9916904ffb3a11b05dc5ca529d7ddb78ae2dc602</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="package-c@23.42">
+      <name>package-c</name>
+      <version>23.42</version>
+      <description>some package C</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>../../../_helpers/local_pckages/c</url>
+          <comment>from directory</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="local">
+      <dependency ref="package-a@23.42"/>
+      <dependency ref="package-b@23.42"/>
+      <dependency ref="package-c@23.42"/>
+    </dependency>
+    <dependency ref="package-a@23.42"/>
+    <dependency ref="package-b@23.42"/>
+    <dependency ref="package-c@23.42"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_main-and-dev_lock10_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_main-and-dev_lock10_1.6.json.bin
@@ -1,0 +1,339 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.20240106",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f8db221c3b98e6ca02ea83a58371b22c374f42ae5bbdf186db9c9a76581459f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.20240106.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efbbdc54590d0f16152fa103c9879c7d4a00e82078f6e2cf01769042165acaa2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.20240106-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.20240106",
+      "type": "library",
+      "version": "2.8.19.20240106"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.20240106"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0",
+        "colorama@0.4.6",
+        "isoduration@20.11.0",
+        "toml@0.10.2"
+      ],
+      "ref": "main-and-dev"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.20240106"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "main-and-dev",
+      "description": "main and dev depenndencies",
+      "name": "main-and-dev",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_main-and-dev_lock10_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_main-and-dev_lock10_1.6.xml.bin
@@ -1,0 +1,251 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="main-and-dev">
+      <name>main-and-dev</name>
+      <version>0.1.0</version>
+      <description>main and dev depenndencies</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.20240106">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.20240106</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.20240106</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.20240106.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f8db221c3b98e6ca02ea83a58371b22c374f42ae5bbdf186db9c9a76581459f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.20240106-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efbbdc54590d0f16152fa103c9879c7d4a00e82078f6e2cf01769042165acaa2</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.20240106"/>
+    </dependency>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="main-and-dev">
+      <dependency ref="arrow@1.3.0"/>
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="types-python-dateutil@2.8.19.20240106"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_main-and-dev_lock11_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_main-and-dev_lock11_1.6.json.bin
@@ -1,0 +1,339 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.20240106",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f8db221c3b98e6ca02ea83a58371b22c374f42ae5bbdf186db9c9a76581459f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.20240106.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efbbdc54590d0f16152fa103c9879c7d4a00e82078f6e2cf01769042165acaa2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.20240106-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.20240106",
+      "type": "library",
+      "version": "2.8.19.20240106"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.20240106"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0",
+        "colorama@0.4.6",
+        "isoduration@20.11.0",
+        "toml@0.10.2"
+      ],
+      "ref": "main-and-dev"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.20240106"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "main-and-dev",
+      "description": "main and dev depenndencies",
+      "name": "main-and-dev",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_main-and-dev_lock11_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_main-and-dev_lock11_1.6.xml.bin
@@ -1,0 +1,251 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="main-and-dev">
+      <name>main-and-dev</name>
+      <version>0.1.0</version>
+      <description>main and dev depenndencies</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.20240106">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.20240106</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.20240106</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.20240106.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f8db221c3b98e6ca02ea83a58371b22c374f42ae5bbdf186db9c9a76581459f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.20240106-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efbbdc54590d0f16152fa103c9879c7d4a00e82078f6e2cf01769042165acaa2</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.20240106"/>
+    </dependency>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="main-and-dev">
+      <dependency ref="arrow@1.3.0"/>
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="types-python-dateutil@2.8.19.20240106"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_main-and-dev_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_main-and-dev_lock20_1.6.json.bin
@@ -1,0 +1,321 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.20240106",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f8db221c3b98e6ca02ea83a58371b22c374f42ae5bbdf186db9c9a76581459f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.20240106.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efbbdc54590d0f16152fa103c9879c7d4a00e82078f6e2cf01769042165acaa2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.20240106-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.20240106",
+      "type": "library",
+      "version": "2.8.19.20240106"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.20240106"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0",
+        "colorama@0.4.6",
+        "isoduration@20.11.0",
+        "toml@0.10.2"
+      ],
+      "ref": "main-and-dev"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.20240106"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "main-and-dev",
+      "description": "main and dev depenndencies",
+      "name": "main-and-dev",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_main-and-dev_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_main-and-dev_lock20_1.6.xml.bin
@@ -1,0 +1,242 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="main-and-dev">
+      <name>main-and-dev</name>
+      <version>0.1.0</version>
+      <description>main and dev depenndencies</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.20240106">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.20240106</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.20240106</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.20240106.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f8db221c3b98e6ca02ea83a58371b22c374f42ae5bbdf186db9c9a76581459f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.20240106-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efbbdc54590d0f16152fa103c9879c7d4a00e82078f6e2cf01769042165acaa2</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.20240106"/>
+    </dependency>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="main-and-dev">
+      <dependency ref="arrow@1.3.0"/>
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="types-python-dateutil@2.8.19.20240106"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock11_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock11_1.6.json.bin
@@ -1,0 +1,576 @@
+{
+  "components": [
+    {
+      "bom-ref": "pathlib2@2.3.5",
+      "description": "Object-oriented filesystem paths",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.5-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.5.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a130b266b3a36134dcc79c17b3c7ac9634f083825ca6ea9d8f557ee6195c9c8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7d8bcb5555003cdf4a8d2872c538faa3a0f5d20630cb360e518ca3b981795e5f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.6.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5266a0fd000452f1b3467d782f079a4343c63aaa119221fbdc4e39577489ca5b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.7.post1-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9fe0edad898b83c0c3e199c842b27ed216645d2e177757b2dd67384d4113c641"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.7.post1.tar.gz"
+        }
+      ],
+      "name": "pathlib2",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pathlib2@2.3.5",
+      "type": "library",
+      "version": "2.3.5"
+    },
+    {
+      "bom-ref": "pathlib2@2.3.6#1",
+      "description": "Object-oriented filesystem paths",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.5-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.5.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a130b266b3a36134dcc79c17b3c7ac9634f083825ca6ea9d8f557ee6195c9c8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7d8bcb5555003cdf4a8d2872c538faa3a0f5d20630cb360e518ca3b981795e5f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.6.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5266a0fd000452f1b3467d782f079a4343c63aaa119221fbdc4e39577489ca5b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.7.post1-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9fe0edad898b83c0c3e199c842b27ed216645d2e177757b2dd67384d4113c641"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.7.post1.tar.gz"
+        }
+      ],
+      "name": "pathlib2",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pathlib2@2.3.6",
+      "type": "library",
+      "version": "2.3.6"
+    },
+    {
+      "bom-ref": "pathlib2@2.3.7.post1#2",
+      "description": "Object-oriented filesystem paths",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.5-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.5.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a130b266b3a36134dcc79c17b3c7ac9634f083825ca6ea9d8f557ee6195c9c8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7d8bcb5555003cdf4a8d2872c538faa3a0f5d20630cb360e518ca3b981795e5f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.6.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5266a0fd000452f1b3467d782f079a4343c63aaa119221fbdc4e39577489ca5b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.7.post1-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9fe0edad898b83c0c3e199c842b27ed216645d2e177757b2dd67384d4113c641"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.7.post1.tar.gz"
+        }
+      ],
+      "name": "pathlib2",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pathlib2@2.3.7.post1",
+      "type": "library",
+      "version": "2.3.7.post1"
+    },
+    {
+      "bom-ref": "scandir@1.10.0",
+      "description": "scandir, a better directory iterator and faster os.walk()",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp27-cp27m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp27-cp27m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2c712840c2e2ee8dfaf36034080108d30060d759c7b73a01a52251cc8989f11f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp34-cp34m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2586c94e907d99617887daed6c1d102b5ca28f1085f90446554abf1faf73123e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp34-cp34m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2b8e3888b11abb2217a32af0766bc06b65cc4a928d8727828ee68af5a967fa6f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp35-cp35m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8c5922863e44ffc00c5c693190648daa6d15e7c1207ed02d6f46a8dcc2869d32"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp35-cp35m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2ae41f43797ca0c11591c0c35f2f5875fa99f8797cb1a1fd440497ec0ae4b022"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp36-cp36m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7d2d7a06a252764061a020407b997dd036f7bd6a175a5ba2b345f0a357f0b3f4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp36-cp36m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "67f15b6f83e6507fdc6fca22fedf6ef8b334b399ca27c6b568cbfaa82a364173"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp37-cp37m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b24086f2375c4a094a6b51e78b4cf7ca16c721dcee2eddd7aa6494b42d6d519d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0.tar.gz"
+        }
+      ],
+      "name": "scandir",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/scandir@1.10.0",
+      "type": "library",
+      "version": "1.10.0"
+    },
+    {
+      "bom-ref": "six@1.11.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.11.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.11.0.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.11.0",
+      "type": "library",
+      "version": "1.11.0"
+    },
+    {
+      "bom-ref": "six@1.16.0#1",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.11.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.11.0.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "pathlib2@2.3.5",
+        "pathlib2@2.3.6#1",
+        "pathlib2@2.3.7.post1#2"
+      ],
+      "ref": "multi-constraint-deps"
+    },
+    {
+      "dependsOn": [
+        "scandir@1.10.0",
+        "six@1.11.0",
+        "six@1.16.0#1"
+      ],
+      "ref": "pathlib2@2.3.5"
+    },
+    {
+      "dependsOn": [
+        "scandir@1.10.0",
+        "six@1.11.0",
+        "six@1.16.0#1"
+      ],
+      "ref": "pathlib2@2.3.6#1"
+    },
+    {
+      "dependsOn": [
+        "six@1.11.0",
+        "six@1.16.0#1"
+      ],
+      "ref": "pathlib2@2.3.7.post1#2"
+    },
+    {
+      "ref": "scandir@1.10.0"
+    },
+    {
+      "ref": "six@1.11.0"
+    },
+    {
+      "ref": "six@1.16.0#1"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "multi-constraint-deps",
+      "description": "multi-constraint depenndencies",
+      "name": "multi-constraint-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock11_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock11_1.6.xml.bin
@@ -1,0 +1,403 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="multi-constraint-deps">
+      <name>multi-constraint-deps</name>
+      <version>0.1.0</version>
+      <description>multi-constraint depenndencies</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="pathlib2@2.3.5">
+      <name>pathlib2</name>
+      <version>2.3.5</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.5</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.5-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.5.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a130b266b3a36134dcc79c17b3c7ac9634f083825ca6ea9d8f557ee6195c9c8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7d8bcb5555003cdf4a8d2872c538faa3a0f5d20630cb360e518ca3b981795e5f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.7.post1-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5266a0fd000452f1b3467d782f079a4343c63aaa119221fbdc4e39577489ca5b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.7.post1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9fe0edad898b83c0c3e199c842b27ed216645d2e177757b2dd67384d4113c641</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pathlib2@2.3.6#1">
+      <name>pathlib2</name>
+      <version>2.3.6</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.5-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.5.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a130b266b3a36134dcc79c17b3c7ac9634f083825ca6ea9d8f557ee6195c9c8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7d8bcb5555003cdf4a8d2872c538faa3a0f5d20630cb360e518ca3b981795e5f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.7.post1-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5266a0fd000452f1b3467d782f079a4343c63aaa119221fbdc4e39577489ca5b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.7.post1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9fe0edad898b83c0c3e199c842b27ed216645d2e177757b2dd67384d4113c641</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pathlib2@2.3.7.post1#2">
+      <name>pathlib2</name>
+      <version>2.3.7.post1</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.7.post1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.5-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.5.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a130b266b3a36134dcc79c17b3c7ac9634f083825ca6ea9d8f557ee6195c9c8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7d8bcb5555003cdf4a8d2872c538faa3a0f5d20630cb360e518ca3b981795e5f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.7.post1-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5266a0fd000452f1b3467d782f079a4343c63aaa119221fbdc4e39577489ca5b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.7.post1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9fe0edad898b83c0c3e199c842b27ed216645d2e177757b2dd67384d4113c641</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="scandir@1.10.0">
+      <name>scandir</name>
+      <version>1.10.0</version>
+      <description>scandir, a better directory iterator and faster os.walk()</description>
+      <purl>pkg:pypi/scandir@1.10.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp27-cp27m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp27-cp27m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp34-cp34m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2c712840c2e2ee8dfaf36034080108d30060d759c7b73a01a52251cc8989f11f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp34-cp34m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2586c94e907d99617887daed6c1d102b5ca28f1085f90446554abf1faf73123e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp35-cp35m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2b8e3888b11abb2217a32af0766bc06b65cc4a928d8727828ee68af5a967fa6f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp35-cp35m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8c5922863e44ffc00c5c693190648daa6d15e7c1207ed02d6f46a8dcc2869d32</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp36-cp36m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2ae41f43797ca0c11591c0c35f2f5875fa99f8797cb1a1fd440497ec0ae4b022</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp36-cp36m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7d2d7a06a252764061a020407b997dd036f7bd6a175a5ba2b345f0a357f0b3f4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp37-cp37m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">67f15b6f83e6507fdc6fca22fedf6ef8b334b399ca27c6b568cbfaa82a364173</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b24086f2375c4a094a6b51e78b4cf7ca16c721dcee2eddd7aa6494b42d6d519d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.11.0">
+      <name>six</name>
+      <version>1.11.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.11.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0#1">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.11.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="multi-constraint-deps">
+      <dependency ref="pathlib2@2.3.5"/>
+      <dependency ref="pathlib2@2.3.6#1"/>
+      <dependency ref="pathlib2@2.3.7.post1#2"/>
+    </dependency>
+    <dependency ref="pathlib2@2.3.5">
+      <dependency ref="scandir@1.10.0"/>
+      <dependency ref="six@1.11.0"/>
+      <dependency ref="six@1.16.0#1"/>
+    </dependency>
+    <dependency ref="pathlib2@2.3.6#1">
+      <dependency ref="scandir@1.10.0"/>
+      <dependency ref="six@1.11.0"/>
+      <dependency ref="six@1.16.0#1"/>
+    </dependency>
+    <dependency ref="pathlib2@2.3.7.post1#2">
+      <dependency ref="six@1.11.0"/>
+      <dependency ref="six@1.16.0#1"/>
+    </dependency>
+    <dependency ref="scandir@1.10.0"/>
+    <dependency ref="six@1.11.0"/>
+    <dependency ref="six@1.16.0#1"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.json.bin
@@ -1,0 +1,420 @@
+{
+  "components": [
+    {
+      "bom-ref": "pathlib2@2.3.5",
+      "description": "Object-oriented filesystem paths",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.5-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.5.tar.gz"
+        }
+      ],
+      "name": "pathlib2",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pathlib2@2.3.5",
+      "type": "library",
+      "version": "2.3.5"
+    },
+    {
+      "bom-ref": "pathlib2@2.3.5#1",
+      "description": "Object-oriented filesystem paths",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        }
+      ],
+      "name": "pathlib2",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:poetry:package:source:resolved_reference",
+          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        },
+        {
+          "name": "cdx:poetry:source:package:reference",
+          "value": "2.3.5"
+        }
+      ],
+      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
+      "type": "library",
+      "version": "2.3.5"
+    },
+    {
+      "bom-ref": "pathlib2@2.3.6#2",
+      "description": "Object-oriented filesystem paths",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a130b266b3a36134dcc79c17b3c7ac9634f083825ca6ea9d8f557ee6195c9c8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7d8bcb5555003cdf4a8d2872c538faa3a0f5d20630cb360e518ca3b981795e5f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.6.tar.gz"
+        }
+      ],
+      "name": "pathlib2",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pathlib2@2.3.6",
+      "type": "library",
+      "version": "2.3.6"
+    },
+    {
+      "bom-ref": "pathlib2@2.3.7.post1#3",
+      "description": "Object-oriented filesystem paths",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5266a0fd000452f1b3467d782f079a4343c63aaa119221fbdc4e39577489ca5b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.7.post1-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9fe0edad898b83c0c3e199c842b27ed216645d2e177757b2dd67384d4113c641"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pathlib2/#pathlib2-2.3.7.post1.tar.gz"
+        }
+      ],
+      "name": "pathlib2",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pathlib2@2.3.7.post1",
+      "type": "library",
+      "version": "2.3.7.post1"
+    },
+    {
+      "bom-ref": "scandir@1.10.0",
+      "description": "scandir, a better directory iterator and faster os.walk()",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp27-cp27m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp27-cp27m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2c712840c2e2ee8dfaf36034080108d30060d759c7b73a01a52251cc8989f11f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp34-cp34m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2586c94e907d99617887daed6c1d102b5ca28f1085f90446554abf1faf73123e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp34-cp34m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2b8e3888b11abb2217a32af0766bc06b65cc4a928d8727828ee68af5a967fa6f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp35-cp35m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8c5922863e44ffc00c5c693190648daa6d15e7c1207ed02d6f46a8dcc2869d32"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp35-cp35m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2ae41f43797ca0c11591c0c35f2f5875fa99f8797cb1a1fd440497ec0ae4b022"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp36-cp36m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7d2d7a06a252764061a020407b997dd036f7bd6a175a5ba2b345f0a357f0b3f4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp36-cp36m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "67f15b6f83e6507fdc6fca22fedf6ef8b334b399ca27c6b568cbfaa82a364173"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp37-cp37m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b24086f2375c4a094a6b51e78b4cf7ca16c721dcee2eddd7aa6494b42d6d519d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/scandir/#scandir-1.10.0.tar.gz"
+        }
+      ],
+      "name": "scandir",
+      "purl": "pkg:pypi/scandir@1.10.0",
+      "type": "library",
+      "version": "1.10.0"
+    },
+    {
+      "bom-ref": "six@1.11.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.11.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.11.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.11.0",
+      "type": "library",
+      "version": "1.11.0"
+    },
+    {
+      "bom-ref": "six@1.16.0#1",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "pathlib2@2.3.5",
+        "pathlib2@2.3.5#1",
+        "pathlib2@2.3.6#2",
+        "pathlib2@2.3.7.post1#3"
+      ],
+      "ref": "multi-constraint-deps"
+    },
+    {
+      "dependsOn": [
+        "scandir@1.10.0",
+        "six@1.11.0",
+        "six@1.16.0#1"
+      ],
+      "ref": "pathlib2@2.3.5"
+    },
+    {
+      "dependsOn": [
+        "scandir@1.10.0",
+        "six@1.11.0",
+        "six@1.16.0#1"
+      ],
+      "ref": "pathlib2@2.3.5#1"
+    },
+    {
+      "dependsOn": [
+        "scandir@1.10.0",
+        "six@1.11.0",
+        "six@1.16.0#1"
+      ],
+      "ref": "pathlib2@2.3.6#2"
+    },
+    {
+      "dependsOn": [
+        "six@1.11.0",
+        "six@1.16.0#1"
+      ],
+      "ref": "pathlib2@2.3.7.post1#3"
+    },
+    {
+      "ref": "scandir@1.10.0"
+    },
+    {
+      "ref": "six@1.11.0"
+    },
+    {
+      "ref": "six@1.16.0#1"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "multi-constraint-deps",
+      "description": "multi-constraint depenndencies",
+      "name": "multi-constraint-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.xml.bin
@@ -1,0 +1,305 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="multi-constraint-deps">
+      <name>multi-constraint-deps</name>
+      <version>0.1.0</version>
+      <description>multi-constraint depenndencies</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="pathlib2@2.3.5">
+      <name>pathlib2</name>
+      <version>2.3.5</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.5</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.5-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.5.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pathlib2@2.3.5#1">
+      <name>pathlib2</name>
+      <version>2.3.5</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:resolved_reference">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
+        <property name="cdx:poetry:source:package:reference">2.3.5</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pathlib2@2.3.6#2">
+      <name>pathlib2</name>
+      <version>2.3.6</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a130b266b3a36134dcc79c17b3c7ac9634f083825ca6ea9d8f557ee6195c9c8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7d8bcb5555003cdf4a8d2872c538faa3a0f5d20630cb360e518ca3b981795e5f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pathlib2@2.3.7.post1#3">
+      <name>pathlib2</name>
+      <version>2.3.7.post1</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.7.post1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.7.post1-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5266a0fd000452f1b3467d782f079a4343c63aaa119221fbdc4e39577489ca5b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.7.post1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9fe0edad898b83c0c3e199c842b27ed216645d2e177757b2dd67384d4113c641</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="scandir@1.10.0">
+      <name>scandir</name>
+      <version>1.10.0</version>
+      <description>scandir, a better directory iterator and faster os.walk()</description>
+      <purl>pkg:pypi/scandir@1.10.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp27-cp27m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp27-cp27m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp34-cp34m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2c712840c2e2ee8dfaf36034080108d30060d759c7b73a01a52251cc8989f11f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp34-cp34m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2586c94e907d99617887daed6c1d102b5ca28f1085f90446554abf1faf73123e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp35-cp35m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2b8e3888b11abb2217a32af0766bc06b65cc4a928d8727828ee68af5a967fa6f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp35-cp35m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8c5922863e44ffc00c5c693190648daa6d15e7c1207ed02d6f46a8dcc2869d32</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp36-cp36m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2ae41f43797ca0c11591c0c35f2f5875fa99f8797cb1a1fd440497ec0ae4b022</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp36-cp36m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7d2d7a06a252764061a020407b997dd036f7bd6a175a5ba2b345f0a357f0b3f4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp37-cp37m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">67f15b6f83e6507fdc6fca22fedf6ef8b334b399ca27c6b568cbfaa82a364173</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b24086f2375c4a094a6b51e78b4cf7ca16c721dcee2eddd7aa6494b42d6d519d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/scandir/#scandir-1.10.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="six@1.11.0">
+      <name>six</name>
+      <version>1.11.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.11.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="six@1.16.0#1">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="multi-constraint-deps">
+      <dependency ref="pathlib2@2.3.5"/>
+      <dependency ref="pathlib2@2.3.5#1"/>
+      <dependency ref="pathlib2@2.3.6#2"/>
+      <dependency ref="pathlib2@2.3.7.post1#3"/>
+    </dependency>
+    <dependency ref="pathlib2@2.3.5">
+      <dependency ref="scandir@1.10.0"/>
+      <dependency ref="six@1.11.0"/>
+      <dependency ref="six@1.16.0#1"/>
+    </dependency>
+    <dependency ref="pathlib2@2.3.5#1">
+      <dependency ref="scandir@1.10.0"/>
+      <dependency ref="six@1.11.0"/>
+      <dependency ref="six@1.16.0#1"/>
+    </dependency>
+    <dependency ref="pathlib2@2.3.6#2">
+      <dependency ref="scandir@1.10.0"/>
+      <dependency ref="six@1.11.0"/>
+      <dependency ref="six@1.16.0#1"/>
+    </dependency>
+    <dependency ref="pathlib2@2.3.7.post1#3">
+      <dependency ref="six@1.11.0"/>
+      <dependency ref="six@1.16.0#1"/>
+    </dependency>
+    <dependency ref="scandir@1.10.0"/>
+    <dependency ref="six@1.11.0"/>
+    <dependency ref="six@1.16.0#1"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_no-deps_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_no-deps_lock20_1.6.json.bin
@@ -1,0 +1,71 @@
+{
+  "dependencies": [
+    {
+      "ref": "no-deps"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "no-deps",
+      "description": "packages with all meta, but no deps",
+      "externalReferences": [
+        {
+          "comment": "from poetry: documentation",
+          "type": "documentation",
+          "url": "https://oss.acme.org/my-project/docs/"
+        },
+        {
+          "comment": "from poetry url: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://oss.acme.org/my-project/bugs/"
+        },
+        {
+          "comment": "from poetry url: Funding",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/funding/"
+        },
+        {
+          "comment": "from poetry url: Change log",
+          "type": "release-notes",
+          "url": "https://oss.acme.org/my-project/changelog/"
+        },
+        {
+          "comment": "from poetry: repository",
+          "type": "vcs",
+          "url": "https://oss.acme.org/my-project.git"
+        },
+        {
+          "comment": "from poetry: homepage",
+          "type": "website",
+          "url": "https://oss.acme.org/my-project/"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "no-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_no-deps_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_no-deps_lock20_1.6.xml.bin
@@ -1,0 +1,84 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="no-deps">
+      <name>no-deps</name>
+      <version>0.1.0</version>
+      <description>packages with all meta, but no deps</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://oss.acme.org/my-project/docs/</url>
+          <comment>from poetry: documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://oss.acme.org/my-project/bugs/</url>
+          <comment>from poetry url: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/funding/</url>
+          <comment>from poetry url: Funding</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://oss.acme.org/my-project/changelog/</url>
+          <comment>from poetry url: Change log</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://oss.acme.org/my-project.git</url>
+          <comment>from poetry: repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://oss.acme.org/my-project/</url>
+          <comment>from poetry: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <dependencies>
+    <dependency ref="no-deps"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_normalize-packagename_lock10_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_normalize-packagename_lock10_1.6.json.bin
@@ -1,0 +1,128 @@
+{
+  "components": [
+    {
+      "bom-ref": "ruamel-yaml@0.18.5",
+      "description": "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order",
+      "name": "ruamel-yaml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "jinja2"
+        }
+      ],
+      "purl": "pkg:pypi/ruamel-yaml@0.18.5",
+      "type": "library",
+      "version": "0.18.5"
+    },
+    {
+      "bom-ref": "ruamel.yaml@0.18.5#1",
+      "description": "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order",
+      "name": "ruamel.yaml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "jinja2"
+        }
+      ],
+      "purl": "pkg:pypi/ruamel.yaml@0.18.5",
+      "type": "library",
+      "version": "0.18.5"
+    },
+    {
+      "bom-ref": "ruamel.yaml.clib@0.2.8",
+      "description": "C version of reader, parser and emitter for ruamel.yaml derived from libyaml",
+      "name": "ruamel.yaml.clib",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/ruamel.yaml.clib@0.2.8",
+      "type": "library",
+      "version": "0.2.8"
+    },
+    {
+      "bom-ref": "ruamel.yaml.jinja2@0.2.7",
+      "description": "jinja2 pre and post-processor to update with YAML",
+      "name": "ruamel.yaml.jinja2",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/ruamel.yaml.jinja2@0.2.7",
+      "type": "library",
+      "version": "0.2.7"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "ruamel-yaml@0.18.5",
+        "ruamel.yaml@0.18.5#1"
+      ],
+      "ref": "normalize-packagename"
+    },
+    {
+      "dependsOn": [
+        "ruamel.yaml.clib@0.2.8",
+        "ruamel.yaml.jinja2@0.2.7"
+      ],
+      "ref": "ruamel-yaml@0.18.5"
+    },
+    {
+      "ref": "ruamel.yaml.clib@0.2.8"
+    },
+    {
+      "dependsOn": [
+        "ruamel-yaml@0.18.5",
+        "ruamel.yaml@0.18.5#1"
+      ],
+      "ref": "ruamel.yaml.jinja2@0.2.7"
+    },
+    {
+      "dependsOn": [
+        "ruamel.yaml.clib@0.2.8",
+        "ruamel.yaml.jinja2@0.2.7"
+      ],
+      "ref": "ruamel.yaml@0.18.5#1"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "normalize-packagename",
+      "description": "packages with non-normalized names",
+      "name": "normalize-packagename",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_normalize-packagename_lock10_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_normalize-packagename_lock10_1.6.xml.bin
@@ -1,0 +1,111 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="normalize-packagename">
+      <name>normalize-packagename</name>
+      <version>0.1.0</version>
+      <description>packages with non-normalized names</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="ruamel-yaml@0.18.5">
+      <name>ruamel-yaml</name>
+      <version>0.18.5</version>
+      <description>ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order</description>
+      <purl>pkg:pypi/ruamel-yaml@0.18.5</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:required-extra">jinja2</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="ruamel.yaml@0.18.5#1">
+      <name>ruamel.yaml</name>
+      <version>0.18.5</version>
+      <description>ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order</description>
+      <purl>pkg:pypi/ruamel.yaml@0.18.5</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:required-extra">jinja2</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="ruamel.yaml.clib@0.2.8">
+      <name>ruamel.yaml.clib</name>
+      <version>0.2.8</version>
+      <description>C version of reader, parser and emitter for ruamel.yaml derived from libyaml</description>
+      <purl>pkg:pypi/ruamel.yaml.clib@0.2.8</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="ruamel.yaml.jinja2@0.2.7">
+      <name>ruamel.yaml.jinja2</name>
+      <version>0.2.7</version>
+      <description>jinja2 pre and post-processor to update with YAML</description>
+      <purl>pkg:pypi/ruamel.yaml.jinja2@0.2.7</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="normalize-packagename">
+      <dependency ref="ruamel-yaml@0.18.5"/>
+      <dependency ref="ruamel.yaml@0.18.5#1"/>
+    </dependency>
+    <dependency ref="ruamel-yaml@0.18.5">
+      <dependency ref="ruamel.yaml.clib@0.2.8"/>
+      <dependency ref="ruamel.yaml.jinja2@0.2.7"/>
+    </dependency>
+    <dependency ref="ruamel.yaml.clib@0.2.8"/>
+    <dependency ref="ruamel.yaml.jinja2@0.2.7">
+      <dependency ref="ruamel-yaml@0.18.5"/>
+      <dependency ref="ruamel.yaml@0.18.5#1"/>
+    </dependency>
+    <dependency ref="ruamel.yaml@0.18.5#1">
+      <dependency ref="ruamel.yaml.clib@0.2.8"/>
+      <dependency ref="ruamel.yaml.jinja2@0.2.7"/>
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_normalize-packagename_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_normalize-packagename_lock20_1.6.json.bin
@@ -1,0 +1,689 @@
+{
+  "components": [
+    {
+      "bom-ref": "ruamel-yaml@0.18.5",
+      "description": "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a013ac02f99a69cdd6277d9664689eb1acba07069f912823177c5eced21a6ada"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml/#ruamel.yaml-0.18.5-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "61917e3a35a569c1133a8f772e1226961bf5a1198bea7e23f06a0841dea1ab0e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml/#ruamel.yaml-0.18.5.tar.gz"
+        }
+      ],
+      "name": "ruamel-yaml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "jinja2"
+        }
+      ],
+      "purl": "pkg:pypi/ruamel-yaml@0.18.5",
+      "type": "library",
+      "version": "0.18.5"
+    },
+    {
+      "bom-ref": "ruamel-yaml-clib@0.2.8",
+      "description": "C version of reader, parser and emitter for ruamel.yaml derived from libyaml",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b42169467c42b692c19cf539c38d4602069d8c1505e97b86387fcf7afb766e1d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "07238db9cbdf8fc1e9de2489a4f68474e70dffcb32232db7c08fa61ca0c7c462"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_13_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fff3573c2db359f091e1589c3d7c5fc2f86f5bdb6f24252c2d8e539d4e45f412"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aa2267c6a303eb483de8d02db2871afb5c5fc15618d894300b88958f729ad74f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_24_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "840f0c7f194986a63d2c2465ca63af8ccbbc90ab1c6001b1978f05119b5e7334"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "024cfe1fc7c7f4e1aff4a81e718109e13409767e4f871443cbff3dba3578203d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c69212f63169ec1cfc9bb44723bf2917cbbd8f6191a00ef3410f5a7fe300722d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cabddb8d8ead485e255fe80429f833172b4cadf99274db39abc080e068cbcc31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bef08cd86169d9eafb3ccb0a39edb11d8e25f3dae2b28f5c52fd997521133069"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b16420e621d26fdfa949a8b4b47ade8810c56002f5389970db4ddda51dbff248"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_13_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25c515e350e5b739842fc3228d662413ef28f295791af5e5110b543cf0b57d9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1707814f0d9791df063f8c19bb51b0d1278b8e9a2353abbb676c2f685dee6afe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_24_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "46d378daaac94f454b3a0e3d8d78cafd78a026b1d71443f4966c696b48a6d899"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "09b055c05697b38ecacb7ac50bdab2240bfca1a0c4872b0fd309bb07dc9aa3a9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "53a300ed9cea38cf5a2a9b069058137c2ca1ce658a874b79baceb8f892f915a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c2a72e9109ea74e511e29032f3b670835f8a59bbdc9ce692c5b4ed91ccf1eedb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ebc06178e8821efc9692ea7544aa5644217358490145629914d8020042c24aa1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "edaef1c1200c4b4cb914583150dcaa3bc30e592e907c01117c08b13a07255ec2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_13_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d176b57452ab5b7028ac47e7b3cf644bcfdc8cacfecf7e71759f7f51a59e5c92"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1dc67314e7e1086c9fdf2680b7b6c2be1c0d8e3a8279f2e993ca2a7545fecf62"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_24_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3213ece08ea033eb159ac52ae052a4899b56ecc124bb80020d9bbceeb50258e9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aab7fd643f71d7946f2ee58cc88c9b7bfc97debd71dcc93e03e2d174628e7e2d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c365d91c88390c8d0a8545df0b5857172824b1c604e867161e6b3d59a827eaa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1758ce7d8e1a29d23de54a16ae867abd370f01b5a69e1a3ba75223eaa3ca1a1b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a5aa27bad2bb83670b71683aae140a1f52b0857a2deff56ad3f6c13a017a26ed"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c58ecd827313af6864893e7af0a3bb85fd529f862b6adbefe14643947cfe2942"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f481f16baec5290e45aebdc2a5168ebc6d35189ae6fea7a58787613a25f6e875"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_12_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "77159f5d5b5c14f7c34073862a6b7d34944075d9f93e681638f6d753606c6ce6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_24_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7f67a1ee819dc4562d444bbafb135832b0b909f81cc90f7aa00260968c9ca1b3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4ecbf9c3e19f9562c7fdd462e8d18dd902a47ca046a2e64dba80699f0b6c09b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "87ea5ff66d8064301a154b3933ae406b0863402a799b16e4a1d24d9fbbcbe0d3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "75e1ed13e1f9de23c5607fe6bd1aeaae21e523b32d83bb33918245361e9cc51b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp37-cp37m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3f215c5daf6a9d7bbed4a0a4f760f3113b10e82ff4c5c44bec20a68c8014f675"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b617618914cb00bf5c34d4357c37aa15183fa229b24767259657746c9077615"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a6a9ffd280b71ad062eae53ac1659ad86a17f59a0fdc7699fd9be40525153337"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_12_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "305889baa4043a09e5b76f8e2a51d4ffba44259f6b4c72dec8ca56207d9c6fe1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_24_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "700e4ebb569e59e16a976857c8798aee258dceac7c7d6b50cab63e080058df91"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e2b4c44b60eadec492926a7270abb100ef9f72798e18743939bdbf037aab8c28"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e79e5db08739731b0ce4850bed599235d601701d5694c36570a99a0c5ca41a9d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "955eae71ac26c1ab35924203fda6220f84dce57d6d7884f189743e2abe3a9fbe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "56f4252222c067b4ce51ae12cbac231bce32aee1d33fbfc9d17e5b8d6966c312"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "03d1162b6d1df1caa3a4bd27aa51ce17c9afc2046c31b0ad60a0a96ec22f8001"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bba64af9fa9cebe325a62fa398760f5c7206b215201b0ec825005f1b18b9bccf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_12_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a1a45e0bb052edf6a1d3a93baef85319733a888363938e1fc9924cb00c8df24c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_24_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "da09ad1c359a728e112d60116f626cc9f29730ff3e0e7db72b9a2dbc2e4beed5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "184565012b60405d93838167f425713180b949e9d8dd0bbc7b49f074407c5a8b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a75879bacf2c987c003368cf14bed0ffe99e8e85acfa6c0bfffc21a090f16880"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84b554931e932c46f94ab306913ad7e11bba988104c5cff26d90d03f68258cd5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25ac8c08322002b06fa1d49d1646181f0b2c72f5cbc15a85e80b4c30a544bb15"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8.tar.gz"
+        }
+      ],
+      "name": "ruamel-yaml-clib",
+      "purl": "pkg:pypi/ruamel-yaml-clib@0.2.8",
+      "type": "library",
+      "version": "0.2.8"
+    },
+    {
+      "bom-ref": "ruamel-yaml-jinja2@0.2.7",
+      "description": "jinja2 pre and post-processor to update with YAML",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb36abd4d308794e9a497e48f98cbd2b921d2cd2946bbc9f1bea42c9b142a241"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-jinja2/#ruamel.yaml.jinja2-0.2.7-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8449be29d9a157fa92d1648adc161d718e469f0d38a6b21e0eabb76fd5b3e663"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ruamel-yaml-jinja2/#ruamel.yaml.jinja2-0.2.7.tar.gz"
+        }
+      ],
+      "name": "ruamel-yaml-jinja2",
+      "purl": "pkg:pypi/ruamel-yaml-jinja2@0.2.7",
+      "type": "library",
+      "version": "0.2.7"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "ruamel-yaml@0.18.5"
+      ],
+      "ref": "normalize-packagename"
+    },
+    {
+      "ref": "ruamel-yaml-clib@0.2.8"
+    },
+    {
+      "dependsOn": [
+        "ruamel-yaml@0.18.5"
+      ],
+      "ref": "ruamel-yaml-jinja2@0.2.7"
+    },
+    {
+      "dependsOn": [
+        "ruamel-yaml-clib@0.2.8",
+        "ruamel-yaml-jinja2@0.2.7"
+      ],
+      "ref": "ruamel-yaml@0.18.5"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "normalize-packagename",
+      "description": "packages with non-normalized names",
+      "name": "normalize-packagename",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_normalize-packagename_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_normalize-packagename_lock20_1.6.xml.bin
@@ -1,0 +1,473 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="normalize-packagename">
+      <name>normalize-packagename</name>
+      <version>0.1.0</version>
+      <description>packages with non-normalized names</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="ruamel-yaml@0.18.5">
+      <name>ruamel-yaml</name>
+      <version>0.18.5</version>
+      <description>ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order</description>
+      <purl>pkg:pypi/ruamel-yaml@0.18.5</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml/#ruamel.yaml-0.18.5-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a013ac02f99a69cdd6277d9664689eb1acba07069f912823177c5eced21a6ada</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml/#ruamel.yaml-0.18.5.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">61917e3a35a569c1133a8f772e1226961bf5a1198bea7e23f06a0841dea1ab0e</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:required-extra">jinja2</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="ruamel-yaml-clib@0.2.8">
+      <name>ruamel-yaml-clib</name>
+      <version>0.2.8</version>
+      <description>C version of reader, parser and emitter for ruamel.yaml derived from libyaml</description>
+      <purl>pkg:pypi/ruamel-yaml-clib@0.2.8</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b42169467c42b692c19cf539c38d4602069d8c1505e97b86387fcf7afb766e1d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_13_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">07238db9cbdf8fc1e9de2489a4f68474e70dffcb32232db7c08fa61ca0c7c462</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fff3573c2db359f091e1589c3d7c5fc2f86f5bdb6f24252c2d8e539d4e45f412</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_24_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aa2267c6a303eb483de8d02db2871afb5c5fc15618d894300b88958f729ad74f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">840f0c7f194986a63d2c2465ca63af8ccbbc90ab1c6001b1978f05119b5e7334</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">024cfe1fc7c7f4e1aff4a81e718109e13409767e4f871443cbff3dba3578203d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c69212f63169ec1cfc9bb44723bf2917cbbd8f6191a00ef3410f5a7fe300722d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cabddb8d8ead485e255fe80429f833172b4cadf99274db39abc080e068cbcc31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bef08cd86169d9eafb3ccb0a39edb11d8e25f3dae2b28f5c52fd997521133069</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_13_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b16420e621d26fdfa949a8b4b47ade8810c56002f5389970db4ddda51dbff248</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">25c515e350e5b739842fc3228d662413ef28f295791af5e5110b543cf0b57d9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_24_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1707814f0d9791df063f8c19bb51b0d1278b8e9a2353abbb676c2f685dee6afe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">46d378daaac94f454b3a0e3d8d78cafd78a026b1d71443f4966c696b48a6d899</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">09b055c05697b38ecacb7ac50bdab2240bfca1a0c4872b0fd309bb07dc9aa3a9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">53a300ed9cea38cf5a2a9b069058137c2ca1ce658a874b79baceb8f892f915a7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c2a72e9109ea74e511e29032f3b670835f8a59bbdc9ce692c5b4ed91ccf1eedb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ebc06178e8821efc9692ea7544aa5644217358490145629914d8020042c24aa1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_13_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">edaef1c1200c4b4cb914583150dcaa3bc30e592e907c01117c08b13a07255ec2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d176b57452ab5b7028ac47e7b3cf644bcfdc8cacfecf7e71759f7f51a59e5c92</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_24_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1dc67314e7e1086c9fdf2680b7b6c2be1c0d8e3a8279f2e993ca2a7545fecf62</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3213ece08ea033eb159ac52ae052a4899b56ecc124bb80020d9bbceeb50258e9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aab7fd643f71d7946f2ee58cc88c9b7bfc97debd71dcc93e03e2d174628e7e2d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5c365d91c88390c8d0a8545df0b5857172824b1c604e867161e6b3d59a827eaa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1758ce7d8e1a29d23de54a16ae867abd370f01b5a69e1a3ba75223eaa3ca1a1b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a5aa27bad2bb83670b71683aae140a1f52b0857a2deff56ad3f6c13a017a26ed</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c58ecd827313af6864893e7af0a3bb85fd529f862b6adbefe14643947cfe2942</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_12_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f481f16baec5290e45aebdc2a5168ebc6d35189ae6fea7a58787613a25f6e875</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_24_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">77159f5d5b5c14f7c34073862a6b7d34944075d9f93e681638f6d753606c6ce6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7f67a1ee819dc4562d444bbafb135832b0b909f81cc90f7aa00260968c9ca1b3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4ecbf9c3e19f9562c7fdd462e8d18dd902a47ca046a2e64dba80699f0b6c09b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">87ea5ff66d8064301a154b3933ae406b0863402a799b16e4a1d24d9fbbcbe0d3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp37-cp37m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">75e1ed13e1f9de23c5607fe6bd1aeaae21e523b32d83bb33918245361e9cc51b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3f215c5daf6a9d7bbed4a0a4f760f3113b10e82ff4c5c44bec20a68c8014f675</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1b617618914cb00bf5c34d4357c37aa15183fa229b24767259657746c9077615</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_12_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a6a9ffd280b71ad062eae53ac1659ad86a17f59a0fdc7699fd9be40525153337</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_24_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">305889baa4043a09e5b76f8e2a51d4ffba44259f6b4c72dec8ca56207d9c6fe1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">700e4ebb569e59e16a976857c8798aee258dceac7c7d6b50cab63e080058df91</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e2b4c44b60eadec492926a7270abb100ef9f72798e18743939bdbf037aab8c28</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e79e5db08739731b0ce4850bed599235d601701d5694c36570a99a0c5ca41a9d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">955eae71ac26c1ab35924203fda6220f84dce57d6d7884f189743e2abe3a9fbe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">56f4252222c067b4ce51ae12cbac231bce32aee1d33fbfc9d17e5b8d6966c312</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">03d1162b6d1df1caa3a4bd27aa51ce17c9afc2046c31b0ad60a0a96ec22f8001</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_12_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bba64af9fa9cebe325a62fa398760f5c7206b215201b0ec825005f1b18b9bccf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_24_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a1a45e0bb052edf6a1d3a93baef85319733a888363938e1fc9924cb00c8df24c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">da09ad1c359a728e112d60116f626cc9f29730ff3e0e7db72b9a2dbc2e4beed5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">184565012b60405d93838167f425713180b949e9d8dd0bbc7b49f074407c5a8b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a75879bacf2c987c003368cf14bed0ffe99e8e85acfa6c0bfffc21a090f16880</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">84b554931e932c46f94ab306913ad7e11bba988104c5cff26d90d03f68258cd5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">25ac8c08322002b06fa1d49d1646181f0b2c72f5cbc15a85e80b4c30a544bb15</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-clib/#ruamel.yaml.clib-0.2.8.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="ruamel-yaml-jinja2@0.2.7">
+      <name>ruamel-yaml-jinja2</name>
+      <version>0.2.7</version>
+      <description>jinja2 pre and post-processor to update with YAML</description>
+      <purl>pkg:pypi/ruamel-yaml-jinja2@0.2.7</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-jinja2/#ruamel.yaml.jinja2-0.2.7-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eb36abd4d308794e9a497e48f98cbd2b921d2cd2946bbc9f1bea42c9b142a241</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ruamel-yaml-jinja2/#ruamel.yaml.jinja2-0.2.7.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8449be29d9a157fa92d1648adc161d718e469f0d38a6b21e0eabb76fd5b3e663</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="normalize-packagename">
+      <dependency ref="ruamel-yaml@0.18.5"/>
+    </dependency>
+    <dependency ref="ruamel-yaml-clib@0.2.8"/>
+    <dependency ref="ruamel-yaml-jinja2@0.2.7">
+      <dependency ref="ruamel-yaml@0.18.5"/>
+    </dependency>
+    <dependency ref="ruamel-yaml@0.18.5">
+      <dependency ref="ruamel-yaml-clib@0.2.8"/>
+      <dependency ref="ruamel-yaml-jinja2@0.2.7"/>
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_private-packges_lock10_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_private-packges_lock10_1.6.json.bin
@@ -1,0 +1,147 @@
+{
+  "components": [
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from url",
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0?download_url=https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2?repository_url=http://pysrc2.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6",
+        "six@1.16.0",
+        "toml@0.10.2"
+      ],
+      "ref": "private-packges"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "private-packges",
+      "description": "packages from aternative package repositories",
+      "name": "private-packges",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_private-packges_lock10_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_private-packges_lock10_1.6.xml.bin
@@ -1,0 +1,129 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="private-packges">
+      <name>private-packges</name>
+      <version>0.1.0</version>
+      <description>packages from aternative package repositories</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0?download_url=https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from url</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2?repository_url=http://pysrc2.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="private-packges">
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="six@1.16.0"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_private-packges_lock11_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_private-packges_lock11_1.6.json.bin
@@ -1,0 +1,147 @@
+{
+  "components": [
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from url",
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0?download_url=https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2?repository_url=http://pysrc2.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.10.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6",
+        "six@1.16.0",
+        "toml@0.10.2"
+      ],
+      "ref": "private-packges"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "private-packges",
+      "description": "packages from aternative package repositories",
+      "name": "private-packges",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_private-packges_lock11_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_private-packges_lock11_1.6.xml.bin
@@ -1,0 +1,129 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="private-packges">
+      <name>private-packges</name>
+      <version>0.1.0</version>
+      <description>packages from aternative package repositories</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0?download_url=https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from url</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2?repository_url=http://pysrc2.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="private-packges">
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="six@1.16.0"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_private-packges_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_private-packges_lock20_1.6.json.bin
@@ -1,0 +1,1216 @@
+{
+  "components": [
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "importlib-metadata@7.0.1",
+      "description": "Read metadata from Python packages",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4805911c3a4ec7c3966410053e9ec6a1fecd629117df5adee56dfc9432a1081e"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/importlib-metadata/#importlib_metadata-7.0.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f238736bb06590ae52ac1fab06a3a9ef1d8dce2b7a35b5ab329371d6c8f5d2cc"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/importlib-metadata/#importlib_metadata-7.0.1.tar.gz"
+        }
+      ],
+      "name": "importlib-metadata",
+      "purl": "pkg:pypi/importlib-metadata@7.0.1?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "7.0.1"
+    },
+    {
+      "bom-ref": "jax@0.4.20",
+      "description": "Differentiate, compile, and transform Numpy code.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3d5952197adca548d99310f1c326bf00548f1cc8652b89edb369166482c2aec2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://storage.googleapis.com/jax-releases/jax_releases.html/jax/#jax-0.4.20-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ea96a763a8b1a9374639d1159ab4de163461d01cd022f67c34c09581b71ed2ac"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://storage.googleapis.com/jax-releases/jax_releases.html/jax/#jax-0.4.20.tar.gz"
+        }
+      ],
+      "name": "jax",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/jax@0.4.20?repository_url=https://storage.googleapis.com/jax-releases/jax_releases.html",
+      "type": "library",
+      "version": "0.4.20"
+    },
+    {
+      "bom-ref": "ml-dtypes@0.3.2",
+      "description": "",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7afde548890a92b41c0fed3a6c525f1200a5727205f73dc21181a2726571bb53"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d1a746fe5fb9cd974a91070174258f0be129c592b93f9ce7df6cc336416c3fbd"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961134ea44c7b8ca63eda902a44b58cd8bd670e21d62e255c81fba0a8e70d9b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b35c4e8ca957c877ac35c79ffa77724ecc3702a1e4b18b08306c03feae597bb"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "763697ab8a88d47443997a7cdf3aac7340049aed45f7521f6b0ec8a0594821fe"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b89b194e9501a92d289c1ffd411380baf5daafb9818109a4f49b0a1b6dce4462"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2c34f2ba9660b21fe1034b608308a01be82bbef2a92fb8199f24dc6bad0d5226"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6604877d567a29bfe7cc02969ae0f2425260e5335505cf5e7fefc3e5465f5655"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "93b78f53431c93953f7850bb1b925a17f0ab5d97527e38a7e865b5b4bc5cfc18"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a17ef2322e60858d93584e9c52a5be7dd6236b056b7fa1ec57f1bb6ba043e33"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e8505946df1665db01332d885c2020b4cb9e84a8b1241eb4ba69d59591f65855"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f47619d978ab1ae7dfdc4052ea97c636c6263e1f19bd1be0e42c346b98d15ff4"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c7b3fb3d4f6b39bcd4f6c4b98f406291f0d681a895490ee29a0f95bab850d53c"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7a4c3fcbf86fa52d0204f07cfd23947ef05b4ad743a1a988e163caa34a201e5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "91f8783fd1f2c23fd3b9ee5ad66b785dafa58ba3cdb050c4458021fa4d1eb226"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7ba8e1fafc7fff3e643f453bffa7d082df1678a73286ce8187d3e825e776eb94"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "533059bc5f1764fac071ef54598db358c167c51a718f68f5bb55e3dee79d2967"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2.tar.gz"
+        }
+      ],
+      "name": "ml-dtypes",
+      "purl": "pkg:pypi/ml-dtypes@0.3.2?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.3.2"
+    },
+    {
+      "bom-ref": "numpy@1.26.3",
+      "description": "Fundamental package for array computing in Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806dd64230dbbfaca8a27faa64e2f414bf1c6622ab78cc4264f7f5f028fee3bf"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "02f98011ba4ab17f46f80f7f8f1c291ee7d855fcef0a5a98db80767a468c85cd"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6d45b3ec2faed4baca41c76617fcdcfa4f684ff7a151ce6fc78ad3b6e85af0a6"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bdd2b45bf079d9ad90377048e2747a0c82351989a2165821f0c96831b4a2a54b"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "211ddd1e94817ed2d175b60b6374120244a4dd2287f4ece45d49228b4d529178"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b1240f767f69d7c4c8a29adde2310b871153df9b26b5cb2b54a561ac85146485"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "21a9484e75ad018974a2fdaa216524d64ed4212e418e0a551a2d83403b0531d3"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9e1591f6ae98bcfac2a4bbf9221c0b92ab49762228f38287f6eeb5f3f55905ce"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b831295e5472954104ecb46cd98c08b98b49c69fdb7040483aff799a755a7374"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9e87562b91f68dd8b1c39149d0323b42e0082db7ddb8e934ab4c292094d575d6"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8c66d6fec467e8c0f975818c1796d25c53521124b7cfb760114be0abad53a0a2"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f25e2811a9c932e43943a2615e65fc487a0b6b49218899e62e426e7f0a57eeda"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "af36e0aa45e25c9f57bf684b1175e59ea05d9a7d3e8e87b7ae1a1da246f2767e"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "51c7f1b344f302067b02e0f5b5d2daa9ed4a721cf49f070280ac202738ea7f00"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7ca4f24341df071877849eb2034948459ce3a07915c2734f1abb4018d9c49d7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "39763aee6dfdd4878032361b30b2b12593fb445ddb66bbac802e2113eb8a6ac4"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a7081fd19a6d573e1a05e600c82a1c421011db7935ed0d5c483e9dd96b99cf13"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "12c70ac274b32bc00c7f61b515126c9205323703abb99cd41836e8125ea0043e"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7f784e13e598e9594750b2ef6729bcd5a47f6cfe4a12cca13def35e06d8163e3"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5f24750ef94d56ce6e33e4019a8a4d68cfdb1ef661a52cdaee628a56d2437419"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "77810ef29e0fb1d289d225cabb9ee6cf4d11978a00bb99f7f8ec2132a84e0166"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8ed07a90f5450d99dad60d3799f9c03c6566709bd53b497eb9ccad9a55867f36"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f73497e8c38295aaa4741bdfa4fda1a5aedda5473074369eca10626835445511"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "da4b0c6c699a0ad73c810736303f7fbae483bcb012e38d7eb06a5e3b432c981b"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1666f634cb3c80ccbd77ec97bc17337718f56d6658acf5d3b906ca03e90ce87f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "18c3319a7d39b2c6a9e3bb75aab2304ab79a811ac0168a671a62e6346c29b03f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0b7e807d6888da0db6e7e75838444d62495e2b588b99e90dd80c3459594e857b"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b4d362e17bcb0011738c2d83e0a65ea8ce627057b2fdda37678f4374a382a137"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b8c275f0ae90069496068c714387b4a0eba5d531aace269559ff2b43655edd58"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cc0743f0302b94f397a4a65a660d4cd24267439eb16493fb3caad2e4389bccbb"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9bc6d1a7f8cedd519c4b7b1156d98e051b726bf160715b769106661d567b3f03"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "867e3644e208c8922a3be26fc6bbf112a035f50f0a86497f98f228c50c607bb2"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3c67423b3703f8fbd90f5adaa37f85b5794d3366948efe9a5190a5f3a83fc34e"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-pp39-pypy39_pp73-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "46f47ee566d98849323f01b349d58f2557f02167ee301e5e28809a8c0e27a2d0"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a8474703bffc65ca15853d5fd4d06b18138ae90c17c8d12169968e998e448bb5"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-pp39-pypy39_pp73-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "697df43e2b6310ecc9d95f05d5ef20eacc09c7c4ecc9da3f235d39e71b7da1e4"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3.tar.gz"
+        }
+      ],
+      "name": "numpy",
+      "purl": "pkg:pypi/numpy@1.26.3?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "1.26.3"
+    },
+    {
+      "bom-ref": "opt-einsum@3.3.0",
+      "description": "Optimizing numpys einsum function",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2455e59e3947d3c275477df7f5205b30635e266fe6dc300e3d9f9646bfcea147"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/opt-einsum/#opt_einsum-3.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "59f6475f77bbc37dcf7cd748519c0ec60722e91e63ca114e68821c0c54a46549"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/opt-einsum/#opt_einsum-3.3.0.tar.gz"
+        }
+      ],
+      "name": "opt-einsum",
+      "purl": "pkg:pypi/opt-einsum@3.3.0?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "3.3.0"
+    },
+    {
+      "bom-ref": "scipy@1.11.4",
+      "description": "Fundamental algorithms for scientific computing in Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bc9a714581f561af0848e6b69947fda0614915f072dfd14142ed1bfe1b806710"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf00bd2b1b0211888d4dc75656c0412213a8b25e80d73898083f402b50f47e41"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp310-cp310-macosx_12_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b9999c008ccf00e8fbcce1236f85ade5c569d13144f77a1946bef8863e8f6eb4"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "933baf588daa8dc9a92c20a0be32f56d43faf3d1a60ab11b3f08c356430f6e56"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8fce70f39076a5aa62e92e69a7f62349f9574d8405c0a5de6ed3ef72de07f446"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6550466fbeec7453d7465e74d4f4b19f905642c89a7525571ee91dd7adabb5a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f313b39a7e94f296025e3cffc2c567618174c0b1dde173960cf23808f9fae4be"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b7c3dca977f30a739e0409fb001056484661cb2541a01aba0bb0029f7b68db8"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp311-cp311-macosx_12_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "00150c5eae7b610c32589dda259eacc7c4f1665aedf25d921907f4d08a951b1c"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "530f9ad26440e85766509dbf78edcfe13ffd0ab7fec2560ee5c36ff74d6269ff"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5e347b14fe01003d3b78e196e84bd3f48ffe4c8a7b8a1afbcb8f5505cb710993"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "acf8ed278cc03f5aff035e69cb511741e0418681d25fbbb86ca65429c4f4d9cd"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "028eccd22e654b3ea01ee63705681ee79933652b2d8f873e7949898dda6d11b6"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2c6ff6ef9cc27f9b3db93a6f8b38f97387e6e0591600369a297a50a8e96e835d"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp312-cp312-macosx_12_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b030c6674b9230d37c5c60ab456e2cf12f6784596d15ce8da9365e70896effc4"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ad669df80528aeca5f557712102538f4f37e503f0c5b9541655016dd0932ca79"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ce7fff2e23ab2cc81ff452a9444c215c28e6305f396b2ba88343a567feec9660"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "36750b7733d960d7994888f0d148d31ea3017ac15eef664194b4ef68d36a4a97"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6e619aba2df228a9b34718efb023966da781e89dd3d21637b27f2e54db0410d7"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f3cd9e7b3c2c1ec26364856f9fbe78695fe631150f94cd1c22228456404cf1ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp39-cp39-macosx_12_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d10e45a6c50211fe256da61a11c34927c68f277e03138777bdebedd933712fea"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "91af76a68eeae0064887a48e25c4e616fa519fa0d38602eda7e0f97d65d57937"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6df1468153a31cf55ed5ed39647279beb9cfb5d3f84369453b49e4b8502394fd"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ee410e6de8f88fd5cf6eadd73c135020bfbbbdfcd0f6162c36a7638a1ea8cc65"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "90a2b78e7f5733b9de748f589f09225013685f9b218275257f8a8168ededaeaa"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4.tar.gz"
+        }
+      ],
+      "name": "scipy",
+      "purl": "pkg:pypi/scipy@1.11.4?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "1.11.4"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0?download_url=https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2?repository_url=http://pysrc2.acme.org:8080/simple",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "zipp@3.17.0",
+      "description": "Backport of pathlib-compatible object wrapper for zip files",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/zipp/#zipp-3.17.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"
+            }
+          ],
+          "type": "distribution",
+          "url": "http://pysrc1.acme.org:8080/simple/zipp/#zipp-3.17.0.tar.gz"
+        }
+      ],
+      "name": "zipp",
+      "purl": "pkg:pypi/zipp@3.17.0?repository_url=http://pysrc1.acme.org:8080/simple",
+      "type": "library",
+      "version": "3.17.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "zipp@3.17.0"
+      ],
+      "ref": "importlib-metadata@7.0.1"
+    },
+    {
+      "dependsOn": [
+        "importlib-metadata@7.0.1",
+        "ml-dtypes@0.3.2",
+        "numpy@1.26.3",
+        "opt-einsum@3.3.0",
+        "scipy@1.11.4"
+      ],
+      "ref": "jax@0.4.20"
+    },
+    {
+      "dependsOn": [
+        "numpy@1.26.3"
+      ],
+      "ref": "ml-dtypes@0.3.2"
+    },
+    {
+      "ref": "numpy@1.26.3"
+    },
+    {
+      "dependsOn": [
+        "numpy@1.26.3"
+      ],
+      "ref": "opt-einsum@3.3.0"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6",
+        "jax@0.4.20",
+        "six@1.16.0",
+        "toml@0.10.2"
+      ],
+      "ref": "private-packges"
+    },
+    {
+      "dependsOn": [
+        "numpy@1.26.3"
+      ],
+      "ref": "scipy@1.11.4"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "zipp@3.17.0"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "private-packges",
+      "description": "packages from aternative package repositories",
+      "name": "private-packges",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_private-packges_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_private-packges_lock20_1.6.xml.bin
@@ -1,0 +1,815 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="private-packges">
+      <name>private-packges</name>
+      <version>0.1.0</version>
+      <description>packages from aternative package repositories</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="importlib-metadata@7.0.1">
+      <name>importlib-metadata</name>
+      <version>7.0.1</version>
+      <description>Read metadata from Python packages</description>
+      <purl>pkg:pypi/importlib-metadata@7.0.1?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/importlib-metadata/#importlib_metadata-7.0.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4805911c3a4ec7c3966410053e9ec6a1fecd629117df5adee56dfc9432a1081e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/importlib-metadata/#importlib_metadata-7.0.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f238736bb06590ae52ac1fab06a3a9ef1d8dce2b7a35b5ab329371d6c8f5d2cc</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="jax@0.4.20">
+      <name>jax</name>
+      <version>0.4.20</version>
+      <description>Differentiate, compile, and transform Numpy code.</description>
+      <purl>pkg:pypi/jax@0.4.20?repository_url=https://storage.googleapis.com/jax-releases/jax_releases.html</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://storage.googleapis.com/jax-releases/jax_releases.html/jax/#jax-0.4.20-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3d5952197adca548d99310f1c326bf00548f1cc8652b89edb369166482c2aec2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://storage.googleapis.com/jax-releases/jax_releases.html/jax/#jax-0.4.20.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ea96a763a8b1a9374639d1159ab4de163461d01cd022f67c34c09581b71ed2ac</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="ml-dtypes@0.3.2">
+      <name>ml-dtypes</name>
+      <version>0.3.2</version>
+      <description/>
+      <purl>pkg:pypi/ml-dtypes@0.3.2?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7afde548890a92b41c0fed3a6c525f1200a5727205f73dc21181a2726571bb53</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d1a746fe5fb9cd974a91070174258f0be129c592b93f9ce7df6cc336416c3fbd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961134ea44c7b8ca63eda902a44b58cd8bd670e21d62e255c81fba0a8e70d9b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b35c4e8ca957c877ac35c79ffa77724ecc3702a1e4b18b08306c03feae597bb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">763697ab8a88d47443997a7cdf3aac7340049aed45f7521f6b0ec8a0594821fe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b89b194e9501a92d289c1ffd411380baf5daafb9818109a4f49b0a1b6dce4462</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2c34f2ba9660b21fe1034b608308a01be82bbef2a92fb8199f24dc6bad0d5226</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6604877d567a29bfe7cc02969ae0f2425260e5335505cf5e7fefc3e5465f5655</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">93b78f53431c93953f7850bb1b925a17f0ab5d97527e38a7e865b5b4bc5cfc18</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a17ef2322e60858d93584e9c52a5be7dd6236b056b7fa1ec57f1bb6ba043e33</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e8505946df1665db01332d885c2020b4cb9e84a8b1241eb4ba69d59591f65855</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f47619d978ab1ae7dfdc4052ea97c636c6263e1f19bd1be0e42c346b98d15ff4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c7b3fb3d4f6b39bcd4f6c4b98f406291f0d681a895490ee29a0f95bab850d53c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7a4c3fcbf86fa52d0204f07cfd23947ef05b4ad743a1a988e163caa34a201e5e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">91f8783fd1f2c23fd3b9ee5ad66b785dafa58ba3cdb050c4458021fa4d1eb226</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7ba8e1fafc7fff3e643f453bffa7d082df1678a73286ce8187d3e825e776eb94</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/ml-dtypes/#ml_dtypes-0.3.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">533059bc5f1764fac071ef54598db358c167c51a718f68f5bb55e3dee79d2967</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="numpy@1.26.3">
+      <name>numpy</name>
+      <version>1.26.3</version>
+      <description>Fundamental package for array computing in Python</description>
+      <purl>pkg:pypi/numpy@1.26.3?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806dd64230dbbfaca8a27faa64e2f414bf1c6622ab78cc4264f7f5f028fee3bf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">02f98011ba4ab17f46f80f7f8f1c291ee7d855fcef0a5a98db80767a468c85cd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6d45b3ec2faed4baca41c76617fcdcfa4f684ff7a151ce6fc78ad3b6e85af0a6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bdd2b45bf079d9ad90377048e2747a0c82351989a2165821f0c96831b4a2a54b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">211ddd1e94817ed2d175b60b6374120244a4dd2287f4ece45d49228b4d529178</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b1240f767f69d7c4c8a29adde2310b871153df9b26b5cb2b54a561ac85146485</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">21a9484e75ad018974a2fdaa216524d64ed4212e418e0a551a2d83403b0531d3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9e1591f6ae98bcfac2a4bbf9221c0b92ab49762228f38287f6eeb5f3f55905ce</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b831295e5472954104ecb46cd98c08b98b49c69fdb7040483aff799a755a7374</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9e87562b91f68dd8b1c39149d0323b42e0082db7ddb8e934ab4c292094d575d6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8c66d6fec467e8c0f975818c1796d25c53521124b7cfb760114be0abad53a0a2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f25e2811a9c932e43943a2615e65fc487a0b6b49218899e62e426e7f0a57eeda</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">af36e0aa45e25c9f57bf684b1175e59ea05d9a7d3e8e87b7ae1a1da246f2767e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">51c7f1b344f302067b02e0f5b5d2daa9ed4a721cf49f070280ac202738ea7f00</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7ca4f24341df071877849eb2034948459ce3a07915c2734f1abb4018d9c49d7b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">39763aee6dfdd4878032361b30b2b12593fb445ddb66bbac802e2113eb8a6ac4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a7081fd19a6d573e1a05e600c82a1c421011db7935ed0d5c483e9dd96b99cf13</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">12c70ac274b32bc00c7f61b515126c9205323703abb99cd41836e8125ea0043e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7f784e13e598e9594750b2ef6729bcd5a47f6cfe4a12cca13def35e06d8163e3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5f24750ef94d56ce6e33e4019a8a4d68cfdb1ef661a52cdaee628a56d2437419</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">77810ef29e0fb1d289d225cabb9ee6cf4d11978a00bb99f7f8ec2132a84e0166</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8ed07a90f5450d99dad60d3799f9c03c6566709bd53b497eb9ccad9a55867f36</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f73497e8c38295aaa4741bdfa4fda1a5aedda5473074369eca10626835445511</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">da4b0c6c699a0ad73c810736303f7fbae483bcb012e38d7eb06a5e3b432c981b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1666f634cb3c80ccbd77ec97bc17337718f56d6658acf5d3b906ca03e90ce87f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">18c3319a7d39b2c6a9e3bb75aab2304ab79a811ac0168a671a62e6346c29b03f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0b7e807d6888da0db6e7e75838444d62495e2b588b99e90dd80c3459594e857b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b4d362e17bcb0011738c2d83e0a65ea8ce627057b2fdda37678f4374a382a137</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b8c275f0ae90069496068c714387b4a0eba5d531aace269559ff2b43655edd58</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cc0743f0302b94f397a4a65a660d4cd24267439eb16493fb3caad2e4389bccbb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9bc6d1a7f8cedd519c4b7b1156d98e051b726bf160715b769106661d567b3f03</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">867e3644e208c8922a3be26fc6bbf112a035f50f0a86497f98f228c50c607bb2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-pp39-pypy39_pp73-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3c67423b3703f8fbd90f5adaa37f85b5794d3366948efe9a5190a5f3a83fc34e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">46f47ee566d98849323f01b349d58f2557f02167ee301e5e28809a8c0e27a2d0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3-pp39-pypy39_pp73-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a8474703bffc65ca15853d5fd4d06b18138ae90c17c8d12169968e998e448bb5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/numpy/#numpy-1.26.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">697df43e2b6310ecc9d95f05d5ef20eacc09c7c4ecc9da3f235d39e71b7da1e4</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="opt-einsum@3.3.0">
+      <name>opt-einsum</name>
+      <version>3.3.0</version>
+      <description>Optimizing numpys einsum function</description>
+      <purl>pkg:pypi/opt-einsum@3.3.0?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/opt-einsum/#opt_einsum-3.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2455e59e3947d3c275477df7f5205b30635e266fe6dc300e3d9f9646bfcea147</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/opt-einsum/#opt_einsum-3.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">59f6475f77bbc37dcf7cd748519c0ec60722e91e63ca114e68821c0c54a46549</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="scipy@1.11.4">
+      <name>scipy</name>
+      <version>1.11.4</version>
+      <description>Fundamental algorithms for scientific computing in Python</description>
+      <purl>pkg:pypi/scipy@1.11.4?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bc9a714581f561af0848e6b69947fda0614915f072dfd14142ed1bfe1b806710</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp310-cp310-macosx_12_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cf00bd2b1b0211888d4dc75656c0412213a8b25e80d73898083f402b50f47e41</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b9999c008ccf00e8fbcce1236f85ade5c569d13144f77a1946bef8863e8f6eb4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">933baf588daa8dc9a92c20a0be32f56d43faf3d1a60ab11b3f08c356430f6e56</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8fce70f39076a5aa62e92e69a7f62349f9574d8405c0a5de6ed3ef72de07f446</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6550466fbeec7453d7465e74d4f4b19f905642c89a7525571ee91dd7adabb5a3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f313b39a7e94f296025e3cffc2c567618174c0b1dde173960cf23808f9fae4be</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp311-cp311-macosx_12_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1b7c3dca977f30a739e0409fb001056484661cb2541a01aba0bb0029f7b68db8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">00150c5eae7b610c32589dda259eacc7c4f1665aedf25d921907f4d08a951b1c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">530f9ad26440e85766509dbf78edcfe13ffd0ab7fec2560ee5c36ff74d6269ff</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5e347b14fe01003d3b78e196e84bd3f48ffe4c8a7b8a1afbcb8f5505cb710993</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">acf8ed278cc03f5aff035e69cb511741e0418681d25fbbb86ca65429c4f4d9cd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">028eccd22e654b3ea01ee63705681ee79933652b2d8f873e7949898dda6d11b6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp312-cp312-macosx_12_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2c6ff6ef9cc27f9b3db93a6f8b38f97387e6e0591600369a297a50a8e96e835d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b030c6674b9230d37c5c60ab456e2cf12f6784596d15ce8da9365e70896effc4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ad669df80528aeca5f557712102538f4f37e503f0c5b9541655016dd0932ca79</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ce7fff2e23ab2cc81ff452a9444c215c28e6305f396b2ba88343a567feec9660</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">36750b7733d960d7994888f0d148d31ea3017ac15eef664194b4ef68d36a4a97</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6e619aba2df228a9b34718efb023966da781e89dd3d21637b27f2e54db0410d7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp39-cp39-macosx_12_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f3cd9e7b3c2c1ec26364856f9fbe78695fe631150f94cd1c22228456404cf1ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d10e45a6c50211fe256da61a11c34927c68f277e03138777bdebedd933712fea</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">91af76a68eeae0064887a48e25c4e616fa519fa0d38602eda7e0f97d65d57937</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6df1468153a31cf55ed5ed39647279beb9cfb5d3f84369453b49e4b8502394fd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ee410e6de8f88fd5cf6eadd73c135020bfbbbdfcd0f6162c36a7638a1ea8cc65</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/scipy/#scipy-1.11.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">90a2b78e7f5733b9de748f589f09225013685f9b218275257f8a8168ededaeaa</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0?download_url=https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from url</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2?repository_url=http://pysrc2.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc2.acme.org:8080/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="zipp@3.17.0">
+      <name>zipp</name>
+      <version>3.17.0</version>
+      <description>Backport of pathlib-compatible object wrapper for zip files</description>
+      <purl>pkg:pypi/zipp@3.17.0?repository_url=http://pysrc1.acme.org:8080/simple</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/zipp/#zipp-3.17.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>http://pysrc1.acme.org:8080/simple/zipp/#zipp-3.17.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="importlib-metadata@7.0.1">
+      <dependency ref="zipp@3.17.0"/>
+    </dependency>
+    <dependency ref="jax@0.4.20">
+      <dependency ref="importlib-metadata@7.0.1"/>
+      <dependency ref="ml-dtypes@0.3.2"/>
+      <dependency ref="numpy@1.26.3"/>
+      <dependency ref="opt-einsum@3.3.0"/>
+      <dependency ref="scipy@1.11.4"/>
+    </dependency>
+    <dependency ref="ml-dtypes@0.3.2">
+      <dependency ref="numpy@1.26.3"/>
+    </dependency>
+    <dependency ref="numpy@1.26.3"/>
+    <dependency ref="opt-einsum@3.3.0">
+      <dependency ref="numpy@1.26.3"/>
+    </dependency>
+    <dependency ref="private-packges">
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="jax@0.4.20"/>
+      <dependency ref="six@1.16.0"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="scipy@1.11.4">
+      <dependency ref="numpy@1.26.3"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="zipp@3.17.0"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_regression-issue611_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_regression-issue611_lock20_1.6.json.bin
@@ -1,0 +1,80 @@
+{
+  "components": [
+    {
+      "bom-ref": "pyhumps@3.7.1",
+      "description": "\ud83d\udc2b  Convert strings (and dictionary keys) between snake case, camel case and pascal case in Python. Inspired by Humps for Node",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c6f2d833f2c7afae039d71b7dc0aba5412ae5b8c8c33d4a208c1d412de17229e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyhumps/#pyhumps-3.7.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5616f0afdbc73ef479fa9999f4abdcb336a0232707ff1a0b86e29fc9339e18da"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyhumps/#pyhumps-3.7.1.tar.gz"
+        }
+      ],
+      "name": "pyhumps",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pyhumps@3.7.1",
+      "type": "library",
+      "version": "3.7.1"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pyhumps@3.7.1"
+    },
+    {
+      "dependsOn": [
+        "pyhumps@3.7.1"
+      ],
+      "ref": "regression-issue611"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "regression-issue611",
+      "description": "regression for issue #611",
+      "name": "regression-issue611",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_regression-issue611_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_regression-issue611_lock20_1.6.xml.bin
@@ -1,0 +1,85 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="regression-issue611">
+      <name>regression-issue611</name>
+      <version>0.1.0</version>
+      <description>regression for issue #611</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="pyhumps@3.7.1">
+      <name>pyhumps</name>
+      <version>3.7.1</version>
+      <description>🐫  Convert strings (and dictionary keys) between snake case, camel case and pascal case in Python. Inspired by Humps for Node</description>
+      <purl>pkg:pypi/pyhumps@3.7.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyhumps/#pyhumps-3.7.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c6f2d833f2c7afae039d71b7dc0aba5412ae5b8c8c33d4a208c1d412de17229e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyhumps/#pyhumps-3.7.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5616f0afdbc73ef479fa9999f4abdcb336a0232707ff1a0b86e29fc9339e18da</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="pyhumps@3.7.1"/>
+    <dependency ref="regression-issue611">
+      <dependency ref="pyhumps@3.7.1"/>
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_regression-issue702_lock10_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_regression-issue702_lock10_1.6.json.bin
@@ -1,0 +1,1126 @@
+{
+  "components": [
+    {
+      "bom-ref": "aiohttp@3.9.3",
+      "description": "Async http client/server framework (asyncio)",
+      "name": "aiohttp",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/aiohttp@3.9.3",
+      "type": "library",
+      "version": "3.9.3"
+    },
+    {
+      "bom-ref": "aiohttp-cors@0.7.0",
+      "description": "CORS support for aiohttp",
+      "name": "aiohttp-cors",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/aiohttp-cors@0.7.0",
+      "type": "library",
+      "version": "0.7.0"
+    },
+    {
+      "bom-ref": "aiosignal@1.3.1",
+      "description": "aiosignal: a list of registered asynchronous callbacks",
+      "name": "aiosignal",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/aiosignal@1.3.1",
+      "type": "library",
+      "version": "1.3.1"
+    },
+    {
+      "bom-ref": "annotated-types@0.6.0",
+      "description": "Reusable constraint types to use with typing.Annotated",
+      "name": "annotated-types",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/annotated-types@0.6.0",
+      "type": "library",
+      "version": "0.6.0"
+    },
+    {
+      "bom-ref": "anyio@4.3.0",
+      "description": "High level compatibility layer for multiple asynchronous event loop implementations",
+      "name": "anyio",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/anyio@4.3.0",
+      "type": "library",
+      "version": "4.3.0"
+    },
+    {
+      "bom-ref": "async-timeout@4.0.3",
+      "description": "Timeout context manager for asyncio programs",
+      "name": "async-timeout",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/async-timeout@4.0.3",
+      "type": "library",
+      "version": "4.0.3"
+    },
+    {
+      "bom-ref": "attrs@23.2.0",
+      "description": "Classes Without Boilerplate",
+      "name": "attrs",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/attrs@23.2.0",
+      "type": "library",
+      "version": "23.2.0"
+    },
+    {
+      "bom-ref": "cachetools@5.3.3",
+      "description": "Extensible memoizing collections and decorators",
+      "name": "cachetools",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/cachetools@5.3.3",
+      "type": "library",
+      "version": "5.3.3"
+    },
+    {
+      "bom-ref": "certifi@2024.2.2",
+      "description": "Python package for providing Mozilla's CA Bundle.",
+      "name": "certifi",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/certifi@2024.2.2",
+      "type": "library",
+      "version": "2024.2.2"
+    },
+    {
+      "bom-ref": "charset-normalizer@3.3.2",
+      "description": "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet.",
+      "name": "charset-normalizer",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/charset-normalizer@3.3.2",
+      "type": "library",
+      "version": "3.3.2"
+    },
+    {
+      "bom-ref": "click@8.1.7",
+      "description": "Composable command line interface toolkit",
+      "name": "click",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/click@8.1.7",
+      "type": "library",
+      "version": "8.1.7"
+    },
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "colorful@0.5.6",
+      "description": "Terminal string styling done right, in Python.",
+      "name": "colorful",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorful@0.5.6",
+      "type": "library",
+      "version": "0.5.6"
+    },
+    {
+      "bom-ref": "distlib@0.3.8",
+      "description": "Distribution utilities",
+      "name": "distlib",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/distlib@0.3.8",
+      "type": "library",
+      "version": "0.3.8"
+    },
+    {
+      "bom-ref": "exceptiongroup@1.2.0",
+      "description": "Backport of PEP 654 (exception groups)",
+      "name": "exceptiongroup",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/exceptiongroup@1.2.0",
+      "type": "library",
+      "version": "1.2.0"
+    },
+    {
+      "bom-ref": "fastapi@0.1.17",
+      "description": "FastAPI framework, high performance, easy to learn, fast to code, ready for production",
+      "name": "fastapi",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/fastapi@0.1.17",
+      "type": "library",
+      "version": "0.1.17"
+    },
+    {
+      "bom-ref": "filelock@3.13.3",
+      "description": "A platform independent file lock.",
+      "name": "filelock",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/filelock@3.13.3",
+      "type": "library",
+      "version": "3.13.3"
+    },
+    {
+      "bom-ref": "frozenlist@1.4.1",
+      "description": "A list-like structure which implements collections.abc.MutableSequence",
+      "name": "frozenlist",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/frozenlist@1.4.1",
+      "type": "library",
+      "version": "1.4.1"
+    },
+    {
+      "bom-ref": "google-api-core@2.8.0",
+      "description": "Google API client core library",
+      "name": "google-api-core",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/google-api-core@2.8.0",
+      "type": "library",
+      "version": "2.8.0"
+    },
+    {
+      "bom-ref": "google-auth@2.29.0",
+      "description": "Google Authentication Library",
+      "name": "google-auth",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/google-auth@2.29.0",
+      "type": "library",
+      "version": "2.29.0"
+    },
+    {
+      "bom-ref": "googleapis-common-protos@1.56.1",
+      "description": "Common protobufs used in Google APIs",
+      "name": "googleapis-common-protos",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/googleapis-common-protos@1.56.1",
+      "type": "library",
+      "version": "1.56.1"
+    },
+    {
+      "bom-ref": "grpcio@1.62.1",
+      "description": "HTTP/2-based RPC framework",
+      "name": "grpcio",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/grpcio@1.62.1",
+      "type": "library",
+      "version": "1.62.1"
+    },
+    {
+      "bom-ref": "h11@0.14.0",
+      "description": "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1",
+      "name": "h11",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/h11@0.14.0",
+      "type": "library",
+      "version": "0.14.0"
+    },
+    {
+      "bom-ref": "idna@3.6",
+      "description": "Internationalized Domain Names in Applications (IDNA)",
+      "name": "idna",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/idna@3.6",
+      "type": "library",
+      "version": "3.6"
+    },
+    {
+      "bom-ref": "jsonschema@4.21.1",
+      "description": "An implementation of JSON Schema validation for Python",
+      "name": "jsonschema",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema@4.21.1",
+      "type": "library",
+      "version": "4.21.1"
+    },
+    {
+      "bom-ref": "jsonschema-specifications@2023.12.1",
+      "description": "The JSON Schema meta-schemas and vocabularies, exposed as a Registry",
+      "name": "jsonschema-specifications",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema-specifications@2023.12.1",
+      "type": "library",
+      "version": "2023.12.1"
+    },
+    {
+      "bom-ref": "msgpack@1.0.8",
+      "description": "MessagePack serializer",
+      "name": "msgpack",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/msgpack@1.0.8",
+      "type": "library",
+      "version": "1.0.8"
+    },
+    {
+      "bom-ref": "multidict@6.0.5",
+      "description": "multidict implementation",
+      "name": "multidict",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/multidict@6.0.5",
+      "type": "library",
+      "version": "6.0.5"
+    },
+    {
+      "bom-ref": "opencensus@0.11.4",
+      "description": "A stats collection and distributed tracing framework",
+      "name": "opencensus",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/opencensus@0.11.4",
+      "type": "library",
+      "version": "0.11.4"
+    },
+    {
+      "bom-ref": "opencensus-context@0.1.3",
+      "description": "OpenCensus Runtime Context",
+      "name": "opencensus-context",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/opencensus-context@0.1.3",
+      "type": "library",
+      "version": "0.1.3"
+    },
+    {
+      "bom-ref": "packaging@24.0",
+      "description": "Core utilities for Python packages",
+      "name": "packaging",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/packaging@24.0",
+      "type": "library",
+      "version": "24.0"
+    },
+    {
+      "bom-ref": "platformdirs@4.2.0",
+      "description": "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\".",
+      "name": "platformdirs",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/platformdirs@4.2.0",
+      "type": "library",
+      "version": "4.2.0"
+    },
+    {
+      "bom-ref": "prometheus-client@0.20.0",
+      "description": "Python client for the Prometheus monitoring system.",
+      "name": "prometheus-client",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/prometheus-client@0.20.0",
+      "type": "library",
+      "version": "0.20.0"
+    },
+    {
+      "bom-ref": "protobuf@5.26.1",
+      "description": "",
+      "name": "protobuf",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/protobuf@5.26.1",
+      "type": "library",
+      "version": "5.26.1"
+    },
+    {
+      "bom-ref": "py-spy@0.3.14",
+      "description": "Sampling profiler for Python programs",
+      "name": "py-spy",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/py-spy@0.3.14",
+      "type": "library",
+      "version": "0.3.14"
+    },
+    {
+      "bom-ref": "pyasn1@0.6.0",
+      "description": "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)",
+      "name": "pyasn1",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pyasn1@0.6.0",
+      "type": "library",
+      "version": "0.6.0"
+    },
+    {
+      "bom-ref": "pyasn1-modules@0.4.0",
+      "description": "A collection of ASN.1-based protocols modules",
+      "name": "pyasn1-modules",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pyasn1-modules@0.4.0",
+      "type": "library",
+      "version": "0.4.0"
+    },
+    {
+      "bom-ref": "pydantic@2.6.4",
+      "description": "Data validation using Python type hints",
+      "name": "pydantic",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pydantic@2.6.4",
+      "type": "library",
+      "version": "2.6.4"
+    },
+    {
+      "bom-ref": "pydantic-core@2.16.3",
+      "description": "",
+      "name": "pydantic-core",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pydantic-core@2.16.3",
+      "type": "library",
+      "version": "2.16.3"
+    },
+    {
+      "bom-ref": "pyyaml@6.0.1",
+      "description": "YAML parser and emitter for Python",
+      "name": "pyyaml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pyyaml@6.0.1",
+      "type": "library",
+      "version": "6.0.1"
+    },
+    {
+      "bom-ref": "ray@2.10.0",
+      "description": "Ray provides a simple, universal API for building distributed applications.",
+      "name": "ray",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "serve"
+        }
+      ],
+      "purl": "pkg:pypi/ray@2.10.0",
+      "type": "library",
+      "version": "2.10.0"
+    },
+    {
+      "bom-ref": "referencing@0.34.0",
+      "description": "JSON Referencing + Python",
+      "name": "referencing",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/referencing@0.34.0",
+      "type": "library",
+      "version": "0.34.0"
+    },
+    {
+      "bom-ref": "requests@2.31.0",
+      "description": "Python HTTP for Humans.",
+      "name": "requests",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/requests@2.31.0",
+      "type": "library",
+      "version": "2.31.0"
+    },
+    {
+      "bom-ref": "rpds-py@0.18.0",
+      "description": "Python bindings to Rust's persistent data structures (rpds)",
+      "name": "rpds-py",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/rpds-py@0.18.0",
+      "type": "library",
+      "version": "0.18.0"
+    },
+    {
+      "bom-ref": "rsa@4.9",
+      "description": "Pure-Python RSA implementation",
+      "name": "rsa",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/rsa@4.9",
+      "type": "library",
+      "version": "4.9"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "smart-open@7.0.4",
+      "description": "Utils for streaming large files (S3, HDFS, GCS, Azure Blob Storage, gzip, bz2...)",
+      "name": "smart-open",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/smart-open@7.0.4",
+      "type": "library",
+      "version": "7.0.4"
+    },
+    {
+      "bom-ref": "sniffio@1.3.1",
+      "description": "Sniff out which async library your code is running under",
+      "name": "sniffio",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/sniffio@1.3.1",
+      "type": "library",
+      "version": "1.3.1"
+    },
+    {
+      "bom-ref": "starlette@0.37.2",
+      "description": "The little ASGI library that shines.",
+      "name": "starlette",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/starlette@0.37.2",
+      "type": "library",
+      "version": "0.37.2"
+    },
+    {
+      "bom-ref": "typing-extensions@4.10.0",
+      "description": "Backported and Experimental Type Hints for Python 3.8+",
+      "name": "typing-extensions",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/typing-extensions@4.10.0",
+      "type": "library",
+      "version": "4.10.0"
+    },
+    {
+      "bom-ref": "urllib3@2.2.1",
+      "description": "HTTP library with thread-safe connection pooling, file post, and more.",
+      "name": "urllib3",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/urllib3@2.2.1",
+      "type": "library",
+      "version": "2.2.1"
+    },
+    {
+      "bom-ref": "uvicorn@0.29.0",
+      "description": "The lightning-fast ASGI server.",
+      "name": "uvicorn",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/uvicorn@0.29.0",
+      "type": "library",
+      "version": "0.29.0"
+    },
+    {
+      "bom-ref": "virtualenv@20.25.1",
+      "description": "Virtual Python Environment builder",
+      "name": "virtualenv",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/virtualenv@20.25.1",
+      "type": "library",
+      "version": "20.25.1"
+    },
+    {
+      "bom-ref": "watchfiles@0.21.0",
+      "description": "Simple, modern and high performance file watching and code reload in python.",
+      "name": "watchfiles",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/watchfiles@0.21.0",
+      "type": "library",
+      "version": "0.21.0"
+    },
+    {
+      "bom-ref": "wrapt@1.16.0",
+      "description": "Module for decorators, wrappers and monkey patching.",
+      "name": "wrapt",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/wrapt@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "yarl@1.9.4",
+      "description": "Yet another URL library",
+      "name": "yarl",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/yarl@1.9.4",
+      "type": "library",
+      "version": "1.9.4"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "aiohttp@3.9.3"
+      ],
+      "ref": "aiohttp-cors@0.7.0"
+    },
+    {
+      "dependsOn": [
+        "aiosignal@1.3.1",
+        "async-timeout@4.0.3",
+        "attrs@23.2.0",
+        "frozenlist@1.4.1",
+        "multidict@6.0.5",
+        "yarl@1.9.4"
+      ],
+      "ref": "aiohttp@3.9.3"
+    },
+    {
+      "dependsOn": [
+        "frozenlist@1.4.1"
+      ],
+      "ref": "aiosignal@1.3.1"
+    },
+    {
+      "ref": "annotated-types@0.6.0"
+    },
+    {
+      "dependsOn": [
+        "exceptiongroup@1.2.0",
+        "idna@3.6",
+        "sniffio@1.3.1",
+        "typing-extensions@4.10.0"
+      ],
+      "ref": "anyio@4.3.0"
+    },
+    {
+      "ref": "async-timeout@4.0.3"
+    },
+    {
+      "ref": "attrs@23.2.0"
+    },
+    {
+      "ref": "cachetools@5.3.3"
+    },
+    {
+      "ref": "certifi@2024.2.2"
+    },
+    {
+      "ref": "charset-normalizer@3.3.2"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6"
+      ],
+      "ref": "click@8.1.7"
+    },
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6"
+      ],
+      "ref": "colorful@0.5.6"
+    },
+    {
+      "ref": "distlib@0.3.8"
+    },
+    {
+      "ref": "exceptiongroup@1.2.0"
+    },
+    {
+      "dependsOn": [
+        "pydantic@2.6.4",
+        "starlette@0.37.2"
+      ],
+      "ref": "fastapi@0.1.17"
+    },
+    {
+      "ref": "filelock@3.13.3"
+    },
+    {
+      "ref": "frozenlist@1.4.1"
+    },
+    {
+      "dependsOn": [
+        "google-auth@2.29.0",
+        "googleapis-common-protos@1.56.1",
+        "protobuf@5.26.1",
+        "requests@2.31.0"
+      ],
+      "ref": "google-api-core@2.8.0"
+    },
+    {
+      "dependsOn": [
+        "cachetools@5.3.3",
+        "pyasn1-modules@0.4.0",
+        "rsa@4.9"
+      ],
+      "ref": "google-auth@2.29.0"
+    },
+    {
+      "dependsOn": [
+        "protobuf@5.26.1"
+      ],
+      "ref": "googleapis-common-protos@1.56.1"
+    },
+    {
+      "ref": "grpcio@1.62.1"
+    },
+    {
+      "ref": "h11@0.14.0"
+    },
+    {
+      "ref": "idna@3.6"
+    },
+    {
+      "dependsOn": [
+        "referencing@0.34.0"
+      ],
+      "ref": "jsonschema-specifications@2023.12.1"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.2.0",
+        "jsonschema-specifications@2023.12.1",
+        "referencing@0.34.0",
+        "rpds-py@0.18.0"
+      ],
+      "ref": "jsonschema@4.21.1"
+    },
+    {
+      "ref": "msgpack@1.0.8"
+    },
+    {
+      "ref": "multidict@6.0.5"
+    },
+    {
+      "ref": "opencensus-context@0.1.3"
+    },
+    {
+      "dependsOn": [
+        "google-api-core@2.8.0",
+        "opencensus-context@0.1.3",
+        "six@1.16.0"
+      ],
+      "ref": "opencensus@0.11.4"
+    },
+    {
+      "ref": "packaging@24.0"
+    },
+    {
+      "ref": "platformdirs@4.2.0"
+    },
+    {
+      "ref": "prometheus-client@0.20.0"
+    },
+    {
+      "ref": "protobuf@5.26.1"
+    },
+    {
+      "ref": "py-spy@0.3.14"
+    },
+    {
+      "dependsOn": [
+        "pyasn1@0.6.0"
+      ],
+      "ref": "pyasn1-modules@0.4.0"
+    },
+    {
+      "ref": "pyasn1@0.6.0"
+    },
+    {
+      "dependsOn": [
+        "typing-extensions@4.10.0"
+      ],
+      "ref": "pydantic-core@2.16.3"
+    },
+    {
+      "dependsOn": [
+        "annotated-types@0.6.0",
+        "pydantic-core@2.16.3",
+        "typing-extensions@4.10.0"
+      ],
+      "ref": "pydantic@2.6.4"
+    },
+    {
+      "ref": "pyyaml@6.0.1"
+    },
+    {
+      "dependsOn": [
+        "aiohttp-cors@0.7.0",
+        "aiohttp@3.9.3",
+        "aiosignal@1.3.1",
+        "click@8.1.7",
+        "colorful@0.5.6",
+        "fastapi@0.1.17",
+        "filelock@3.13.3",
+        "frozenlist@1.4.1",
+        "grpcio@1.62.1",
+        "jsonschema@4.21.1",
+        "msgpack@1.0.8",
+        "opencensus@0.11.4",
+        "packaging@24.0",
+        "prometheus-client@0.20.0",
+        "protobuf@5.26.1",
+        "py-spy@0.3.14",
+        "pydantic@2.6.4",
+        "pyyaml@6.0.1",
+        "requests@2.31.0",
+        "smart-open@7.0.4",
+        "starlette@0.37.2",
+        "uvicorn@0.29.0",
+        "virtualenv@20.25.1",
+        "watchfiles@0.21.0"
+      ],
+      "ref": "ray@2.10.0"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.2.0",
+        "rpds-py@0.18.0"
+      ],
+      "ref": "referencing@0.34.0"
+    },
+    {
+      "dependsOn": [
+        "ray@2.10.0"
+      ],
+      "ref": "regression-issue702"
+    },
+    {
+      "dependsOn": [
+        "certifi@2024.2.2",
+        "charset-normalizer@3.3.2",
+        "idna@3.6",
+        "urllib3@2.2.1"
+      ],
+      "ref": "requests@2.31.0"
+    },
+    {
+      "ref": "rpds-py@0.18.0"
+    },
+    {
+      "dependsOn": [
+        "pyasn1@0.6.0"
+      ],
+      "ref": "rsa@4.9"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "dependsOn": [
+        "wrapt@1.16.0"
+      ],
+      "ref": "smart-open@7.0.4"
+    },
+    {
+      "ref": "sniffio@1.3.1"
+    },
+    {
+      "dependsOn": [
+        "anyio@4.3.0"
+      ],
+      "ref": "starlette@0.37.2"
+    },
+    {
+      "ref": "typing-extensions@4.10.0"
+    },
+    {
+      "ref": "urllib3@2.2.1"
+    },
+    {
+      "dependsOn": [
+        "click@8.1.7",
+        "h11@0.14.0",
+        "typing-extensions@4.10.0"
+      ],
+      "ref": "uvicorn@0.29.0"
+    },
+    {
+      "dependsOn": [
+        "distlib@0.3.8",
+        "filelock@3.13.3",
+        "platformdirs@4.2.0"
+      ],
+      "ref": "virtualenv@20.25.1"
+    },
+    {
+      "dependsOn": [
+        "anyio@4.3.0"
+      ],
+      "ref": "watchfiles@0.21.0"
+    },
+    {
+      "ref": "wrapt@1.16.0"
+    },
+    {
+      "dependsOn": [
+        "idna@3.6",
+        "multidict@6.0.5"
+      ],
+      "ref": "yarl@1.9.4"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "regression-issue702",
+      "description": "regression for issue #702",
+      "name": "regression-issue702",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_regression-issue702_lock10_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_regression-issue702_lock10_1.6.xml.bin
@@ -1,0 +1,725 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="regression-issue702">
+      <name>regression-issue702</name>
+      <version>0.1.0</version>
+      <description>regression for issue #702</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="aiohttp@3.9.3">
+      <name>aiohttp</name>
+      <version>3.9.3</version>
+      <description>Async http client/server framework (asyncio)</description>
+      <purl>pkg:pypi/aiohttp@3.9.3</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="aiohttp-cors@0.7.0">
+      <name>aiohttp-cors</name>
+      <version>0.7.0</version>
+      <description>CORS support for aiohttp</description>
+      <purl>pkg:pypi/aiohttp-cors@0.7.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="aiosignal@1.3.1">
+      <name>aiosignal</name>
+      <version>1.3.1</version>
+      <description>aiosignal: a list of registered asynchronous callbacks</description>
+      <purl>pkg:pypi/aiosignal@1.3.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="annotated-types@0.6.0">
+      <name>annotated-types</name>
+      <version>0.6.0</version>
+      <description>Reusable constraint types to use with typing.Annotated</description>
+      <purl>pkg:pypi/annotated-types@0.6.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="anyio@4.3.0">
+      <name>anyio</name>
+      <version>4.3.0</version>
+      <description>High level compatibility layer for multiple asynchronous event loop implementations</description>
+      <purl>pkg:pypi/anyio@4.3.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="async-timeout@4.0.3">
+      <name>async-timeout</name>
+      <version>4.0.3</version>
+      <description>Timeout context manager for asyncio programs</description>
+      <purl>pkg:pypi/async-timeout@4.0.3</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="attrs@23.2.0">
+      <name>attrs</name>
+      <version>23.2.0</version>
+      <description>Classes Without Boilerplate</description>
+      <purl>pkg:pypi/attrs@23.2.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="cachetools@5.3.3">
+      <name>cachetools</name>
+      <version>5.3.3</version>
+      <description>Extensible memoizing collections and decorators</description>
+      <purl>pkg:pypi/cachetools@5.3.3</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="certifi@2024.2.2">
+      <name>certifi</name>
+      <version>2024.2.2</version>
+      <description>Python package for providing Mozilla's CA Bundle.</description>
+      <purl>pkg:pypi/certifi@2024.2.2</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="charset-normalizer@3.3.2">
+      <name>charset-normalizer</name>
+      <version>3.3.2</version>
+      <description>The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet.</description>
+      <purl>pkg:pypi/charset-normalizer@3.3.2</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="click@8.1.7">
+      <name>click</name>
+      <version>8.1.7</version>
+      <description>Composable command line interface toolkit</description>
+      <purl>pkg:pypi/click@8.1.7</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorful@0.5.6">
+      <name>colorful</name>
+      <version>0.5.6</version>
+      <description>Terminal string styling done right, in Python.</description>
+      <purl>pkg:pypi/colorful@0.5.6</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="distlib@0.3.8">
+      <name>distlib</name>
+      <version>0.3.8</version>
+      <description>Distribution utilities</description>
+      <purl>pkg:pypi/distlib@0.3.8</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="exceptiongroup@1.2.0">
+      <name>exceptiongroup</name>
+      <version>1.2.0</version>
+      <description>Backport of PEP 654 (exception groups)</description>
+      <purl>pkg:pypi/exceptiongroup@1.2.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="fastapi@0.1.17">
+      <name>fastapi</name>
+      <version>0.1.17</version>
+      <description>FastAPI framework, high performance, easy to learn, fast to code, ready for production</description>
+      <purl>pkg:pypi/fastapi@0.1.17</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="filelock@3.13.3">
+      <name>filelock</name>
+      <version>3.13.3</version>
+      <description>A platform independent file lock.</description>
+      <purl>pkg:pypi/filelock@3.13.3</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="frozenlist@1.4.1">
+      <name>frozenlist</name>
+      <version>1.4.1</version>
+      <description>A list-like structure which implements collections.abc.MutableSequence</description>
+      <purl>pkg:pypi/frozenlist@1.4.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="google-api-core@2.8.0">
+      <name>google-api-core</name>
+      <version>2.8.0</version>
+      <description>Google API client core library</description>
+      <purl>pkg:pypi/google-api-core@2.8.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="google-auth@2.29.0">
+      <name>google-auth</name>
+      <version>2.29.0</version>
+      <description>Google Authentication Library</description>
+      <purl>pkg:pypi/google-auth@2.29.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="googleapis-common-protos@1.56.1">
+      <name>googleapis-common-protos</name>
+      <version>1.56.1</version>
+      <description>Common protobufs used in Google APIs</description>
+      <purl>pkg:pypi/googleapis-common-protos@1.56.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="grpcio@1.62.1">
+      <name>grpcio</name>
+      <version>1.62.1</version>
+      <description>HTTP/2-based RPC framework</description>
+      <purl>pkg:pypi/grpcio@1.62.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="h11@0.14.0">
+      <name>h11</name>
+      <version>0.14.0</version>
+      <description>A pure-Python, bring-your-own-I/O implementation of HTTP/1.1</description>
+      <purl>pkg:pypi/h11@0.14.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="idna@3.6">
+      <name>idna</name>
+      <version>3.6</version>
+      <description>Internationalized Domain Names in Applications (IDNA)</description>
+      <purl>pkg:pypi/idna@3.6</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema@4.21.1">
+      <name>jsonschema</name>
+      <version>4.21.1</version>
+      <description>An implementation of JSON Schema validation for Python</description>
+      <purl>pkg:pypi/jsonschema@4.21.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema-specifications@2023.12.1">
+      <name>jsonschema-specifications</name>
+      <version>2023.12.1</version>
+      <description>The JSON Schema meta-schemas and vocabularies, exposed as a Registry</description>
+      <purl>pkg:pypi/jsonschema-specifications@2023.12.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="msgpack@1.0.8">
+      <name>msgpack</name>
+      <version>1.0.8</version>
+      <description>MessagePack serializer</description>
+      <purl>pkg:pypi/msgpack@1.0.8</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="multidict@6.0.5">
+      <name>multidict</name>
+      <version>6.0.5</version>
+      <description>multidict implementation</description>
+      <purl>pkg:pypi/multidict@6.0.5</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="opencensus@0.11.4">
+      <name>opencensus</name>
+      <version>0.11.4</version>
+      <description>A stats collection and distributed tracing framework</description>
+      <purl>pkg:pypi/opencensus@0.11.4</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="opencensus-context@0.1.3">
+      <name>opencensus-context</name>
+      <version>0.1.3</version>
+      <description>OpenCensus Runtime Context</description>
+      <purl>pkg:pypi/opencensus-context@0.1.3</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="packaging@24.0">
+      <name>packaging</name>
+      <version>24.0</version>
+      <description>Core utilities for Python packages</description>
+      <purl>pkg:pypi/packaging@24.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="platformdirs@4.2.0">
+      <name>platformdirs</name>
+      <version>4.2.0</version>
+      <description>A small Python package for determining appropriate platform-specific dirs, e.g. a &quot;user data dir&quot;.</description>
+      <purl>pkg:pypi/platformdirs@4.2.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="prometheus-client@0.20.0">
+      <name>prometheus-client</name>
+      <version>0.20.0</version>
+      <description>Python client for the Prometheus monitoring system.</description>
+      <purl>pkg:pypi/prometheus-client@0.20.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="protobuf@5.26.1">
+      <name>protobuf</name>
+      <version>5.26.1</version>
+      <description/>
+      <purl>pkg:pypi/protobuf@5.26.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="py-spy@0.3.14">
+      <name>py-spy</name>
+      <version>0.3.14</version>
+      <description>Sampling profiler for Python programs</description>
+      <purl>pkg:pypi/py-spy@0.3.14</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pyasn1@0.6.0">
+      <name>pyasn1</name>
+      <version>0.6.0</version>
+      <description>Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)</description>
+      <purl>pkg:pypi/pyasn1@0.6.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pyasn1-modules@0.4.0">
+      <name>pyasn1-modules</name>
+      <version>0.4.0</version>
+      <description>A collection of ASN.1-based protocols modules</description>
+      <purl>pkg:pypi/pyasn1-modules@0.4.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pydantic@2.6.4">
+      <name>pydantic</name>
+      <version>2.6.4</version>
+      <description>Data validation using Python type hints</description>
+      <purl>pkg:pypi/pydantic@2.6.4</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pydantic-core@2.16.3">
+      <name>pydantic-core</name>
+      <version>2.16.3</version>
+      <description/>
+      <purl>pkg:pypi/pydantic-core@2.16.3</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pyyaml@6.0.1">
+      <name>pyyaml</name>
+      <version>6.0.1</version>
+      <description>YAML parser and emitter for Python</description>
+      <purl>pkg:pypi/pyyaml@6.0.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="ray@2.10.0">
+      <name>ray</name>
+      <version>2.10.0</version>
+      <description>Ray provides a simple, universal API for building distributed applications.</description>
+      <purl>pkg:pypi/ray@2.10.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:required-extra">serve</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="referencing@0.34.0">
+      <name>referencing</name>
+      <version>0.34.0</version>
+      <description>JSON Referencing + Python</description>
+      <purl>pkg:pypi/referencing@0.34.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="requests@2.31.0">
+      <name>requests</name>
+      <version>2.31.0</version>
+      <description>Python HTTP for Humans.</description>
+      <purl>pkg:pypi/requests@2.31.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rpds-py@0.18.0">
+      <name>rpds-py</name>
+      <version>0.18.0</version>
+      <description>Python bindings to Rust's persistent data structures (rpds)</description>
+      <purl>pkg:pypi/rpds-py@0.18.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rsa@4.9">
+      <name>rsa</name>
+      <version>4.9</version>
+      <description>Pure-Python RSA implementation</description>
+      <purl>pkg:pypi/rsa@4.9</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="smart-open@7.0.4">
+      <name>smart-open</name>
+      <version>7.0.4</version>
+      <description>Utils for streaming large files (S3, HDFS, GCS, Azure Blob Storage, gzip, bz2...)</description>
+      <purl>pkg:pypi/smart-open@7.0.4</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="sniffio@1.3.1">
+      <name>sniffio</name>
+      <version>1.3.1</version>
+      <description>Sniff out which async library your code is running under</description>
+      <purl>pkg:pypi/sniffio@1.3.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="starlette@0.37.2">
+      <name>starlette</name>
+      <version>0.37.2</version>
+      <description>The little ASGI library that shines.</description>
+      <purl>pkg:pypi/starlette@0.37.2</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="typing-extensions@4.10.0">
+      <name>typing-extensions</name>
+      <version>4.10.0</version>
+      <description>Backported and Experimental Type Hints for Python 3.8+</description>
+      <purl>pkg:pypi/typing-extensions@4.10.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="urllib3@2.2.1">
+      <name>urllib3</name>
+      <version>2.2.1</version>
+      <description>HTTP library with thread-safe connection pooling, file post, and more.</description>
+      <purl>pkg:pypi/urllib3@2.2.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="uvicorn@0.29.0">
+      <name>uvicorn</name>
+      <version>0.29.0</version>
+      <description>The lightning-fast ASGI server.</description>
+      <purl>pkg:pypi/uvicorn@0.29.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="virtualenv@20.25.1">
+      <name>virtualenv</name>
+      <version>20.25.1</version>
+      <description>Virtual Python Environment builder</description>
+      <purl>pkg:pypi/virtualenv@20.25.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="watchfiles@0.21.0">
+      <name>watchfiles</name>
+      <version>0.21.0</version>
+      <description>Simple, modern and high performance file watching and code reload in python.</description>
+      <purl>pkg:pypi/watchfiles@0.21.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="wrapt@1.16.0">
+      <name>wrapt</name>
+      <version>1.16.0</version>
+      <description>Module for decorators, wrappers and monkey patching.</description>
+      <purl>pkg:pypi/wrapt@1.16.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="yarl@1.9.4">
+      <name>yarl</name>
+      <version>1.9.4</version>
+      <description>Yet another URL library</description>
+      <purl>pkg:pypi/yarl@1.9.4</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="aiohttp-cors@0.7.0">
+      <dependency ref="aiohttp@3.9.3"/>
+    </dependency>
+    <dependency ref="aiohttp@3.9.3">
+      <dependency ref="aiosignal@1.3.1"/>
+      <dependency ref="async-timeout@4.0.3"/>
+      <dependency ref="attrs@23.2.0"/>
+      <dependency ref="frozenlist@1.4.1"/>
+      <dependency ref="multidict@6.0.5"/>
+      <dependency ref="yarl@1.9.4"/>
+    </dependency>
+    <dependency ref="aiosignal@1.3.1">
+      <dependency ref="frozenlist@1.4.1"/>
+    </dependency>
+    <dependency ref="annotated-types@0.6.0"/>
+    <dependency ref="anyio@4.3.0">
+      <dependency ref="exceptiongroup@1.2.0"/>
+      <dependency ref="idna@3.6"/>
+      <dependency ref="sniffio@1.3.1"/>
+      <dependency ref="typing-extensions@4.10.0"/>
+    </dependency>
+    <dependency ref="async-timeout@4.0.3"/>
+    <dependency ref="attrs@23.2.0"/>
+    <dependency ref="cachetools@5.3.3"/>
+    <dependency ref="certifi@2024.2.2"/>
+    <dependency ref="charset-normalizer@3.3.2"/>
+    <dependency ref="click@8.1.7">
+      <dependency ref="colorama@0.4.6"/>
+    </dependency>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="colorful@0.5.6">
+      <dependency ref="colorama@0.4.6"/>
+    </dependency>
+    <dependency ref="distlib@0.3.8"/>
+    <dependency ref="exceptiongroup@1.2.0"/>
+    <dependency ref="fastapi@0.1.17">
+      <dependency ref="pydantic@2.6.4"/>
+      <dependency ref="starlette@0.37.2"/>
+    </dependency>
+    <dependency ref="filelock@3.13.3"/>
+    <dependency ref="frozenlist@1.4.1"/>
+    <dependency ref="google-api-core@2.8.0">
+      <dependency ref="google-auth@2.29.0"/>
+      <dependency ref="googleapis-common-protos@1.56.1"/>
+      <dependency ref="protobuf@5.26.1"/>
+      <dependency ref="requests@2.31.0"/>
+    </dependency>
+    <dependency ref="google-auth@2.29.0">
+      <dependency ref="cachetools@5.3.3"/>
+      <dependency ref="pyasn1-modules@0.4.0"/>
+      <dependency ref="rsa@4.9"/>
+    </dependency>
+    <dependency ref="googleapis-common-protos@1.56.1">
+      <dependency ref="protobuf@5.26.1"/>
+    </dependency>
+    <dependency ref="grpcio@1.62.1"/>
+    <dependency ref="h11@0.14.0"/>
+    <dependency ref="idna@3.6"/>
+    <dependency ref="jsonschema-specifications@2023.12.1">
+      <dependency ref="referencing@0.34.0"/>
+    </dependency>
+    <dependency ref="jsonschema@4.21.1">
+      <dependency ref="attrs@23.2.0"/>
+      <dependency ref="jsonschema-specifications@2023.12.1"/>
+      <dependency ref="referencing@0.34.0"/>
+      <dependency ref="rpds-py@0.18.0"/>
+    </dependency>
+    <dependency ref="msgpack@1.0.8"/>
+    <dependency ref="multidict@6.0.5"/>
+    <dependency ref="opencensus-context@0.1.3"/>
+    <dependency ref="opencensus@0.11.4">
+      <dependency ref="google-api-core@2.8.0"/>
+      <dependency ref="opencensus-context@0.1.3"/>
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="packaging@24.0"/>
+    <dependency ref="platformdirs@4.2.0"/>
+    <dependency ref="prometheus-client@0.20.0"/>
+    <dependency ref="protobuf@5.26.1"/>
+    <dependency ref="py-spy@0.3.14"/>
+    <dependency ref="pyasn1-modules@0.4.0">
+      <dependency ref="pyasn1@0.6.0"/>
+    </dependency>
+    <dependency ref="pyasn1@0.6.0"/>
+    <dependency ref="pydantic-core@2.16.3">
+      <dependency ref="typing-extensions@4.10.0"/>
+    </dependency>
+    <dependency ref="pydantic@2.6.4">
+      <dependency ref="annotated-types@0.6.0"/>
+      <dependency ref="pydantic-core@2.16.3"/>
+      <dependency ref="typing-extensions@4.10.0"/>
+    </dependency>
+    <dependency ref="pyyaml@6.0.1"/>
+    <dependency ref="ray@2.10.0">
+      <dependency ref="aiohttp-cors@0.7.0"/>
+      <dependency ref="aiohttp@3.9.3"/>
+      <dependency ref="aiosignal@1.3.1"/>
+      <dependency ref="click@8.1.7"/>
+      <dependency ref="colorful@0.5.6"/>
+      <dependency ref="fastapi@0.1.17"/>
+      <dependency ref="filelock@3.13.3"/>
+      <dependency ref="frozenlist@1.4.1"/>
+      <dependency ref="grpcio@1.62.1"/>
+      <dependency ref="jsonschema@4.21.1"/>
+      <dependency ref="msgpack@1.0.8"/>
+      <dependency ref="opencensus@0.11.4"/>
+      <dependency ref="packaging@24.0"/>
+      <dependency ref="prometheus-client@0.20.0"/>
+      <dependency ref="protobuf@5.26.1"/>
+      <dependency ref="py-spy@0.3.14"/>
+      <dependency ref="pydantic@2.6.4"/>
+      <dependency ref="pyyaml@6.0.1"/>
+      <dependency ref="requests@2.31.0"/>
+      <dependency ref="smart-open@7.0.4"/>
+      <dependency ref="starlette@0.37.2"/>
+      <dependency ref="uvicorn@0.29.0"/>
+      <dependency ref="virtualenv@20.25.1"/>
+      <dependency ref="watchfiles@0.21.0"/>
+    </dependency>
+    <dependency ref="referencing@0.34.0">
+      <dependency ref="attrs@23.2.0"/>
+      <dependency ref="rpds-py@0.18.0"/>
+    </dependency>
+    <dependency ref="regression-issue702">
+      <dependency ref="ray@2.10.0"/>
+    </dependency>
+    <dependency ref="requests@2.31.0">
+      <dependency ref="certifi@2024.2.2"/>
+      <dependency ref="charset-normalizer@3.3.2"/>
+      <dependency ref="idna@3.6"/>
+      <dependency ref="urllib3@2.2.1"/>
+    </dependency>
+    <dependency ref="rpds-py@0.18.0"/>
+    <dependency ref="rsa@4.9">
+      <dependency ref="pyasn1@0.6.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="smart-open@7.0.4">
+      <dependency ref="wrapt@1.16.0"/>
+    </dependency>
+    <dependency ref="sniffio@1.3.1"/>
+    <dependency ref="starlette@0.37.2">
+      <dependency ref="anyio@4.3.0"/>
+    </dependency>
+    <dependency ref="typing-extensions@4.10.0"/>
+    <dependency ref="urllib3@2.2.1"/>
+    <dependency ref="uvicorn@0.29.0">
+      <dependency ref="click@8.1.7"/>
+      <dependency ref="h11@0.14.0"/>
+      <dependency ref="typing-extensions@4.10.0"/>
+    </dependency>
+    <dependency ref="virtualenv@20.25.1">
+      <dependency ref="distlib@0.3.8"/>
+      <dependency ref="filelock@3.13.3"/>
+      <dependency ref="platformdirs@4.2.0"/>
+    </dependency>
+    <dependency ref="watchfiles@0.21.0">
+      <dependency ref="anyio@4.3.0"/>
+    </dependency>
+    <dependency ref="wrapt@1.16.0"/>
+    <dependency ref="yarl@1.9.4">
+      <dependency ref="idna@3.6"/>
+      <dependency ref="multidict@6.0.5"/>
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_regression-issue702_lock11_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_regression-issue702_lock11_1.6.json.bin
@@ -1,0 +1,12535 @@
+{
+  "components": [
+    {
+      "bom-ref": "aiohttp@3.9.3",
+      "description": "Async http client/server framework (asyncio)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "939677b61f9d72a4fa2a042a5eee2a99a24001a67c13da113b2e30396567db54"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f5cd333fcf7590a18334c90f8c9147c837a6ec8a178e88d90a9b96ea03194cc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "82e6aa28dd46374f72093eda8bcd142f7771ee1eb9d1e223ff0fa7177a96b4a5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f56455b0c2c7cc3b0c584815264461d07b177f903a04481dfc33e08a89f0c26b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bca77a198bb6e69795ef2f09a5f4c12758487f83f33d63acde5f0d4919815768"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e083c285857b78ee21a96ba1eb1b5339733c3563f72980728ca2b08b53826ca5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ab40e6251c3873d86ea9b30a1ac6d7478c09277b32e14745d0d3c6e76e3c7e29"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "df822ee7feaaeffb99c1a9e5e608800bd8eda6e5f18f5cfb0dc7eeb2eaa6bbec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "acef0899fea7492145d2bbaaaec7b345c87753168589cc7faf0afec9afe9b747"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd73265a9e5ea618014802ab01babf1940cecb90c9762d8b9e7d2cc1e1969ec6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a78ed8a53a1221393d9637c01870248a6f4ea5b214a59a92a36f18151739452c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b0e029353361f1746bac2e4cc19b32f972ec03f0f943b390c4ab3371840aabf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7cf5c9458e1e90e3c390c2639f1017a0379a99a94fdfad3a1fd966a2874bba52"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e59c23c52765951b69ec45ddbbc9403a8761ee6f57253250c6e1536cacc758b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "055ce4f74b82551678291473f66dc9fb9048a50d8324278751926ff0ae7715e5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b88f9386ff1ad91ace19d2a1c0225896e28815ee09fc6a8932fded8cda97c3d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c46956ed82961e31557b6857a5ca153c67e5476972e5f7190015018760938da2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "07b837ef0d2f252f96009e9b8435ec1fef68ef8b1461933253d318748ec1acdc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dad46e6f620574b3b4801c68255492e0159d1712271cc99d8bdf35f2043ec266"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5ed3e046ea7b14938112ccd53d91c1539af3e6679b222f9469981e3dac7ba1ce"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "039df344b45ae0b34ac885ab5b53940b174530d4dd8a14ed8b0e2155b9dddccb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7943c414d3a8d9235f5f15c22ace69787c140c80b718dcd57caaade95f7cd93b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84871a243359bb42c12728f04d181a389718710129b36b6aad0fc4655a7647d4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5eafe2c065df5401ba06821b9a054d9cb2848867f3c59801b5d07a0be3a380ae"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9d3c9b50f19704552f23b4eaea1fc082fdd82c63429a6506446cbd8737823da3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f033d80bc6283092613882dfe40419c6a6a1527e04fc69350e87a9df02bbc283"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2c895a656dd7e061b2fd6bb77d971cc38f2afc277229ce7dd3552de8313a483e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f5a71d25cd8106eab05f8704cd9167b6e5187bcdf8f090a66c6d88b634802b4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "50fca156d718f8ced687a373f9e140c1bb765ca16e3d6f4fe116e3df7c05b2c5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5fe9ce6c09668063b8447f85d43b8d1c4e5d3d7e92c63173e6180b2ac5d46dd8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "38a19bc3b686ad55804ae931012f78f7a534cce165d089a2059f658f6c91fa60"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "770d015888c2a598b377bd2f663adfd947d78c0124cfe7b959e1ef39f5b13869"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ee43080e75fc92bf36219926c8e6de497f9b247301bbf88c5c7593d931426679"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "52df73f14ed99cee84865b95a3d9e044f226320a87af208f068ecc33e0c35b96"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dc9b311743a78043b26ffaeeb9715dc360335e5517832f5a8e339f8a43581e4d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b955ed993491f1a5da7f92e98d5dad3c1e14dc175f74517c4e610b1f2456fb11"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "504b6981675ace64c28bf4a05a508af5cde526e36492c98916127f5a02354d53"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a6fe5571784af92b6bc2fda8d1925cccdf24642d49546d3144948a6a1ed58ca5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ba39e9c8627edc56544c8628cc180d88605df3892beeb2b94c9bc857774848ca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e5e46b578c0e9db71d04c4b506a2121c0cb371dd89af17a0586ff6769d4c58c1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "938a9653e1e0c592053f815f7028e41a3062e902095e5a7dc84617c87267ebd5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c3452ea726c76e92f3b9fae4b34a151981a9ec0a4847a627c43d71a15ac32aa6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ff30218887e62209942f91ac1be902cc80cddb86bf00fbc6783b7a43b2bea26f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "38f307b41e0bea3294a9a2a87833191e4bcf89bb0365e83a8be3a58b31fb7f38"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b791a3143681a520c0a17e26ae7465f1b6f99461a28019d1a2f425236e6eedb5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0ed621426d961df79aa3b963ac7af0d40392956ffa9be022024cd16297b30c8c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7f46acd6a194287b7e41e87957bfe2ad1ad88318d447caf5b090012f2c5bb528"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "feeb18a801aacb098220e2c3eea59a512362eb408d4afd0c242044c33ad6d542"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f734e38fd8666f53da904c52a23ce517f1b07722118d750405af7e4123933511"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b40670ec7e2156d8e57f70aec34a7216407848dfe6c693ef131ddf6e76feb672"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fdd215b7b7fd4a53994f238d0f46b7ba4ac4c0adb12452beee724ddd0743ae5d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "017a21b0df49039c8f46ca0971b3a7fdc1f56741ab1240cb90ca408049766168"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e99abf0bba688259a496f966211c49a514e65afa9b3073a1fcee08856e04425b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "648056db9a9fa565d3fa851880f99f45e3f9a771dd3ff3bb0c048ea83fb28194"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8aacb477dc26797ee089721536a292a664846489c49d3ef9725f992449eda5a8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "522a11c934ea660ff8953eda090dcd2154d367dec1ae3c540aff9f8a5c109ab4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5bce0dc147ca85caa5d33debc4f4d65e8e8b5c97c7f9f660f215fa74fc49a321"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b4af9f25b49a7be47c0972139e59ec0e8285c371049df1a63b6ca81fdd216a2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "298abd678033b8571995650ccee753d9458dfa0377be4dba91e4491da3f2be63"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "69361bfdca5468c0488d7017b9b1e5ce769d40b46a9f4a2eed26b78619e9396c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0fa43c32d1643f518491d9d3a730f85f5bbaedcbd7fbcae27435bb8b7a061b29"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "835a55b7ca49468aaaac0b217092dfdff370e6c215c9224c52f30daaa735c1c1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "06a9b2c8837d9a94fae16c6223acc14b4dfdff216ab9b7202e07a9a09541168f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "abf151955990d23f84205286938796c55ff11bbfb4ccfada8c9c83ae6b3c89a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "59c26c95975f26e662ca78fdf543d4eeaef70e533a672b4113dd888bd2423caa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f95511dd5d0e05fd9728bac4096319f80615aaef4acbecb35a990afebe953b0e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "595f105710293e76b9dc09f52e0dd896bd064a79346234b521f6b968ffdd8e58"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c7c8b816c2b5af5c8a436df44ca08258fc1a13b449393a91484225fcb7545533"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f1088fa100bf46e7b398ffd9904f4808a0612e1d966b4aa43baa535d1b6341eb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f59dfe57bb1ec82ac0698ebfcdb7bcd0e99c255bd637ff613760d5f33e7c81b3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "361a1026c9dd4aba0109e4040e2aecf9884f5cfe1b1b1bd3d09419c205e2e53d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "363afe77cfcbe3a36353d8ea133e904b108feea505aa4792dad6585a8192c55a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8e2c45c208c62e955e8256949eb225bd8b66a4c9b6865729a786f2aa79b72e9d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f7217af2e14da0856e082e96ff637f14ae45c10a5714b63c77f26d8884cf1051"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27468897f628c627230dba07ec65dc8d0db566923c48f29e084ce382119802bc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "90842933e5d1ff760fae6caca4b2b3edba53ba8f4b71e95dacf2818a2aca06f7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3.tar.gz"
+        }
+      ],
+      "name": "aiohttp",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/aiohttp@3.9.3",
+      "type": "library",
+      "version": "3.9.3"
+    },
+    {
+      "bom-ref": "aiohttp-cors@0.7.0",
+      "description": "CORS support for aiohttp",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d39c6d7100fd9764ed1caf8cebf0eb01bf5e3f24e2e073fda6234bc48b19f5d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp-cors/#aiohttp-cors-0.7.0.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0451ba59fdf6909d0e2cd21e4c0a43752bc0703d33fc78ae94d9d9321710193e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp-cors/#aiohttp_cors-0.7.0-py3-none-any.whl"
+        }
+      ],
+      "name": "aiohttp-cors",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/aiohttp-cors@0.7.0",
+      "type": "library",
+      "version": "0.7.0"
+    },
+    {
+      "bom-ref": "aiosignal@1.3.1",
+      "description": "aiosignal: a list of registered asynchronous callbacks",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f8376fb07dd1e86a584e4fcdec80b36b7f81aac666ebc724e2c090300dd83b17"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiosignal/#aiosignal-1.3.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54cd96e15e1649b75d6c87526a6ff0b6c1b0dd3459f43d9ca11d48c339b68cfc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiosignal/#aiosignal-1.3.1.tar.gz"
+        }
+      ],
+      "name": "aiosignal",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/aiosignal@1.3.1",
+      "type": "library",
+      "version": "1.3.1"
+    },
+    {
+      "bom-ref": "annotated-types@0.6.0",
+      "description": "Reusable constraint types to use with typing.Annotated",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0641064de18ba7a25dee8f96403ebc39113d0cb953a01429249d5c7564666a43"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/annotated-types/#annotated_types-0.6.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "563339e807e53ffd9c267e99fc6d9ea23eb8443c08f112651963e24e22f84a5d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/annotated-types/#annotated_types-0.6.0.tar.gz"
+        }
+      ],
+      "name": "annotated-types",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/annotated-types@0.6.0",
+      "type": "library",
+      "version": "0.6.0"
+    },
+    {
+      "bom-ref": "anyio@4.3.0",
+      "description": "High level compatibility layer for multiple asynchronous event loop implementations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/anyio/#anyio-4.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/anyio/#anyio-4.3.0.tar.gz"
+        }
+      ],
+      "name": "anyio",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/anyio@4.3.0",
+      "type": "library",
+      "version": "4.3.0"
+    },
+    {
+      "bom-ref": "async-timeout@4.0.3",
+      "description": "Timeout context manager for asyncio programs",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/async-timeout/#async-timeout-4.0.3.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/async-timeout/#async_timeout-4.0.3-py3-none-any.whl"
+        }
+      ],
+      "name": "async-timeout",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/async-timeout@4.0.3",
+      "type": "library",
+      "version": "4.0.3"
+    },
+    {
+      "bom-ref": "attrs@23.2.0",
+      "description": "Classes Without Boilerplate",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/#attrs-23.2.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/#attrs-23.2.0.tar.gz"
+        }
+      ],
+      "name": "attrs",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/attrs@23.2.0",
+      "type": "library",
+      "version": "23.2.0"
+    },
+    {
+      "bom-ref": "cachetools@5.3.3",
+      "description": "Extensible memoizing collections and decorators",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0abad1021d3f8325b2fc1d2e9c8b9c9d57b04c3932657a72465447332c24d945"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/cachetools/#cachetools-5.3.3-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ba29e2dfa0b8b556606f097407ed1aa62080ee108ab0dc5ec9d6a723a007d105"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/cachetools/#cachetools-5.3.3.tar.gz"
+        }
+      ],
+      "name": "cachetools",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/cachetools@5.3.3",
+      "type": "library",
+      "version": "5.3.3"
+    },
+    {
+      "bom-ref": "certifi@2024.2.2",
+      "description": "Python package for providing Mozilla's CA Bundle.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/#certifi-2024.2.2-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/#certifi-2024.2.2.tar.gz"
+        }
+      ],
+      "name": "certifi",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/certifi@2024.2.2",
+      "type": "library",
+      "version": "2024.2.2"
+    },
+    {
+      "bom-ref": "charset-normalizer@3.3.2",
+      "description": "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset-normalizer-3.3.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2127566c664442652f024c837091890cb1942c30937add288223dc895793f898"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-py3-none-any.whl"
+        }
+      ],
+      "name": "charset-normalizer",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/charset-normalizer@3.3.2",
+      "type": "library",
+      "version": "3.3.2"
+    },
+    {
+      "bom-ref": "click@8.1.7",
+      "description": "Composable command line interface toolkit",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/click/#click-8.1.7-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/click/#click-8.1.7.tar.gz"
+        }
+      ],
+      "name": "click",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/click@8.1.7",
+      "type": "library",
+      "version": "8.1.7"
+    },
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "colorful@0.5.6",
+      "description": "Terminal string styling done right, in Python.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eab8c1c809f5025ad2b5238a50bd691e26850da8cac8f90d660ede6ea1af9f1e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorful/#colorful-0.5.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b56d5c01db1dac4898308ea889edcb113fbee3e6ec5df4bacffd61d5241b5b8d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorful/#colorful-0.5.6.tar.gz"
+        }
+      ],
+      "name": "colorful",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/colorful@0.5.6",
+      "type": "library",
+      "version": "0.5.6"
+    },
+    {
+      "bom-ref": "distlib@0.3.8",
+      "description": "Distribution utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/distlib/#distlib-0.3.8-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/distlib/#distlib-0.3.8.tar.gz"
+        }
+      ],
+      "name": "distlib",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/distlib@0.3.8",
+      "type": "library",
+      "version": "0.3.8"
+    },
+    {
+      "bom-ref": "exceptiongroup@1.2.0",
+      "description": "Backport of PEP 654 (exception groups)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/exceptiongroup/#exceptiongroup-1.2.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/exceptiongroup/#exceptiongroup-1.2.0.tar.gz"
+        }
+      ],
+      "name": "exceptiongroup",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/exceptiongroup@1.2.0",
+      "type": "library",
+      "version": "1.2.0"
+    },
+    {
+      "bom-ref": "fastapi@0.1.17",
+      "description": "FastAPI framework, high performance, easy to learn, fast to code, ready for production",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a6aaad2f60684477480ac9d7a1c95e67f4696a722f184db467494bfdd5b8f29d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fastapi/#fastapi-0.1.17-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a9a9b6cc32c38bab27a6549b94c44a30c70b485bc789d03de3aa8725f3394be5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fastapi/#fastapi-0.1.17.tar.gz"
+        }
+      ],
+      "name": "fastapi",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/fastapi@0.1.17",
+      "type": "library",
+      "version": "0.1.17"
+    },
+    {
+      "bom-ref": "filelock@3.13.3",
+      "description": "A platform independent file lock.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5ffa845303983e7a0b7ae17636509bc97997d58afeafa72fb141a17b152284cb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/filelock/#filelock-3.13.3-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a79895a25bbefdf55d1a2a0a80968f7dbb28edcd6d4234a0afb3f37ecde4b546"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/filelock/#filelock-3.13.3.tar.gz"
+        }
+      ],
+      "name": "filelock",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/filelock@3.13.3",
+      "type": "library",
+      "version": "3.13.3"
+    },
+    {
+      "bom-ref": "frozenlist@1.4.1",
+      "description": "A list-like structure which implements collections.abc.MutableSequence",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f9aa1878d1083b276b0196f2dfbe00c9b7e752475ed3b682025ff20c1c1f51ac"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "29acab3f66f0f24674b7dc4736477bcd4bc3ad4b896f5f45379a67bce8b96868"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "74fb4bee6880b529a0c6560885fce4dc95936920f9f20f53d99a213f7bf66776"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "590344787a90ae57d62511dd7c736ed56b428f04cd8c161fcc5e7232c130c69a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "068b63f23b17df8569b7fdca5517edef76171cf3897eb68beb01341131fbd2ad"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c849d495bf5154cd8da18a9eb15db127d4dba2968d88831aff6f0331ea9bd4c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9750cc7fe1ae3b1611bb8cfc3f9ec11d532244235d75901fb6b8e42ce9229dfe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a9b2de4cf0cdd5bd2dee4c4f63a653c61d2408055ab77b151c1957f221cabf2a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0633c8d5337cb5c77acbccc6357ac49a1770b8c487e5b3505c57b949b4b82e98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27657df69e8801be6c3638054e202a135c7f299267f1a55ed3a598934f6c0d75"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f9a3ea26252bd92f570600098783d1371354d89d5f6b7dfd87359d669f2109b5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f57dab5fe3407b6c0c1cc907ac98e8a189f9e418f3b6e54d65a718aaafe3950"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e02a0e11cf6597299b9f3bbd3f93d79217cb90cfd1411aec33848b13f5c656cc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a828c57f00f729620a442881cc60e57cfcec6842ba38e1b19fd3e47ac0ff8dc1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f56e2333dda1fe0f909e7cc59f021eba0d2307bc6f012a1ccf2beca6ba362439"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a0cb6f11204443f27a1628b0e460f37fb30f624be6051d490fa7d7e26d4af3d0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b46c8ae3a8f1f41a0d2ef350c0b6e65822d80772fe46b653ab6b6274f61d4a49"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fde5bd59ab5357e3853313127f4d3565fc7dad314a74d7b5d43c22c6a5ed2ced"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "722e1124aec435320ae01ee3ac7bec11a5d47f25d0ed6328f2273d287bc3abb0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2471c201b70d58a0f0c1f91261542a03d9a5e088ed3dc6c160d614c01649c106"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c757a9dd70d72b076d6f68efdbb9bc943665ae954dad2801b874c8c69e185068"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f146e0911cb2f1da549fc58fc7bcd2b836a44b79ef871980d605ec392ff6b0d2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f9c515e7914626b2a2e1e311794b4c35720a0be87af52b79ff8e1429fc25f19"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c302220494f5c1ebeb0912ea782bcd5e2f8308037b3c7553fad0e48ebad6ad82"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "442acde1e068288a4ba7acfe05f5f343e19fac87bfc96d89eb886b0363e977ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b280e6507ea8a4fa0c0a7150b4e526a8d113989e28eaaef946cc77ffd7efc0a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fe1a06da377e3a1062ae5fe0926e12b84eceb8a50b350ddca72dc85015873f74"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "db9e724bebd621d9beca794f2a4ff1d26eed5965b004a97f1f1685a173b869c2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e774d53b1a477a67838a904131c4b0eef6b3d8a651f8b138b04f748fccfefe17"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fb3c2db03683b5767dedb5769b8a40ebb47d6f7f45b1b3e3b4b51ec8ad9d9825"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1979bc0aeb89b33b588c51c54ab0161791149f2461ea7c7c946d95d5f93b56ae"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cc7b01b3754ea68a62bd77ce6020afaffb44a590c2289089289363472d13aedb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c9c92be9fd329ac801cc420e08452b70e7aeab94ea4233a4804f0915c14eba9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c3894db91f5a489fc8fa6a9991820f368f0b3cbdb9cd8849547ccfab3392d86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ba60bb19387e13597fb059f32cd4d59445d7b18b69a745b8f8e5db0346f33480"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8aefbba5f69d42246543407ed2461db31006b0f76c4e32dfd6f42215a2c41d09"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "780d3a35680ced9ce682fbcf4cb9c2bad3136eeff760ab33707b71db84664e3a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9acbb16f06fe7f52f441bb6f413ebae6c37baa6ef9edd49cdd567216da8600cd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "23b701e65c7b36e4bf15546a89279bd4d8675faabc287d06bbcfac7d3c33e1e6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e0153a805a98f5ada7e09826255ba99fb4f7524bb81bf6b47fb702666484ae1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dd9b1baec094d91bf36ec729445f7769d0d0cf6b64d04d86e45baf89e2b9059b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1a4471094e146b6790f61b98616ab8e44f72661879cc63fa1049d13ef711e71e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5667ed53d68d91920defdf4035d1cdaa3c3121dc0b113255124bcfada1cfa1b8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "beee944ae828747fd7cb216a70f120767fc9f4f00bacae8543c14a6831673f89"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "64536573d0a2cb6e625cf309984e2d873979709f2cf22839bf2d61790b448ad5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "20b51fa3f588ff2fe658663db52a41a4f7aa6c04f6201449c6c7c476bd255c0d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "410478a0c562d1a5bcc2f7ea448359fcb050ed48b3c6f6f4f18c313a9bdb1826"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c6321c9efe29975232da3bd0af0ad216800a47e93d763ce64f291917a381b8eb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48f6a4533887e189dae092f1cf981f2e3885175f7a0f33c91fb5b7b682b6bab6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6eb73fa5426ea69ee0e012fb59cdc76a15b1283d6e32e4f8dc4482ec67d1194d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fbeb989b5cc29e8daf7f976b421c220f1b8c731cbf22b9130d8815418ea45887"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "32453c1de775c889eb4e22f1197fe3bdfe457d16476ea407472b9442e6295f7a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "693945278a31f2086d9bf3df0fe8254bbeaef1fe71e1351c3bd730aa7d31c41b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1d0ce09d36d53bbbe566fe296965b23b961764c0bcf3ce2fa45f463745c04701"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a670dc61eb0d0eb7080890c13de3066790f9049b47b0de04007090807c776b0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dca69045298ce5c11fd539682cff879cc1e664c245d1c64da929813e54241d11"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a06339f38e9ed3a64e4c4e43aec7f59084033647f908e4259d279a52d3757d09"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b7f2f9f912dca3934c1baec2e4585a674ef16fe00218d833856408c48d5beee7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7004be74cbb7d9f34553a5ce5fb08be14fb33bc86f332fb71cbe5216362a497"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5a7d70357e7cee13f470c7883a063aae5fe209a493c57d86eb7f5a6f910fae09"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bfa4a17e17ce9abf47a74ae02f32d014c5e9404b6d9ac7f729e01562bbee601e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b7e3ed87d4138356775346e6845cccbe66cd9e207f3cd11d2f0b9fd13681359d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c99169d4ff810155ca50b4da3b075cbde79752443117d89429595c2e8e37fed8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "edb678da49d9f72c9f6c609fbe41a5dfb9a9282f9e6a2253d5a91e0fc382d7c0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6db4667b187a6742b33afbbaf05a7bc551ffcf1ced0000a571aedbb4aa42fc7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "55fdc093b5a3cb41d420884cdaf37a1e74c3c37a31f46e66286d9145d2063bd0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "82e8211d69a4f4bc360ea22cd6555f8e61a1bd211d1d5d39d3d228b48c83a897"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "89aa2c2eeb20957be2d950b85974b30a01a762f3308cd02bb15e1ad632e22dc7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9d3e0c25a2350080e9319724dede4f31f43a6c9779be48021a7f4ebde8b2d742"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7268252af60904bf52c26173cbadc3a071cece75f873705419c8681f24d3edea"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0c250a29735d4f15321007fb02865f0e6b6a41a6b88f1f523ca1596ab5f50bd5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "96ec70beabbd3b10e8bfe52616a13561e58fe84c0101dd031dc78f250d5128b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "23b2d7679b73fe0e5a4560b672a39f98dfc6f60df63823b0a9970525325b95f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a7496bfe1da7fb1a4e1cc23bb67c58fab69311cc7d32b5a99c2007b4b2a0e932"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e6a20a581f9ce92d389a8c7d7c3dd47c81fd5d6e655c8dddf341e14aa48659d0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "04ced3e6a46b4cfffe20f9ae482818e34eba9b5fb0ce4056e4cc9b6e212d09b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c037a86e8513059a2613aaba4d817bb90b9d9b6b69aace3ce9c877e8c8ed402b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1.tar.gz"
+        }
+      ],
+      "name": "frozenlist",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/frozenlist@1.4.1",
+      "type": "library",
+      "version": "1.4.1"
+    },
+    {
+      "bom-ref": "google-api-core@2.8.0",
+      "description": "Google API client core library",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "065bb8e11c605fd232707ae50963dc1c8af5b3c95b4568887515985e6c1156b3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/google-api-core/#google-api-core-2.8.0.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b9f59236ce1bae9a687c1d4f22957e79a2669e53d032893f6bf0fca54f6931d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/google-api-core/#google_api_core-2.8.0-py3-none-any.whl"
+        }
+      ],
+      "name": "google-api-core",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/google-api-core@2.8.0",
+      "type": "library",
+      "version": "2.8.0"
+    },
+    {
+      "bom-ref": "google-auth@2.29.0",
+      "description": "Google Authentication Library",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "672dff332d073227550ffc7457868ac4218d6c500b155fe6cc17d2b13602c360"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/google-auth/#google-auth-2.29.0.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d452ad095688cd52bae0ad6fafe027f6a6d6f560e810fec20914e17a09526415"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/google-auth/#google_auth-2.29.0-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "google-auth",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/google-auth@2.29.0",
+      "type": "library",
+      "version": "2.29.0"
+    },
+    {
+      "bom-ref": "googleapis-common-protos@1.56.1",
+      "description": "Common protobufs used in Google APIs",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b5ee59dc646eb61a8eb65ee1db186d3df6687c8804830024f32573298bca19b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/googleapis-common-protos/#googleapis-common-protos-1.56.1.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ddcd955b5bb6589368f659fa475373faa1ed7d09cde5ba25e88513d87007e174"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/googleapis-common-protos/#googleapis_common_protos-1.56.1-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "googleapis-common-protos",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/googleapis-common-protos@1.56.1",
+      "type": "library",
+      "version": "1.56.1"
+    },
+    {
+      "bom-ref": "grpcio@1.62.1",
+      "description": "HTTP/2-based RPC framework",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "179bee6f5ed7b5f618844f760b6acf7e910988de77a4f75b95bbfaa8106f3c1e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-linux_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48611e4fa010e823ba2de8fd3f77c1322dd60cb0d180dc6630a7e157b205f7ea"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-macosx_12_0_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2a0e71b0a2158aa4bce48be9f8f9eb45cbd17c78c7443616d00abbe2a509f6d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-manylinux_2_17_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fbe80577c7880911d3ad65e5ecc997416c98f354efeba2f8d0f9112a67ed65a5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "58f6c693d446964e3292425e1d16e21a97a48ba9172f2d0df9d7b640acb99243"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "77c339403db5a20ef4fed02e4d1a9a3d9866bf9c0afc77a42234677313ea22f3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b5a4ea906db7dec694098435d84bf2854fe158eb3cd51e1107e571246d4d1d70"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4187201a53f8561c015bc745b81a1b2d278967b8de35f3399b84b0695e281d5f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "844d1f3fb11bd1ed362d3fdc495d0770cfab75761836193af166fee113421d66"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "833379943d1728a005e44103f17ecd73d058d37d95783eb8f0b28ddc1f54d7b2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-linux_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c7fcc6a32e7b7b58f5a7d27530669337a5d587d4066060bcb9dee7a8c833dfb7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-macosx_10_10_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fa7d28eb4d50b7cbe75bb8b45ed0da9a1dc5b219a0af59449676a29c2eed9698"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-manylinux_2_17_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48f7135c3de2f298b833be8b4ae20cafe37091634e91f61f5a7eb3d61ec6f660"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "71f11fd63365ade276c9d4a7b7df5c136f9030e3457107e1791b3737a9b9ed6a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b49fd8fe9f9ac23b78437da94c54aa7e9996fbb220bac024a67469ce5d0825f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "482ae2ae78679ba9ed5752099b32e5fe580443b4f798e1b71df412abf43375db"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1faa02530b6c7426404372515fe5ddf66e199c2ee613f88f025c6f3bd816450c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5bd90b8c395f39bc82a5fb32a0173e220e3f401ff697840f4003e15b96d1befc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b134d5d71b4e0837fff574c00e49176051a1c532d26c052a1e43231f252d813b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-linux_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d1f6c96573dc09d50dbcbd91dbf71d5cf97640c9427c32584010fbbd4c0e0037"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-macosx_10_10_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "359f821d4578f80f41909b9ee9b76fb249a21035a061a327f91c953493782c31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-manylinux_2_17_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a485f0c2010c696be269184bdb5ae72781344cb4e60db976c59d84dd6354fac9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b50b09b4dc01767163d67e1532f948264167cd27f49e9377e3556c3cba1268e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3227c667dccbe38f2c4d943238b887bac588d97c104815aecc62d2fd976e014b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3952b581eb121324853ce2b191dae08badb75cd493cb4e0243368aa9e61cfd41"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "83a17b303425104d6329c10eb34bba186ffa67161e63fa6cdae7776ff76df73f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6696ffe440333a19d8d128e88d440f91fb92c75a80ce4b44d55800e656a3ef1d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e3393b0823f938253370ebef033c9fd23d27f3eae8eb9a8f6264900c7ea3fb5a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-linux_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "83e7ccb85a74beaeae2634f10eb858a0ed1a63081172649ff4261f929bacfd22"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-macosx_10_10_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "882020c87999d54667a284c7ddf065b359bd00251fcd70279ac486776dbf84ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-manylinux_2_17_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a10383035e864f386fe096fed5c47d27a2bf7173c56a6e26cffaaa5a361addb1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "960edebedc6b9ada1ef58e1c71156f28689978188cd8cff3b646b57288a927d9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "23e2e04b83f347d0aadde0c9b616f4726c3d76db04b438fd3904b289a725267f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "978121758711916d34fe57c1f75b79cdfc73952f1481bb9583399331682d36f7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9084086190cc6d628f282e5615f987288b95457292e969b9205e45b442276407"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "22bccdd7b23c420a27fd28540fb5dcbc97dc6be105f7698cb0e7d7a420d0e362"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-linux_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8999bf1b57172dbc7c3e4bb3c732658e918f5c333b2942243f10d0d653953ba9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-macosx_10_10_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d9e52558b8b8c2f4ac05ac86344a7417ccdd2b460a59616de49eb6933b07a0bd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-manylinux_2_17_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1714e7bc935780bc3de1b3fcbc7674209adf5208ff825799d579ffd6cd0bd505"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c8842ccbd8c0e253c1f189088228f9b433f7a93b7196b9e5b6f87dba393f5d5d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f1e7b36bdff50103af95a80923bf1853f6823dd62f2d2a2524b66ed74103e49"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bba97b8e8883a8038606480d6b6772289f4c907f6ba780fa1f7b7da7dfd76f06"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a7f615270fe534548112a74e790cd9d4f5509d744dd718cd442bf016626c22e4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e6c8c8693df718c5ecbc7babb12c69a4e3677fd11de8886f05ab22d4e6b1c43b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "73db2dc1b201d20ab7083e7041946910bb991e7e9761a0394bbc3c2632326483"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-linux_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "407b26b7f7bbd4f4751dbc9767a1f0716f9fe72d3d7e96bb3ccfc4aace07c8de"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-macosx_10_10_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f8de7c8cef9261a2d0a62edf2ccea3d741a523c6b8a6477a340a1f2e417658de"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-manylinux_2_17_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9bd5c8a1af40ec305d001c60236308a67e25419003e9bb3ebfab5695a8d0b369"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "be0477cb31da67846a33b1a75c611f88bfbcd427fe17701b6317aefceee1b96f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "60dcd824df166ba266ee0cfaf35a31406cd16ef602b49f5d4dfb21f014b0dedd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "973c49086cabab773525f6077f95e5a993bfc03ba8fc32e32f2c279497780585"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "12859468e8918d3bd243d213cd6fd6ab07208195dc140763c00dfe901ce1e1b4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b7209117bbeebdfa5d898205cc55153a51285757902dd73c47de498ad4d11332"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6c455e008fa86d9e9a9d85bb76da4277c0d7d9668a3bfa70dbe86e9f3c759947"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1.tar.gz"
+        }
+      ],
+      "name": "grpcio",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/grpcio@1.62.1",
+      "type": "library",
+      "version": "1.62.1"
+    },
+    {
+      "bom-ref": "h11@0.14.0",
+      "description": "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/h11/#h11-0.14.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/h11/#h11-0.14.0.tar.gz"
+        }
+      ],
+      "name": "h11",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/h11@0.14.0",
+      "type": "library",
+      "version": "0.14.0"
+    },
+    {
+      "bom-ref": "idna@3.6",
+      "description": "Internationalized Domain Names in Applications (IDNA)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/#idna-3.6-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/#idna-3.6.tar.gz"
+        }
+      ],
+      "name": "idna",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/idna@3.6",
+      "type": "library",
+      "version": "3.6"
+    },
+    {
+      "bom-ref": "jsonschema@4.21.1",
+      "description": "An implementation of JSON Schema validation for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7996507afae316306f9e2290407761157c6f78002dcf7419acb99822143d1c6f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema/#jsonschema-4.21.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "85727c00279f5fa6bedbe6238d2aa6403bedd8b4864ab11207d07df3cc1b2ee5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema/#jsonschema-4.21.1.tar.gz"
+        }
+      ],
+      "name": "jsonschema",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema@4.21.1",
+      "type": "library",
+      "version": "4.21.1"
+    },
+    {
+      "bom-ref": "jsonschema-specifications@2023.12.1",
+      "description": "The JSON Schema meta-schemas and vocabularies, exposed as a Registry",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "87e4fdf3a94858b8a2ba2778d9ba57d8a9cafca7c7489c46ba0d30a8bc6a9c3c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.12.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48a76787b3e70f5ed53f1160d2b81f586e4ca6d1548c5de7085d1682674764cc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.12.1.tar.gz"
+        }
+      ],
+      "name": "jsonschema-specifications",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema-specifications@2023.12.1",
+      "type": "library",
+      "version": "2023.12.1"
+    },
+    {
+      "bom-ref": "msgpack@1.0.8",
+      "description": "MessagePack serializer",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "505fe3d03856ac7d215dbe005414bc28505d26f0c128906037e66d98c4e95868"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e6b7842518a63a9f17107eb176320960ec095a8ee3b4420b5f688e24bf50c53c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "376081f471a2ef24828b83a641a02c575d6103a3ad7fd7dade5486cad10ea659"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5e390971d082dba073c05dbd56322427d3280b7cc8b53484c9377adfbae67dc2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "00e073efcba9ea99db5acef3959efa45b52bc67b61b00823d2a1a6944bf45982"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "82d92c773fbc6942a7a8b520d22c11cfc8fd83bba86116bfcf962c2f5c2ecdaa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9ee32dcb8e531adae1f1ca568822e9b3a738369b3b686d1477cbc643c4a9c128"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e3aa7e51d738e0ec0afbed661261513b38b3014754c9459508399baf14ae0c9d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "69284049d07fce531c17404fcba2bb1df472bc2dcdac642ae71a2d079d950653"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "13577ec9e247f8741c84d06b9ece5f654920d8365a4b636ce0e44f15e07ec693"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e532dbd6ddfe13946de050d7474e3f5fb6ec774fbb1a188aaf469b08cf04189a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9517004e21664f2b5a5fd6333b0731b9cf0817403a941b393d89a2f1dc2bd836"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d16a786905034e7e34098634b184a7d81f91d4c3d246edc6bd7aefb2fd8ea6ad"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e2872993e209f7ed04d963e4b4fbae72d034844ec66bc4ca403329db2074377b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c330eace3dd100bdb54b5653b966de7f51c26ec4a7d4e87132d9b4f738220ba"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "83b5c044f3eff2a6534768ccfd50425939e7a8b5cf9a7261c385de1e20dcfc85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1876b0b653a808fcd50123b953af170c535027bf1d053b59790eebb0aeb38950"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dfe1f0f0ed5785c187144c46a292b8c34c1295c01da12e10ccddfc16def4448a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3528807cbbb7f315bb81959d5961855e7ba52aa60a3097151cb21956fbc7502b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e2f879ab92ce502a1e65fce390eab619774dda6a6ff719718069ac94084098ce"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "26ee97a8261e6e35885c2ecd2fd4a6d38252246f94a2aec23665a4e66d066305"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eadb9f826c138e6cf3c49d6f8de88225a3c0ab181a9b4ba792e006e5292d150e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "114be227f5213ef8b215c22dde19532f5da9652e56e8ce969bf0a26d7c419fee"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d661dc4785affa9d0edfdd1e59ec056a58b3dbb9f196fa43587f3ddac654ac7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d56fd9f1f1cdc8227d7b7918f55091349741904d9520c65f0139a9755952c9e8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0726c282d188e204281ebd8de31724b7d749adebc086873a59efb8cf7ae27df3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8db8e423192303ed77cff4dce3a4b88dbfaf43979d280181558af5e2c3c71afc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "99881222f4a8c2f641f25703963a5cefb076adffd959e0558dc9f803a52d6a58"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b5505774ea2a73a86ea176e8a9a4a7c8bf5d521050f0f6f8426afe798689243f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ef254a06bcea461e65ff0373d8a0dd1ed3aa004af48839f002a0c994a6f72d04"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e1dd7839443592d00e96db831eddb4111a2a81a46b028f0facd60a09ebbdd543"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "64d0fcd436c5683fdd7c907eeae5e2cbb5eb872fafbc03a43609d7941840995c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "74398a4cf19de42e1498368c36eed45d9528f5fd0155241e82c4082b7e16cffd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0ceea77719d45c839fd73abcb190b8390412a890df2f83fb8cf49b2a4b5c2f40"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1ab0bbcd4d1f7b6991ee7c753655b481c50084294218de69365f8f1970d4c151"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1cce488457370ffd1f953846f82323cb6b2ad2190987cd4d70b2713e17268d24"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3923a1778f7e5ef31865893fdca12a8d7dc03a44b33e2a5f3295416314c09f5d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a22e47578b30a3e199ab067a4d43d790249b3c0587d9a771921f86250c8435db"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bd739c9251d01e0279ce729e37b39d49a08c0420d3fee7f2a4968c0576678f77"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d3420522057ebab1728b21ad473aa950026d07cb09da41103f8e597dfbfaeb13"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5845fdf5e5d5b78a49b826fcdc0eb2e2aa7191980e3d2cfd2a30303a74f212e2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6a0e76621f6e1f908ae52860bdcb58e1ca85231a9b0545e64509c931dd34275a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "374a8e88ddab84b9ada695d255679fb99c53513c0a51778796fcf0944d6c789c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f3709997b228685fe53e8c433e2df9f0cdb5f4542bd5114ed17ac3c0129b0480"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f51bab98d52739c50c56658cc303f190785f9a2cd97b823357e7aeae54c8f68a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "73ee792784d48aa338bba28063e19a27e8d989344f34aad14ea6e1b9bd83f596"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f9904e24646570539a8950400602d66d2b2c492b9010ea7e965025cb71d0c86d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e75753aeda0ddc4c28dce4c32ba2f6ec30b1b02f6c0b14e547841ba5b24f753f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5dbf059fb4b7c240c873c1245ee112505be27497e90f7c6591261c7d3c3a8228"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4916727e31c28be8beaf11cf117d6f6f188dcc36daae4e851fee88646f5b6b18"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7938111ed1358f536daf311be244f34df7bf3cdedb3ed883787aca97778b28d8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "493c5c5e44b06d6c9268ce21b302c9ca055c1fd3484c25ba41d34476c76ee746"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8.tar.gz"
+        }
+      ],
+      "name": "msgpack",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/msgpack@1.0.8",
+      "type": "library",
+      "version": "1.0.8"
+    },
+    {
+      "bom-ref": "multidict@6.0.5",
+      "description": "multidict implementation",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "228b644ae063c10e7f324ab1ab6b548bdf6f8b47f3ec234fef1093bc2735e5f9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "896ebdcf62683551312c30e20614305f53125750803b614e9e6ce74a96232604"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "411bf8515f3be9813d06004cac41ccf7d1cd46dfe233705933dd163b60e37600"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1d147090048129ce3c453f0292e7697d333db95e52616b3793922945804a433c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "215ed703caf15f578dca76ee6f6b21b7603791ae090fbf1ef9d865571039ade5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7c6390cf87ff6234643428991b7359b5f59cc15155695deb4eda5c777d2b880f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "21fd81c4ebdb4f214161be351eb5bcf385426bf023041da2fd9e60681f3cebae"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3cc2ad10255f903656017363cd59436f2111443a76f996584d1077e43ee51182"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6939c95381e003f54cd4c5516740faba40cf5ad3eeff460c3ad1d3e0ea2549bf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "220dd781e3f7af2c2c1053da9fa96d9cf3072ca58f057f4c5adaaa1cab8fc442"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "766c8f7511df26d9f11cd3a8be623e59cca73d44643abab3f8c8c07620524e4a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fe5d7785250541f7f5019ab9cba2c71169dc7d74d0f45253f8313f436458a4ef"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c1c1496e73051918fcd4f58ff2e0f2f3066d1c76a0c6aeffd9b45d53243702cc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7afcdd1fc07befad18ec4523a782cde4e93e0a2bf71239894b8d61ee578c1319"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "99f60d34c048c5c2fabc766108c103612344c46e35d4ed9ae0673d33c8fb26e8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f285e862d2f153a70586579c15c44656f888806ed0e5b56b64489afe4a2dbfba"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "53689bb4e102200a4fafa9de9c7c3c212ab40a7ab2c8e474491914d2305f187e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "612d1156111ae11d14afaf3a0669ebf6c170dbb735e510a7438ffe2369a847fd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7be7047bd08accdb7487737631d25735c9a04327911de89ff1b26b81745bd4e3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "de170c7b4fe6859beb8926e84f7d7d6c693dfe8e27372ce3b76f01c46e489fcf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "04bde7a7b3de05732a4eb39c94574db1ec99abb56162d6c520ad26f83267de29"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "85f67aed7bb647f93e7520633d8f51d3cbc6ab96957c71272b286b2f30dc70ed"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "425bf820055005bfc8aa9a0b99ccb52cc2f4070153e34b701acc98d201693733"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d3eb1ceec286eba8220c26f3b0096cf189aea7057b6e7b7a2e60ed36b373b77f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7901c05ead4b3fb75113fb1dd33eb1253c6d3ee37ce93305acd9d38e0b5f21a4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e0e79d91e71b9867c73323a3444724d496c037e578a0e1755ae159ba14f4f3d1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "29bfeb0dff5cb5fdab2023a7a9947b3b4af63e9c47cae2a10ad58394b517fddc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e030047e85cbcedbfc073f71836d62dd5dadfbe7531cae27789ff66bc551bd5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2f4848aa3baa109e6ab81fe2006c77ed4d3cd1e0ac2c1fbddb7b1277c168788c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2faa5ae9376faba05f630d7e5e6be05be22913782b927b19d12b8145968a85ea"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "51d035609b86722963404f711db441cf7134f1889107fb171a970c9701f92e1e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cbebcd5bcaf1eaf302617c114aa67569dd3f090dd0ce8ba9e35e9985b41ac35b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2ffc42c922dbfddb4a4c3b438eb056828719f07608af27d163191cb3e3aa6cc5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ceb3b7e6a0135e092de86110c5a74e46bda4bd4fbfeeb3a3bcec79c0f861e450"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "79660376075cfd4b2c80f295528aa6beb2058fd289f4c9252f986751a4cd0496"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e4428b29611e989719874670fd152b6625500ad6c686d464e99f5aaeeaca175a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d84a5c3a5f7ce6db1f999fb9438f686bc2e09d38143f2d93d8406ed2dd6b9226"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "76c0de87358b192de7ea9649beb392f107dcad9ad27276324c24c91774ca5271"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "79a6d2ba910adb2cbafc95dad936f8b9386e77c84c35bc0add315b856d7c3abb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "92d16a3e275e38293623ebf639c471d3e03bb20b8ebb845237e0d3664914caef"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fb616be3538599e797a2017cccca78e354c767165e8858ab5116813146041a24"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "14c2976aa9038c2629efa2c148022ed5eb4cb939e15ec7aace7ca932f48f9ba6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "435a0984199d81ca178b9ae2c26ec3d49692d20ee29bc4c11a2a8d4514c67eda"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9fe7b0653ba3d9d65cbe7698cca585bf0f8c83dbbcc710db9c90f478e175f2d5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "01265f5e40f5a17f8241d52656ed27192be03bfa8764d88e8220141d1e4b3556"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "19fe01cea168585ba0f678cad6f58133db2aa14eccaf22f88e4a6dccadfad8b3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6bf7a982604375a8d49b6cc1b781c1747f243d91b81035a9b43a2126c04766f5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "107c0cdefe028703fb5dafe640a409cb146d44a6ae201e55b35a4af8e95457dd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "403c0911cd5d5791605808b942c88a8155c2592e05332d2bf78f18697a5fa15e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aeaf541ddbad8311a87dd695ed9642401131ea39ad7bc8cf3ef3967fd093b626"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e4972624066095e52b569e02b5ca97dbd7a7ddd4294bf4e7247d52635630dd83"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d946b0a9eb8aaa590df1fe082cee553ceab173e6cb5b03239716338629c50c7a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b55358304d7a73d7bdf5de62494aaf70bd33015831ffd98bc498b433dfe5b10c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a3145cb08d8625b2d3fee1b2d596a8766352979c9bffe5d7833e0503d0f0b5e5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d65f25da8e248202bd47445cec78e0025c0fe7582b23ec69c3b27a640dd7a8e3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c9bf56195c6bbd293340ea82eafd0071cb3d450c703d2c93afb89f93b8386ccc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "69db76c09796b313331bb7048229e3bee7928eb62bab5e071e9f7fcc4879caee"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fce28b3c8a81b6b36dfac9feb1de115bab619b3c13905b419ec71d03a3fc1423"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "76f067f5121dcecf0d63a67f29080b26c43c71a98b10c701b0677e4a065fbd54"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b82cc8ace10ab5bd93235dfaab2021c70637005e1ac787031f4d1da63d493c1d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5cb241881eefd96b46f89b1a056187ea8e9ba14ab88ba632e68d7a2ecb7aadf7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e8e94e6912639a02ce173341ff62cc1201232ab86b8a8fcc05572741a5dc7d93"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "09a892e4a9fb47331da06948690ae38eaa2426de97b4ccbfafbdcbe5c8f37ff8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "55205d03e8a598cfc688c71ca8ea5f66447164efff8869517f175ea632c7cb7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "37b15024f864916b4951adb95d3a80c9431299080341ab9544ed148091b53f50"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f2a1dee728b52b33eebff5072817176c172050d44d67befd681609b4746e1c2e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "edd08e6f2f1a390bf137080507e44ccc086353c8e98c657e666c017718561b89"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "60d698e8179a42ec85172d12f50b1668254628425a6bd611aba022257cac1386"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3d25f19500588cbc47dc19081d78131c32637c25804df8414463ec908631e453"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4cc0ef8b962ac7a5e62b9e826bd0cd5040e7d401bc45a6835910ed699037a461"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eca2e9d0cc5a889850e9bbd68e98314ada174ff6ccd1129500103df7a94a7a44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4a6a4f196f08c58c59e0b8ef8ec441d12aee4125a7d4f4fef000ccb22f8d7241"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0275e35209c27a3f7951e1ce7aaf93ce0d163b28948444bec61dd7badc6d3f8c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7be68734bd8c9a513f2b0cfd508802d6609da068f40dc57d4e3494cefc92929"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1d9ea7a7e779d7a3561aade7d596649fbecfa5c08a7674b11b423783217933f9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ea1456df2a27c73ce51120fa2f519f1bea2f4a03a917f4a43c8707cf4cbbae1a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf590b134eb70629e350691ecca88eac3e3b8b3c86992042fb82e3cb1830d5e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c0631926c4f58e9a5ccce555ad7747d9a9f8b10619621f22f9635f069f6233e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dce1c6912ab9ff5f179eaf6efe7365c1f425ed690b03341911bf4939ef2f3046"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c0868d64af83169e4d4152ec612637a543f7a336e4a307b119e98042e852ad9c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "141b43360bfd3bdd75f15ed811850763555a251e38b2405967f8e25fb43f7d40"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7df704ca8cf4a073334e0427ae2345323613e4df18cc224f647f251e5e75a527"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6214c5a5571802c33f80e6c84713b2c79e024995b9c5897f794b43e714daeec9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd6c8fca38178e12c00418de737aef1261576bd1b6e8c6134d3e729a4e858b38"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e02021f87a5b6932fa6ce916ca004c4d441509d33bbdbeca70d05dff5e9d2479"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ebd8d160f91a764652d3e51ce0d2956b38efe37c9231cd82cfc0bed2e40b581c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "04da1bb8c8dbadf2a18a452639771951c662c5ad03aefe4884775454be322c9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d6f6d4f185481c9669b9447bf9d9cf3b95a0e9df9d169bbc17e363b7d5487755"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0d63c74e3d7ab26de115c49bffc92cc77ed23395303d496eae515d4204a625e7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f7e301075edaf50500f0b341543c41194d8df3ae5caf4702f2095f3ca73dd8da"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5.tar.gz"
+        }
+      ],
+      "name": "multidict",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/multidict@6.0.5",
+      "type": "library",
+      "version": "6.0.5"
+    },
+    {
+      "bom-ref": "opencensus@0.11.4",
+      "description": "A stats collection and distributed tracing framework",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a18487ce68bc19900336e0ff4655c5a116daf10c1b3685ece8d971bddad6a864"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/opencensus/#opencensus-0.11.4-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/opencensus/#opencensus-0.11.4.tar.gz"
+        }
+      ],
+      "name": "opencensus",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/opencensus@0.11.4",
+      "type": "library",
+      "version": "0.11.4"
+    },
+    {
+      "bom-ref": "opencensus-context@0.1.3",
+      "description": "OpenCensus Runtime Context",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a03108c3c10d8c80bb5ddf5c8a1f033161fa61972a9917f9b9b3a18517f0088c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/opencensus-context/#opencensus-context-0.1.3.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "073bb0590007af276853009fac7e4bab1d523c3f03baf4cb4511ca38967c6039"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/opencensus-context/#opencensus_context-0.1.3-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "opencensus-context",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/opencensus-context@0.1.3",
+      "type": "library",
+      "version": "0.1.3"
+    },
+    {
+      "bom-ref": "packaging@24.0",
+      "description": "Core utilities for Python packages",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/packaging/#packaging-24.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/packaging/#packaging-24.0.tar.gz"
+        }
+      ],
+      "name": "packaging",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/packaging@24.0",
+      "type": "library",
+      "version": "24.0"
+    },
+    {
+      "bom-ref": "platformdirs@4.2.0",
+      "description": "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\".",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/platformdirs/#platformdirs-4.2.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/platformdirs/#platformdirs-4.2.0.tar.gz"
+        }
+      ],
+      "name": "platformdirs",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/platformdirs@4.2.0",
+      "type": "library",
+      "version": "4.2.0"
+    },
+    {
+      "bom-ref": "prometheus-client@0.20.0",
+      "description": "Python client for the Prometheus monitoring system.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cde524a85bce83ca359cc837f28b8c0db5cac7aa653a588fd7e84ba061c329e7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/prometheus-client/#prometheus_client-0.20.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "287629d00b147a32dcb2be0b9df905da599b2d82f80377083ec8463309a4bb89"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/prometheus-client/#prometheus_client-0.20.0.tar.gz"
+        }
+      ],
+      "name": "prometheus-client",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/prometheus-client@0.20.0",
+      "type": "library",
+      "version": "0.20.0"
+    },
+    {
+      "bom-ref": "protobuf@5.26.1",
+      "description": "",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3c388ea6ddfe735f8cf69e3f7dc7611e73107b60bdfcf5d0f024c3ccd3794e23"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp310-abi3-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e6039957449cb918f331d32ffafa8eb9255769c96aa0560d9a5bf0b4e00a2a33"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp310-abi3-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "38aa5f535721d5bb99861166c445c4105c4e285c765fbb2ac10f116e32dcd46d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp37-abi3-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fbfe61e7ee8c1860855696e3ac6cfd1b01af5498facc6834fcc345c9684fb2ca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp37-abi3-manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f7417703f841167e5a27d48be13389d52ad705ec09eade63dfc3180a959215d7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp37-abi3-manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d693d2504ca96750d92d9de8a103102dd648fda04540495535f0fec7577ed8fc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9b557c317ebe6836835ec4ef74ec3e994ad0894ea424314ad3552bc6e8835b4e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b9ba3ca83c2e31219ffbeb9d76b63aad35a3eb1544170c55336993d7a18ae72c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7ee014c2c87582e101d6b54260af03b6596728505c79f17c8586e7523aaa8f8c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "da612f2720c0183417194eeaa2523215c4fcc1a1949772dc65f05047e08d5932"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8ca2a1d97c290ec7b16e4e5dff2e5ae150cc1582f55b5ab300d45cb0dfa90e51"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1.tar.gz"
+        }
+      ],
+      "name": "protobuf",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/protobuf@5.26.1",
+      "type": "library",
+      "version": "5.26.1"
+    },
+    {
+      "bom-ref": "py-spy@0.3.14",
+      "description": "Sampling profiler for Python programs",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5b342cc5feb8d160d57a7ff308de153f6be68dcf506ad02b4d67065f2bae7f45"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fe7efe6c91f723442259d428bf1f9ddb9c1679828866b353d539345ca40d9dd2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "590905447241d789d9de36cff9f52067b6f18d8b5e9fb399242041568d414461"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fd6211fe7f587b3532ba9d300784326d9a6f2b890af7bf6fff21a029ebbc812b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e8e48032e71c94c3dd51694c39e762e4bbfec250df5bf514adcdd64e79371e0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f59b0b52e56ba9566305236375e6fc68888261d0d36b5addbe3cf85affbefc0e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8f5b311d09f3a8e33dbd0d44fc6e37b715e8e0c7efefafcda8bfd63b31ab5a31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-win_amd64.whl"
+        }
+      ],
+      "name": "py-spy",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/py-spy@0.3.14",
+      "type": "library",
+      "version": "0.3.14"
+    },
+    {
+      "bom-ref": "pyasn1@0.6.0",
+      "description": "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cca4bb0f2df5504f02f6f8a775b6e416ff9b0b3b16f7ee80b5a3153d9b804473"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyasn1/#pyasn1-0.6.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a35ab2c4b5ef98e17dfdec8ab074046fbda76e281c5a706ccd82328cfc8f64c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyasn1/#pyasn1-0.6.0.tar.gz"
+        }
+      ],
+      "name": "pyasn1",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pyasn1@0.6.0",
+      "type": "library",
+      "version": "0.6.0"
+    },
+    {
+      "bom-ref": "pyasn1-modules@0.4.0",
+      "description": "A collection of ASN.1-based protocols modules",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "be04f15b66c206eed667e0bb5ab27e2b1855ea54a842e5037738099e8ca4ae0b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyasn1-modules/#pyasn1_modules-0.4.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "831dbcea1b177b28c9baddf4c6d1013c24c3accd14a1873fffaa6a2e905f17b6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyasn1-modules/#pyasn1_modules-0.4.0.tar.gz"
+        }
+      ],
+      "name": "pyasn1-modules",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pyasn1-modules@0.4.0",
+      "type": "library",
+      "version": "0.4.0"
+    },
+    {
+      "bom-ref": "pydantic@2.6.4",
+      "description": "Data validation using Python type hints",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cc46fce86607580867bdc3361ad462bab9c222ef042d3da86f2fb333e1d916c5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic/#pydantic-2.6.4-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b1704e0847db01817624a6b86766967f552dd9dbf3afba4004409f908dcc84e6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic/#pydantic-2.6.4.tar.gz"
+        }
+      ],
+      "name": "pydantic",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pydantic@2.6.4",
+      "type": "library",
+      "version": "2.6.4"
+    },
+    {
+      "bom-ref": "pydantic-core@2.16.3",
+      "description": "",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "75b81e678d1c1ede0785c7f46690621e4c6e63ccd9192af1f0bd9d504bbb6bf4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9c865a7ee6f93783bd5d781af5a4c43dadc37053a5b42f7d18dc019f8c9d2bd1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "162e498303d2b1c036b957a1278fa0899d02b2842f1ff901b6395104c5554a45"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2f583bd01bbfbff4eaee0868e6fc607efdfcc2b03c1c766b06a707abbc856187"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b926dd38db1519ed3043a4de50214e0d600d404099c3392f098a7f9d75029ff8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "716b542728d4c742353448765aa7cdaa519a7b82f9564130e2b3f6766018c9ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fc4ad7f7ee1a13d9cb49d8198cd7d7e3aa93e425f371a68235f784e99741561f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bd87f48924f360e5d1c5f770d6155ce0e7d83f7b4e10c2f9ec001c73cf475c99"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0df446663464884297c793874573549229f9eca73b59360878f382a0fc085979"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4df8a199d9f6afc5ae9a65f8f95ee52cae389a8c6b20163762bde0426275b7db"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "456855f57b413f077dff513a5a28ed838dbbb15082ba00f80750377eed23d132"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "732da3243e1b8d3eab8c6ae23ae6a58548849d2e4a4e03a1924c8ddf71a387cb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "519ae0312616026bf4cedc0fe459e982734f3ca82ee8c7246c19b650b60a5ee4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3992a322a5617ded0a9f23fd06dbc1e4bd7cf39bc4ccf344b10f80af58beacd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d62da299c6ecb04df729e4b5c52dc0d53f4f8430b4492b93aa8de1f541c4aac"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2acca2be4bb2f2147ada8cac612f8a98fc09f41c89f87add7256ad27332c2fda"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b662180108c55dfbf1280d865b2d116633d436cfc0bba82323554873967b340"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7c6ed0dc9d8e65f24f5824291550139fe6f37fac03788d4580da0d33bc00c97"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a6b1bb0827f56654b4437955555dc3aeeebeddc47c2d7ed575477f082622c49e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e56f8186d6210ac7ece503193ec84104da7ceb98f68ce18c07282fcc2452e76f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "936e5db01dd49476fa8f4383c259b8b1303d5dd5fb34c97de194560698cc2c5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "33809aebac276089b78db106ee692bdc9044710e26f24a9a2eaa35a0f9fa70ba"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ded1c35f15c9dea16ead9bffcde9bb5c7c031bff076355dc58dcb1cb436c4721"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d89ca19cdd0dd5f31606a9329e309d4fcbb3df860960acec32630297d61820df"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6162f8d2dc27ba21027f261e4fa26f8bcb3cf9784b7f9499466a311ac284b5b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-none-win_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0f56ae86b60ea987ae8bcd6654a887238fd53d1384f9b222ac457070b7ac4cff"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c9bd22a2a639e26171068f8ebb5400ce2c1bc7d17959f60a3b753ae13c632975"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4204e773b4b408062960e65468d5346bdfe139247ee5f1ca2a378983e11388a2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f651dd19363c632f4abe3480a7c87a9773be27cfe1341aef06e8759599454120"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aaf09e615a0bf98d406657e0008e4a8701b11481840be7d31755dc9f97c44053"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8e47755d8152c1ab5b55928ab422a76e2e7b22b5ed8e90a7d584268dd49e9c6b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "500960cb3a0543a724a81ba859da816e8cf01b0e6aaeedf2c3775d12ee49cade"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf6204fe865da605285c34cf1172879d0314ff267b1c35ff59de7154f35fdc2e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d33dd21f572545649f90c38c227cc8631268ba25c460b5569abebdd0ec5974ca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "49d5d58abd4b83fb8ce763be7794d09b2f50f10aa65c0f0c1696c677edeb7cbf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f53aace168a2a10582e570b7736cc5bef12cae9cf21775e3eafac597e8551fbe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0d32576b1de5a30d9a97f300cc6a3f4694c428d956adbc7e6e2f9cad279e45ed"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ec08be75bb268473677edb83ba71e7e74b43c008e4a7b1907c6d57e940bf34b6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-none-win_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b1f6f5938d63c6139860f044e2538baeee6f0b251a1816e7adb6cbce106a1f01"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2a1ef6a36fdbf71538142ed604ad19b82f67b05749512e47f247a6ddd06afdc7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "704d35ecc7e9c31d48926150afada60401c55efa3b46cd1ded5a01bdffaf1d48"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d937653a696465677ed583124b94a4b2d79f5e30b2c46115a68e482c6a591c8a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c9803edf8e29bd825f43481f19c37f50d2b01899448273b3a7758441b512acf8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "72282ad4892a9fb2da25defeac8c2e84352c108705c972db82ab121d15f14e6d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7f752826b5b8361193df55afcdf8ca6a57d0232653494ba473630a83ba50d8c9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4384a8f68ddb31a0b0c3deae88765f5868a1b9148939c3f4121233314ad5532c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a4b2bf78342c40b3dc830880106f54328928ff03e357935ad26c7128bbd66ce8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "13dcc4802961b5f843a9385fc821a0b0135e8c07fc3d9949fd49627c1a5e6ae5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e3e70c94a0c3841e6aa831edab1619ad5c511199be94d0c11ba75fe06efe107a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ecdf6bf5f578615f2e985a5e1f6572e23aa632c4bd1dc67f8f406d445ac115ed"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bda1ee3e08252b8d41fa5537413ffdddd58fa73107171a126d3b9ff001b9b820"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "21b888c973e4f26b7a96491c0965a8a312e13be108022ee510248fe379a5fa23"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "be0ec334369316fa73448cc8c982c01e5d2a81c95969d58b8f6e272884df0074"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b5b6079cc452a7c53dd378c6f881ac528246b3ac9aae0f8eef98498a75657805"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7ee8d5f878dccb6d499ba4d30d757111847b6849ae07acdd1205fffa1fc1253c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7233d65d9d651242a68801159763d09e9ec96e8a158dbf118dc090cd77a104c9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c6119dc90483a5cb50a1306adb8d52c66e447da88ea44f323e0ae1a5fcb14256"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "578114bc803a4c1ff9946d977c221e4376620a46cf78da267d946397dc9514a8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d8f99b147ff3fcf6b3cc60cb0c39ea443884d5559a30b1481e92495f2310ff2b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4ac6b4ce1e7283d715c4b729d8f9dab9627586dafce81d9eaa009dd7f25dd972"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7774b570e61cb998490c5235740d475413a1f6de823169b4cf94e2fe9e9f6b2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9091632a25b8b87b9a605ec0e61f241c456e9248bfdcf7abdf344fdb169c81cf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "36fa178aacbc277bc6b62a2c3da95226520da4f4e9e206fdf076484363895d2c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dcca5d2bf65c6fb591fff92da03f94cd4f315972f97c21975398bd4bd046854a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2a72fb9963cba4cd5793854fd12f4cfee731e86df140f59ff52a49b3552db241"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b60cc1a081f80a2105a59385b92d82278b15d80ebb3adb200542ae165cd7d183"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cbcc558401de90a746d02ef330c528f2e668c83350f045833543cd57ecead1ad"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fee427241c2d9fb7192b658190f9f5fd6dfe41e02f3c1489d2ec1e6a5ab1e04a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f4cb85f693044e0f71f394ff76c98ddc1bc0953e48c061725e540396d5c8a2e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b29eeb887aa931c2fcef5aa515d9d176d25006794610c264ddc114c053bf96fe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a425479ee40ff021f8216c9d07a6a3b54b31c8267c6e17aa88b70d7ebd0e5e5b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c5cbc703168d1b7a838668998308018a2718c2130595e8e190220238addc96f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "99b6add4c0b39a513d323d3b93bc173dac663c27b99860dd5bf491b240d26137"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "75f76ee558751746d6a38f89d60b6228fa174e5172d143886af0f85aa306fd89"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "00ee1c97b5364b84cb0bd82e9bbf645d5e2871fb8c58059d158412fee2d33d8a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "287073c66748f624be4cef893ef9174e3eb88fe0b8a78dc22e88eca4bc357ca6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ed25e1835c00a332cb10c683cd39da96a719ab1dfc08427d476bce41b92531fc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "86b3d0033580bd6bbe07590152007275bd7af95f98eaa5bd36f3da219dcd93da"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1cac689f80a3abab2d3c0048b29eea5751114054f032a941a32de4c852c59cad"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3.tar.gz"
+        }
+      ],
+      "name": "pydantic-core",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pydantic-core@2.16.3",
+      "type": "library",
+      "version": "2.16.3"
+    },
+    {
+      "bom-ref": "pyyaml@6.0.1",
+      "description": "YAML parser and emitter for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1.tar.gz"
+        }
+      ],
+      "name": "pyyaml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pyyaml@6.0.1",
+      "type": "library",
+      "version": "6.0.1"
+    },
+    {
+      "bom-ref": "ray@2.10.0",
+      "description": "Ray provides a simple, universal API for building distributed applications.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8a174268c7b6ca9826e4884b837395b695a45c17049927965d1b4cc370184ba2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-macosx_10_15_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c193deed7e3f604cdb37047f5646cab14f4337693dd32add8bc902dfadb89f75"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a3db89d22afc7a0a976249715dd90ffe69f7692d32cb599cd1afbc38482060f7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cb74f7d2aa5a21e5f9dcb315a4f9bde822328e76ba95cd0ba370cfda098a67f4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "44ab600fe0b5a12675d0d42d564994ac4e53286217c4de1c4eb00d74ae79ef24"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8eb606b7d247213b377ccca0f8d425f9c61a48b23e9b2e4566bc75f66d797bb5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-macosx_10_15_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8eb11aec8a65946f7546d0e703158c03a85a8be27332dbbf86d9411802700e7e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5b4ec4b5707e18382685d0703ed04afd1602359a3056f6ae4b37588a0551eef3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c7d1438cba8726ec9a59c96964e007b60a0728436647f48c383228692c2f2ee0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eceecea4133e63f5d607cc9f2a4278de51eeeeef552f694895e381aae9ff8522"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fb92f2d6d4eca602dfb0d3d459a09be59668e1560ce4bd89b692892f25b1933b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-macosx_10_15_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "31aa60373fc7291752ee89a5f5ad8effec682b1f165911f38ae95fc43bc668a9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5b7d41eb04f6b67c38170edc0406dc71537eabfd6e5d4e3399a36385ff8b0194"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8a44535e6266fa09e3eb4fc9035906decfc9f3aeda86fe66b1e738a01a51939a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "77ba4120d694e7c3dc7d93a9d3cb33925827d04ad11af2d21fa0db66f227d27a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b49a8c2b40f02a56a2af2b6026c1eedd485747c6e4c2cf9ac433af6e572bdbb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-macosx_10_15_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5fe8fb8847304dd3a6e435b95af9e5436309f2b3612c63c56bf4ac8dea73f9f4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f215eb704f2cb72e984d5a85fe435b4d74808c906950176789ba2101ce739082"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "32d97e5343578a3d37ab5f30148fa193dec46a21fa21f15b6f23fe48a420831a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "917d081fc98500f244ebc0e8da836025e1e4fa52f21030b8336cb0a2c79e84e2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-win_amd64.whl"
+        }
+      ],
+      "name": "ray",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "serve"
+        }
+      ],
+      "purl": "pkg:pypi/ray@2.10.0",
+      "type": "library",
+      "version": "2.10.0"
+    },
+    {
+      "bom-ref": "referencing@0.34.0",
+      "description": "JSON Referencing + Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d53ae300ceddd3169f1ffa9caf2cb7b769e92657e4fafb23d34b93679116dfd4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/#referencing-0.34.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5773bd84ef41799a5a8ca72dc34590c041eb01bf9aa02632b4a973fb0181a844"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/#referencing-0.34.0.tar.gz"
+        }
+      ],
+      "name": "referencing",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/referencing@0.34.0",
+      "type": "library",
+      "version": "0.34.0"
+    },
+    {
+      "bom-ref": "requests@2.31.0",
+      "description": "Python HTTP for Humans.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/requests/#requests-2.31.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/requests/#requests-2.31.0.tar.gz"
+        }
+      ],
+      "name": "requests",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/requests@2.31.0",
+      "type": "library",
+      "version": "2.31.0"
+    },
+    {
+      "bom-ref": "rpds-py@0.18.0",
+      "description": "Python bindings to Rust's persistent data structures (rpds)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5b4e7d8d6c9b2e8ee2d55c90b59c707ca59bc30058269b3db7b1f8df5763557e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c463ed05f9dfb9baebef68048aed8dcdc94411e4bf3d33a39ba97e271624f8f7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "01e36a39af54a30f28b73096dd39b6802eddd04c90dbe161c1b8dbe22353189f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d62dec4976954a23d7f91f2f4530852b0c7608116c257833922a896101336c51"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dd18772815d5f008fa03d2b9a681ae38d5ae9f0e599f7dda233c439fcaa00d40"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "923d39efa3cfb7279a0327e337a7958bff00cc447fd07a25cddb0a1cc9a6d2da"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "39514da80f971362f9267c600b6d459bfbbc549cffc2cef8e47474fddc9b45b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a34d557a42aa28bd5c48a023c570219ba2593bcbbb8dc1b98d8cf5d529ab1434"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "93df1de2f7f7239dc9cc5a4a12408ee1598725036bd2dedadc14d94525192fc3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "34b18ba135c687f4dac449aa5157d36e2cbb7c03cbea4ddbd88604e076aa836e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c0b5dcf9193625afd8ecc92312d6ed78781c46ecbf39af9ad4681fc9f464af88"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c4325ff0442a12113a6379af66978c3fe562f846763287ef66bdc1d57925d337"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7223a2a5fe0d217e60a60cdae28d6949140dde9c3bcc714063c5b463065e3d66"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a96e0c6a41dcdba3a0a581bbf6c44bb863f27c541547fb4b9711fd8cf0ffad4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "30f43887bbae0d49113cbaab729a112251a940e9b274536613097ab8b4899cf6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fcb25daa9219b4cf3a0ab24b0eb9a5cc8949ed4dc72acb8fa16b7e1681aa3c58"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d68c93e381010662ab873fea609bf6c0f428b6d0bb00f2c6939782e0818d37bf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b34b7aa8b261c1dbf7720b5d6f01f38243e9b9daf7e6b8bc1fd4657000062f2c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2e6d75ab12b0bbab7215e5d40f1e5b738aa539598db27ef83b2ec46747df90e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0b8612cd233543a3781bc659c731b9d607de65890085098986dfd573fc2befe5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aec493917dd45e3c69d00a8874e7cbed844efd935595ef78a0f25f14312e33c6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "661d25cbffaf8cc42e971dd570d87cb29a665f49f4abe1f9e76be9a5182c4688"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1df3659d26f539ac74fb3b0c481cdf9d725386e3552c6fa2974f4d33d78e544b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a1ce3ba137ed54f83e56fb983a5859a27d43a40188ba798993812fed73c70836"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "69e64831e22a6b377772e7fb337533c365085b31619005802a79242fee620bc1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "998e33ad22dc7ec7e030b3df701c43630b5bc0d8fbc2267653577e3fec279afa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7f2facbd386dd60cbbf1a794181e6aa0bd429bd78bfdf775436020172e2a23f0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1d9a5be316c15ffb2b3c405c4ff14448c36b4435be062a7f578ccd8b01f0c4d8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd5bf1af8efe569654bbef5a3e0a56eca45f87cfcffab31dd8dde70da5982475"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5417558f6887e9b6b65b4527232553c139b57ec42c64570569b155262ac0754f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "56a737287efecafc16f6d067c2ea0117abadcd078d58721f967952db329a3e5c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8f03bccbd8586e9dd37219bce4d4e0d3ab492e6b3b533e973fa08a112cb2ffc9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4457a94da0d5c53dc4b3e4de1158bdab077db23c53232f37a3cb7afdb053a4e3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0ab39c1ba9023914297dd88ec3b3b3c3f33671baeb6acf82ad7ce883f6e8e157"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9d54553c1136b50fd12cc17e5b11ad07374c316df307e4cfd6441bea5fb68496"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0af039631b6de0397ab2ba16eaf2872e9f8fca391b44d3d8cac317860a700a3f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84ffab12db93b5f6bad84c712c92060a2d321b35c3c9960b43d08d0f639d60d7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "685537e07897f173abcf67258bee3c05c374fa6fff89d4c7e42fb391b0605e98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e003b002ec72c8d5a3e3da2989c7d6065b47d9eaa70cd8808b5384fbb970f4ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08f9ad53c3f31dfb4baa00da22f1e862900f45908383c062c27628754af2e88e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c0013fe6b46aa496a6749c77e00a3eb07952832ad6166bd481c74bda0dcb6d58"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e32a92116d4f2a80b629778280103d2a510a5b3f6314ceccd6e38006b5e92dcb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e541ec6f2ec456934fd279a3120f856cd0aedd209fc3852eca563f81738f6861"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bed88b9a458e354014d662d47e7a5baafd7ff81c780fd91584a10d6ec842cb73"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2644e47de560eb7bd55c20fc59f6daa04682655c58d08185a9b95c1970fa1e07"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8e8916ae4c720529e18afa0b879473049e95949bf97042e938530e072fde061d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "465a3eb5659338cf2a9243e50ad9b2296fa15061736d6e26240e713522b6235c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ea7d4a99f3b38c37eac212dbd6ec42b7a5ec51e2c74b5d3223e43c811609e65f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "67071a6171e92b6da534b8ae326505f7c18022c6f19072a81dcf40db2638767c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "41ef53e7c58aa4ef281da975f62c258950f54b76ec8e45941e93a3d1d8580594"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fdea4952db2793c4ad0bdccd27c1d8fdd1423a92f04598bc39425bcc2b8ee46e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7cd863afe7336c62ec78d7d1349a2f34c007a3cc6c2369d667c65aeec412a5b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5307def11a35f5ae4581a0b658b0af8178c65c530e94893345bebf41cc139d33"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "77f195baa60a54ef9d2de16fbbfd3ff8b04edc0c0140a761b56c267ac11aa467"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "39f5441553f1c2aed4de4377178ad8ff8f9d733723d6c66d983d75341de265ab"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9a00312dea9310d4cb7dbd7787e722d2e86a95c2db92fbd7d0155f97127bcb40"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8f2fc11e8fe034ee3c34d316d0ad8808f45bc3b9ce5857ff29d513f3ff2923a1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "586f8204935b9ec884500498ccc91aa869fc652c40c093bd9e1471fbcc25c022"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ddc2f4dfd396c7bfa18e6ce371cba60e4cf9d2e5cdb71376aa2da264605b60b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5ddcba87675b6d509139d1b521e0c8250e967e63b5909a7e8f8944d0f90ff36f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7bd339195d84439cbe5771546fe8a4e8a7a045417d8f9de9a368c434e42a721e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d7c36232a90d4755b720fbd76739d8891732b18cf240a9c645d75f00639a9024"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b0817e34942b2ca527b0e9298373e7cc75f429e8da2055607f4931fded23e20"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "99f70b740dc04d09e6b2699b675874367885217a2e9f782bdf5395632ac663b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6ef687afab047554a2d366e112dd187b62d261d49eb79b77e386f94644363294"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ad36cfb355e24f1bd37cac88c112cd7730873f20fb0bdaf8ba59eedf8216079f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "36b3ee798c58ace201289024b52788161e1ea133e4ac93fba7d49da5fec0ef9e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f8a2f084546cc59ea99fda8e070be2fd140c3092dc11524a71aa8f0f3d5a55ca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e4461d0f003a0aa9be2bdd1b798a041f177189c1a0f7619fe8c95ad08d9a45d7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8db715ebe3bb7d86d77ac1826f7d67ec11a70dbd2376b7cc214199360517b641"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "793968759cd0d96cac1e367afd70c235867831983f876a53389ad869b043c948"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "66e6a3af5a75363d2c9a48b07cb27c4ea542938b1a2e93b15a503cdfa8490795"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6ef0befbb5d79cf32d0266f5cff01545602344eda89480e1dd88aca964260b18"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1d4acf42190d449d5e89654d5c1ed3a4f17925eec71f05e2a41414689cda02d1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a5f446dd5055667aabaee78487f2b5ab72e244f9bc0b2ffebfeec79051679984"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9dbbeb27f4e70bfd9eec1be5477517365afe05a9b2c441a0b21929ee61048124"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "22806714311a69fd0af9b35b7be97c18a0fc2826e6827dbb3a8c94eac6cf7eeb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b34ae4636dfc4e76a438ab826a0d1eed2589ca7d9a1b2d5bb546978ac6485461"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8c8370641f1a7f0e0669ddccca22f1da893cef7628396431eb445d46d893e5cd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c8362467a0fdeccd47935f22c256bec5e6abe543bf0d66e3d3d57a8fb5731863"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "11a8c85ef4a07a7638180bf04fe189d12757c696eb41f310d2426895356dcf05"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b316144e85316da2723f9d8dc75bada12fa58489a527091fa1d5a612643d1a0e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf1ea2e34868f6fbf070e1af291c8180480310173de0b0c43fc38a02929fc0e3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e546e768d08ad55b20b11dbb78a745151acbd938f8f00d0cfbabe8b0199b9880"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4901165d170a5fde6f589acb90a6b33629ad1ec976d4529e769c6f3d885e3e80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "618a3d6cae6ef8ec88bb76dd80b83cfe415ad4f1d942ca2a903bf6b6ff97a2da"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ed4eb745efbff0a8e9587d22a84be94a5eb7d2d99c02dacf7bd0911713ed14dd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6c81e5f372cd0dc5dc4809553d34f832f60a46034a5f187756d9b90586c2c307"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "43fbac5f22e25bee1d482c97474f930a353542855f05c1161fd804c9dc74a09d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6d7faa6f14017c0b1e69f5e2c357b998731ea75a442ab3841c0dbbbfe902d2c4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08231ac30a842bd04daabc4d71fddd7e6d26189406d5a69535638e4dcb88fe76"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "044a3e61a7c2dafacae99d1e722cc2d4c05280790ec5a05031b3876809d89a5c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3f26b5bd1079acdb0c7a5645e350fe54d16b17bfc5e71f371c449383d3342e17"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "482103aed1dfe2f3b71a58eff35ba105289b8d862551ea576bd15479aba01f66"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1374f4129f9bcca53a1bba0bb86bf78325a0374577cf7e9e4cd046b1e6f20e24"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "635dc434ff724b178cb192c70016cc0ad25a275228f749ee0daf0eddbc8183b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bc362ee4e314870a70f4ae88772d72d877246537d9f8cb8f7eacf10884862432"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4832d7d380477521a8c1644bbab6588dfedea5e30a7d967b5fb75977c45fd77f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "42821446ee7a76f5d9f71f9e33a4fb2ffd724bb3e7f93386150b61a43115788d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0.tar.gz"
+        }
+      ],
+      "name": "rpds-py",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/rpds-py@0.18.0",
+      "type": "library",
+      "version": "0.18.0"
+    },
+    {
+      "bom-ref": "rsa@4.9",
+      "description": "Pure-Python RSA implementation",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rsa/#rsa-4.9-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rsa/#rsa-4.9.tar.gz"
+        }
+      ],
+      "name": "rsa",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/rsa@4.9",
+      "type": "library",
+      "version": "4.9"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "smart-open@7.0.4",
+      "description": "Utils for streaming large files (S3, HDFS, GCS, Azure Blob Storage, gzip, bz2...)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4e98489932b3372595cddc075e6033194775165702887216b65eba760dfd8d47"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/smart-open/#smart_open-7.0.4-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "62b65852bdd1d1d516839fcb1f6bc50cd0f16e05b4ec44b52f43d38bcb838524"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/smart-open/#smart_open-7.0.4.tar.gz"
+        }
+      ],
+      "name": "smart-open",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/smart-open@7.0.4",
+      "type": "library",
+      "version": "7.0.4"
+    },
+    {
+      "bom-ref": "sniffio@1.3.1",
+      "description": "Sniff out which async library your code is running under",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/sniffio/#sniffio-1.3.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/sniffio/#sniffio-1.3.1.tar.gz"
+        }
+      ],
+      "name": "sniffio",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/sniffio@1.3.1",
+      "type": "library",
+      "version": "1.3.1"
+    },
+    {
+      "bom-ref": "starlette@0.37.2",
+      "description": "The little ASGI library that shines.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6fe59f29268538e5d0d182f2791a479a0c64638e6935d1c6989e63fb2699c6ee"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/starlette/#starlette-0.37.2-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9af890290133b79fc3db55474ade20f6220a364a0402e0b556e7cd5e1e093823"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/starlette/#starlette-0.37.2.tar.gz"
+        }
+      ],
+      "name": "starlette",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/starlette@0.37.2",
+      "type": "library",
+      "version": "0.37.2"
+    },
+    {
+      "bom-ref": "typing-extensions@4.10.0",
+      "description": "Backported and Experimental Type Hints for Python 3.8+",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/typing-extensions/#typing_extensions-4.10.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/typing-extensions/#typing_extensions-4.10.0.tar.gz"
+        }
+      ],
+      "name": "typing-extensions",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/typing-extensions@4.10.0",
+      "type": "library",
+      "version": "4.10.0"
+    },
+    {
+      "bom-ref": "urllib3@2.2.1",
+      "description": "HTTP library with thread-safe connection pooling, file post, and more.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/urllib3/#urllib3-2.2.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/urllib3/#urllib3-2.2.1.tar.gz"
+        }
+      ],
+      "name": "urllib3",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/urllib3@2.2.1",
+      "type": "library",
+      "version": "2.2.1"
+    },
+    {
+      "bom-ref": "uvicorn@0.29.0",
+      "description": "The lightning-fast ASGI server.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2c2aac7ff4f4365c206fd773a39bf4ebd1047c238f8b8268ad996829323473de"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvicorn/#uvicorn-0.29.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6a69214c0b6a087462412670b3ef21224fa48cae0e452b5883e8e8bdfdd11dd0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvicorn/#uvicorn-0.29.0.tar.gz"
+        }
+      ],
+      "name": "uvicorn",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/uvicorn@0.29.0",
+      "type": "library",
+      "version": "0.29.0"
+    },
+    {
+      "bom-ref": "virtualenv@20.25.1",
+      "description": "Virtual Python Environment builder",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961c026ac520bac5f69acb8ea063e8a4f071bcc9457b9c1f28f6b085c511583a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/virtualenv/#virtualenv-20.25.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e08e13ecdca7a0bd53798f356d5831434afa5b07b93f0abdf0797b7a06ffe197"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/virtualenv/#virtualenv-20.25.1.tar.gz"
+        }
+      ],
+      "name": "virtualenv",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/virtualenv@20.25.1",
+      "type": "library",
+      "version": "20.25.1"
+    },
+    {
+      "bom-ref": "watchfiles@0.21.0",
+      "description": "Simple, modern and high performance file watching and code reload in python.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27b4035013f1ea49c6c0b42d983133b136637a527e48c132d368eb19bf1ac6aa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c81818595eff6e92535ff32825f31c116f867f64ff8cdf6562cd1d6b2e1e8f3e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6c107ea3cf2bd07199d66f156e3ea756d1b84dfd43b542b2d870b77868c98c03"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0d9ac347653ebd95839a7c607608703b20bc07e577e870d824fa4801bc1cb124"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5eb86c6acb498208e7663ca22dbe68ca2cf42ab5bf1c776670a50919a56e64ab"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f564bf68404144ea6b87a78a3f910cc8de216c6b12a4cf0b27718bf4ec38d303"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3d0f32ebfaa9c6011f8454994f86108c2eb9c79b8b7de00b36d558cadcedaa3d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b6d45d9b699ecbac6c7bd8e0a2609767491540403610962968d258fd6405c17c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aff06b2cac3ef4616e26ba17a9c250c1fe9dd8a5d907d0193f84c499b1b6e6a9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d9792dff410f266051025ecfaa927078b94cc7478954b06796a9756ccc7e14a9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "214cee7f9e09150d4fb42e24919a1e74d8c9b8a9306ed1474ecaddcd5479c293"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1ad7247d79f9f55bb25ab1778fd47f32d70cf36053941f07de0b7c4e96b5d235"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "668c265d90de8ae914f860d3eeb164534ba2e836811f91fecc7050416ee70aa7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a23092a992e61c3a6a70f350a56db7197242f3490da9c87b500f389b2d01eef"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7941bbcfdded9c26b0bf720cb7e6fd803d95a55d2c14b4bd1f6a2772230c586"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "11cd0c3100e2233e9c53106265da31d574355c288e15259c0d40a4405cbae317"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d78f30cbe8b2ce770160d3c08cff01b2ae9306fe66ce899b73f0409dc1846c1b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6674b00b9756b0af620aa2a3346b01f8e2a3dc729d25617e1b89cf6af4a54eb1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fd7ac678b92b29ba630d8c842d8ad6c555abda1b9ef044d6cc092dacbfc9719d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9c873345680c1b87f1e09e0eaf8cf6c891b9851d8b4d3645e7efe2ec20a20cc7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "49f56e6ecc2503e7dbe233fa328b2be1a7797d31548e7a193237dcdf1ad0eee0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "02d91cbac553a3ad141db016e3350b03184deaafeba09b9d6439826ee594b365"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ebe684d7d26239e23d102a2bad2a358dedf18e462e8808778703427d1f584400"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4566006aa44cb0d21b8ab53baf4b9c667a0ed23efe4aaad8c227bfba0bf15cbe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c550a56bf209a3d987d5a975cdf2063b3389a5d16caf29db4bdddeae49f22078"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-none-win_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "51ddac60b96a42c15d24fbdc7a4bfcd02b5a29c047b7f8bf63d3f6f5a860949a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "511f0b034120cd1989932bf1e9081aa9fb00f1f949fbd2d9cab6264916ae89b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cfb92d49dbb95ec7a07511bc9efb0faff8fe24ef3805662b8d6808ba8409a71a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3f92944efc564867bbf841c823c8b71bb0be75e06b8ce45c084b46411475a915"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "642d66b75eda909fd1112d35c53816d59789a4b38c141a96d62f50a3ef9b3360"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d23bcd6c8eaa6324fe109d8cac01b41fe9a54b8c498af9ce464c1aeeb99903d6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "18d5b4da8cf3e41895b34e8c37d13c9ed294954907929aacd95153508d5d89d7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b8d1eae0f65441963d805f766c7e9cd092f91e0c600c820c764a4ff71a0764c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1fd9a5205139f3c6bb60d11f6072e0552f0a20b712c85f43d42342d162be1235"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a1e3014a625bcf107fbf38eece0e47fa0190e52e45dc6eee5a8265ddc6dc5ea7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9d09869f2c5a6f2d9df50ce3064b3391d3ecb6dced708ad64467b9e4f2c9bef3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "18722b50783b5e30a18a8a5db3006bab146d2b705c92eb9a94f78c72beb94094"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a3b9bec9579a15fb3ca2d9878deae789df72f2b0fdaf90ad49ee389cad5edab6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-none-win_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4ea10a29aa5de67de02256a28d1bf53d21322295cb00bd2d57fcd19b850ebd99"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "40bca549fdc929b470dd1dbfcb47b3295cb46a6d2c90e50588b0a1b3bd98f429"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9b37a7ba223b2f26122c148bb8d09a9ff312afca998c48c725ff5a0a632145f7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ec8c8900dc5c83650a63dd48c4d1d245343f904c4b64b48798c67a3767d7e165"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8ad3fe0a3567c2f0f629d800409cd528cb6251da12e81a1f765e5c5345fd0137"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9d353c4cfda586db2a176ce42c88f2fc31ec25e50212650c89fdd0f560ee507b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "83a696da8922314ff2aec02987eefb03784f473281d740bf9170181829133765"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5a03651352fc20975ee2a707cd2d74a386cd303cc688f407296064ad1e6d1562"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3ad692bc7792be8c32918c699638b660c0de078a6cbe464c46e1340dadb94c19"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "06247538e8253975bdb328e7683f8515ff5ff041f43be6c40bff62d989b7d0b0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9a0aa47f94ea9a0b39dd30850b0adf2e1cd32a8b4f9c7aa443d852aacf9ca214"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d5f400326840934e3507701f9f7269247f7c026d1b6cfd49477d2be0933cfca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7f762a1a85a12cc3484f77eee7be87b10f8c50b0b787bb02f4e357403cad0c0e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6e9be3ef84e2bb9710f3f777accce25556f4a71e15d2b73223788d528fcc2052"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4c48a10d17571d1275701e14a601e36959ffada3add8cdbc9e5061a6e3579a5d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6c889025f59884423428c261f212e04d438de865beda0b1e1babab85ef4c0f01"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "66fac0c238ab9a2e72d026b5fb91cb902c146202bbd29a9a1a44e8db7b710b6f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b4a21f71885aa2744719459951819e7bf5a906a6448a6b2bbce8e9cc9f2c8128"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1c9198c989f47898b2c22201756f73249de3748e0fc9de44adaf54a8b259cc0c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d8f57c4461cd24fda22493109c45b3980863c58a25b8bec885ca8bea6b8d4b28"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "853853cbf7bf9408b404754b92512ebe3e3a83587503d766d23e6bf83d092ee6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d5b1dc0e708fad9f92c296ab2f948af403bf201db8fb2eb4c8179db143732e49"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "59137c0c6826bd56c710d1d2bda81553b5e6b7c84d5a676747d80caf0409ad94"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6cb8fdc044909e2078c248986f2fc76f911f72b51ea4a4fbbf472e01d14faa58"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ab03a90b305d2588e8352168e8c5a1520b721d2d367f31e9332c4235b30b8994"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "927c589500f9f41e370b0125c12ac9e7d3a2fd166b89e9ee2828b3dda20bfe6f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1bd467213195e76f838caf2c28cd65e58302d0254e636e7c0fca81efa4a2e62c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "02b73130687bc3f6bb79d8a170959042eb56eb3a42df3671c79b428cd73f17cc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08dca260e85ffae975448e344834d765983237ad6dc308231aa16e7933db763e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3ccceb50c611c433145502735e0370877cced72a6c70fd2410238bcbc7fe51d8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "57d430f5fb63fea141ab71ca9c064e80de3a20b427ca2febcbfcef70ff0ce895"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0dd5fad9b9c0dd89904bbdea978ce89a2b692a7ee8a0ce19b940e538c88a809c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "be6dd5d52b73018b21adc1c5d28ac0c68184a64769052dfeb0c5d9998e7f56a2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3cab0e06143768499384a8a5efb9c4dc53e19382952859e4802f294214f36ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8c6ed10c2497e5fedadf61e465b3ca12a19f96004c15dcffe4bd442ebadc2d85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "43babacef21c519bc6631c5fce2a61eccdfc011b4bcb9047255e9620732c8097"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c76c635fabf542bb78524905718c39f736a98e5ab25b23ec6d4abede1a85a6a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0.tar.gz"
+        }
+      ],
+      "name": "watchfiles",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/watchfiles@0.21.0",
+      "type": "library",
+      "version": "0.21.0"
+    },
+    {
+      "bom-ref": "wrapt@1.16.0",
+      "description": "Module for decorators, wrappers and monkey patching.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ffa565331890b90056c01db69c0fe634a776f8019c143a5ae265f9c6bc4bd6d4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e4fdb9275308292e880dcbeb12546df7f3e0f96c6b41197e0cf37d2826359020"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bb2dee3874a500de01c93d5c71415fcaef1d858370d405824783e7a8ef5db440"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2a88e6010048489cda82b1326889ec075a8c856c2e6a256072b28eaee3ccf487"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac83a914ebaf589b69f7d0a1277602ff494e21f4c2f743313414378f8f50a4cf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "73aa7d98215d39b8455f103de64391cb79dfcad601701a3aa0dddacf74911d72"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "807cc8543a477ab7422f1120a217054f958a66ef7314f76dd9e77d3f02cdccd0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bf5703fdeb350e36885f2875d853ce13172ae281c56e509f4e6eca049bdfb136"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f6b2d0c6703c988d334f297aa5df18c45e97b0af3679bb75059e0e0bd8b1069d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "decbfa2f618fa8ed81c95ee18a387ff973143c656ef800c9f24fb7e9c16054e2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1a5db485fe2de4403f13fafdc231b0dbae5eca4359232d2efc79025527375b09"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "75ea7d0ee2a15733684badb16de6794894ed9c55aa5e9903260922f0482e687d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a452f9ca3e3267cd4d0fcf2edd0d035b1934ac2bd7e0e57ac91ad6b95c0c6389"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "43aa59eadec7890d9958748db829df269f0368521ba6dc68cc172d5d03ed8060"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "72554a23c78a8e7aa02abbd699d129eead8b147a23c56e08d08dfc29cfdddca1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d2efee35b4b0a347e0d99d28e884dfd82797852d62fcd7ebdeee26f3ceb72cf3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6dcfcffe73710be01d90cae08c3e548d90932d37b39ef83969ae135d36ef3956"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb6e651000a19c96f452c85132811d25e9264d836951022d6e81df2fff38337d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "66027d667efe95cc4fa945af59f92c5a02c6f5bb6012bff9e60542c74c75c362"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5eb404d89131ec9b4f748fa5cfb5346802e5ee8836f57d516576e61f304f3b7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9090c9e676d5236a6948330e83cb89969f433b1943a558968f659ead07cb3b36"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "94265b00870aa407bd0cbcfd536f17ecde43b94fb8d228560a1e9d3041462d73"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f2058f813d4f2b5e3a9eb2eb3faf8f1d99b81c3e51aeda4b168406443e8ba809"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "98b5e1f498a8ca1858a1cdbffb023bfd954da4e3fa2c0cb5853d40014557248b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "14d7dc606219cdd7405133c713f2c218d4252f2a469003f8c46bb92d5d095d81"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "49aac49dc4782cb04f58986e81ea0b4768e4ff197b57324dcbd7699c5dfb40b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "418abb18146475c310d7a6dc71143d6f7adec5b004ac9ce08dc7a34e2babdc5c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "685f568fa5e627e93f3b52fda002c7ed2fa1800b50ce51f6ed1d572d8ab3e7fc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dcdba5c86e368442528f7060039eda390cc4091bfd1dca41e8046af7c910dda8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d462f28826f4657968ae51d2181a074dfe03c200d6131690b7d65d55b0f360f8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a33a747400b94b6d6b8a165e4480264a64a78c8a4c734b62136062e9a248dd39"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3646eefa23daeba62643a58aac816945cadc0afaf21800a1421eeba5f6cfb9c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3ebf019be5c09d400cf7b024aa52b1f3aeebeff51550d007e92c3c1c4afc2a40"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0d2691979e93d06a95a26257adb7bfd0c93818e89b1406f5a28f36e0d8c1e1fc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1acd723ee2a8826f3d53910255643e33673e1d11db84ce5880675954183ec47e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bc57efac2da352a51cc4658878a68d2b1b67dbe9d33c36cb826ca449d80a8465"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "da4813f751142436b075ed7aa012a8778aa43a99f7b36afe9b742d3ed8bdc95e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6f6eac2360f2d543cc875a0e5efd413b6cbd483cb3ad7ebf888884a6e0d2e966"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a0ea261ce52b5952bf669684a251a66df239ec6d441ccb59ec7afa882265d593"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7bd2d7ff69a2cac767fbf7a2b206add2e9a210e57947dd7ce03e25d03d2de292"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9159485323798c8dc530a224bd3ffcf76659319ccc7bbd52e01e73bd0241a0c5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a86373cf37cd7764f2201b76496aba58a52e76dedfaa698ef9e9688bfd9e41cf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "73870c364c11f03ed072dda68ff7aea6d2a3a5c3fe250d917a429c7432e15228"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b935ae30c6e7400022b50f8d359c03ed233d45b725cfdd299462f41ee5ffba6f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "db98ad84a55eb09b3c32a96c576476777e87c520a34e2519d3e59c44710c002c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9153ed35fc5e4fa3b2fe97bddaa7cbec0ed22412b85bcdaf54aeba92ea37428c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "66dfbaa7cfa3eb707bbfcd46dab2bc6207b005cbc9caa2199bcbc81d95071a00"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1dd50a2696ff89f57bd8847647a1c363b687d3d796dc30d4dd4a9d1689a706f0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "44a2754372e32ab315734c6c73b24351d06e77ffff6ae27d2ecf14cf3d229202"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8e9723528b9f787dc59168369e42ae1c3b0d3fadb2f1a71de14531d321ee05b0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dbed418ba5c3dce92619656802cc5355cb679e58d0d89b50f116e4a9d5a9603e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "941988b89b4fd6b41c3f0bfb20e92bd23746579736b7343283297c4c8cbae68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6a42cd0cfa8ffc1915aef79cb4284f6383d8a3e9dcca70c445dcfdd639d51267"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1ca9b6085e4f866bd584fb135a041bfc32cab916e69f714a7d1d397f8c4891ca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d5e49454f19ef621089e204f862388d29e6e8d8b162efce05208913dde5b9ad6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c31f72b1b6624c9d863fc095da460802f43a7c6868c5dda140f51da24fd47d7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "490b0ee15c1a55be9c1bd8609b8cecd60e325f0575fc98f50058eae366e01f41"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9b201ae332c3637a42f02d1045e1d0cccfdc41f1f2f801dafbaa7e9b4797bfc2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2076fad65c6736184e77d7d4729b63a6d1ae0b70da4868adeec40989858eb3fb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c5cd603b575ebceca7da5a3a251e69561bec509e0b46e4993e1cac402b7247b8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b47cfad9e9bbbed2339081f4e346c93ecd7ab504299403320bf85f7f85c7d46c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5f15814a33e42b04e3de432e573aa557f9f0f56458745c2074952f564c50e664"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "db2e408d983b0e61e238cf579c09ef7020560441906ca990fe8412153e3b291f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "edfad1d29c73f9b863ebe7082ae9321374ccb10879eeabc84ba3b69f2579d537"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ed867c42c268f876097248e05b6117a65bcd1e63b779e916fe2e33cd6fd0d3c3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0.tar.gz"
+        }
+      ],
+      "name": "wrapt",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/wrapt@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "yarl@1.9.4",
+      "description": "Yet another URL library",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a8c1df72eb746f4136fe9a2e72b0c9dc1da1cbd23b5372f94b5820ff8ae30e0e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a3a6ed1d525bfb91b3fc9b690c5a21bb52de28c018530ad85093cc488bee2dd2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c38c9ddb6103ceae4e4498f9c08fac9b590c5c71b0370f98714768e22ac6fa66"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d9e09c9d74f4566e905a0b8fa668c58109f7624db96a2171f21747abc7524234"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b8477c1ee4bd47c57d49621a062121c3023609f7a13b8a46953eb6c9716ca392"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d5ff2c858f5f6a42c2a8e751100f237c5e869cbde669a724f2062d4c4ef93551"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "357495293086c5b6d34ca9616a43d329317feab7917518bc97a08f9e55648455"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54525ae423d7b7a8ee81ba189f131054defdb122cde31ff17477951464c1691c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "801e9264d19643548651b9db361ce3287176671fb0117f96b5ac0ee1c3530d53"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e516dc8baf7b380e6c1c26792610230f37147bb754d6426462ab115a02944385"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7d5aaac37d19b2904bb9dfe12cdb08c8443e7ba7d2852894ad448d4b8f442863"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54beabb809ffcacbd9d28ac57b0db46e42a6e341a030293fb3185c409e626b8b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bac8d525a8dbc2a1507ec731d2867025d11ceadcb4dd421423a5d42c56818541"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7855426dfbddac81896b6e533ebefc0af2f132d4a47340cee6d22cac7190022d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "848cd2a1df56ddbffeb375535fb62c9d1645dde33ca4d51341378b3f5954429b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "35a2b9396879ce32754bd457d31a51ff0a9d426fd9e0e3c33394bf4b9036b099"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4c7d56b293cc071e82532f70adcbd8b61909eec973ae9d2d1f9b233f3d943f2c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d8a1c6c0be645c745a081c192e747c5de06e944a0d21245f4cf7c05e457c36e0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b3c1ffe10069f655ea2d731808e76e0f452fc6c749bea04781daf18e6039525"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "549d19c84c55d11687ddbd47eeb348a89df9cb30e1993f1b128f4685cd0ebbf8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a7409f968456111140c1c95301cadf071bd30a81cbd7ab829169fb9e3d72eae9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e23a6d84d9d1738dbc6e38167776107e63307dfc8ad108e580548d1f2c587f42"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d8b889777de69897406c9fb0b76cdf2fd0f31267861ae7501d93003d55f54fbe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "03caa9507d3d3c83bca08650678e25364e1843b484f19986a527630ca376ecce"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4e9035df8d0880b2f1c7f5031f33f69e071dfe72ee9310cfc76f7b605958ceb9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c0ec0ed476f77db9fb29bca17f0a8fcc7bc97ad4c6c1d8959c507decb22e8572"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ee04010f26d5102399bd17f8df8bc38dc7ccd7701dc77f4a68c5b8d733406958"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "49a180c2e0743d5d6e0b4d1a9e5f633c62eca3f8a86ba5dd3c471060e352ca98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81eb57278deb6098a5b62e88ad8281b2ba09f2f1147c4767522353eaa6260b31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d1d2532b340b692880261c15aee4dc94dd22ca5d61b9db9a8a361953d36410b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0d2454f0aef65ea81037759be5ca9947539667eecebca092733b2eb43c965a81"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "44d8ffbb9c06e5a7f529f38f53eda23e50d1ed33c6c869e01481d3fafa6b8142"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aaaea1e536f98754a6e5c56091baa1b6ce2f2700cc4a00b0d49eca8dea471074"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3777ce5536d17989c91696db1d459574e9a9bd37660ea7ee4d3344579bb6f129"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9fc5fc1eeb029757349ad26bbc5880557389a03fa6ada41703db5e068881e5f2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ea65804b5dc88dacd4a40279af0cdadcfe74b3e5b4c897aa0d81cf86927fee78"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aa102d6d280a5455ad6a0f9e6d769989638718e938a6a0a2ff3f4a7ff8c62cc4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "09efe4615ada057ba2d30df871d2f668af661e971dfeedf0c159927d48bbeff0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "008d3e808d03ef28542372d01057fd09168419cdc8f848efe2804f894ae03e51"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6f5cb257bc2ec58f437da2b37a8cd48f666db96d47b8a3115c29f316313654ff"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "992f18e0ea248ee03b5a6e8b3b4738850ae7dbb172cc41c966462801cbf62cf7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e9d124c191d5b881060a9e5060627694c3bdd1fe24c5eecc8d5d7d0eb6faabc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3986b6f41ad22988e53d5778f91855dc0399b043fc8946d4f2e68af22ee9ff10"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b21516d181cd77ebd06ce160ef8cc2a5e9ad35fb1c5930882baff5ac865eee7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a9bd00dc3bc395a662900f33f74feb3e757429e545d831eef5bb280252631984"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "63b20738b5aac74e239622d2fe30df4fca4942a86e31bf47a81a0e94c14df94f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d7d7f7de27b8944f1fee2c26a88b4dabc2409d2fea7a9ed3df79b67277644e17"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c74018551e31269d56fab81a728f683667e7c28c04e807ba08f8c9e3bba32f14"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ca06675212f94e7a610e85ca36948bb8fc023e458dd6c63ef71abfd482481aa5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5aef935237d60a51a62b86249839b51345f47564208c6ee615ed2a40878dccdd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2b134fd795e2322b7684155b7855cc99409d10b2e408056db2b93b51a52accc7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d25039a474c4c72a5ad4b52495056f843a7ff07b632c1b92ea9043a3d9950f6e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f7d6b36dd2e029b6bcb8a13cf19664c7b8e19ab3a58e0fefbb5b8461447ed5ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "957b4774373cf6f709359e5c8c4a0af9f6d7875db657adb0feaf8d6cb3c3964c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d7eeb6d22331e2fd42fce928a81c697c9ee2d51400bd1a28803965883e13cead"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6a962e04b8f91f8c4e5917e518d17958e3bdee71fd1d8b88cdce74dd0ebbf434"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f3bc6af6e2b8f92eced34ef6a96ffb248e863af20ef4fde9448cc8c9b858b749"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ad4d7a90a92e528aadf4965d685c17dacff3df282db1121136c382dc0b6014d2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ec61d826d80fc293ed46c9dd26995921e3a82146feacd952ef0757236fc137be"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8be9e837ea9113676e5754b43b940b50cce76d9ed7d2461df1af39a8ee674d9f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bef596fdaa8f26e3d66af846bbe77057237cb6e8efff8cd7cc8dff9a62278bbf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2d47552b6e52c3319fede1b60b3de120fe83bde9b7bddad11a69fb0af7db32f1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84fc30f71689d7fc9168b92788abc977dc8cefa806909565fc2951d02f6b7d57"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4aa9741085f635934f3a2583e16fcf62ba835719a8b2b28fb2917bb0537c1dfa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "206a55215e6d05dbc6c98ce598a59e6fbd0c493e2de4ea6cc2f4934d5a18d130"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "07574b007ee20e5c375a8fe4a0789fad26db905f9813be0f9fef5a68080de559"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5a2e2433eb9344a163aced6a5f6c9222c0786e5a9e9cac2c89f0b28433f56e23"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6ad6d10ed9b67a382b45f29ea028f92d25bc0bc1daf6c5b801b90b5aa70fb9ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6fe79f998a4052d79e1c30eeb7d6c1c1056ad33300f682465e1b4e9b5a188b78"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a825ec844298c791fd28ed14ed1bffc56a98d15b8c58a20e0e08c1f5f2bea1be"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8619d6915b3b0b34420cf9b2bb6d81ef59d984cb0fde7544e9ece32b4b3043c3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "686a0c2f85f83463272ddffd4deb5e591c98aac1897d65e92319f729c320eece"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a00862fb23195b6b8322f7d781b0dc1d82cb3bcac346d1e38689370cc1cc398b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "604f31d97fa493083ea21bd9b92c419012531c4e17ea6da0f65cacdcf5d0bd27"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8a854227cf581330ffa2c4824d96e52ee621dd571078a252c25e3a3b3d94a1b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ba6f52cbc7809cd8d74604cce9c14868306ae4aa0282016b641c661f981a6e91"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a6327976c7c2f4ee6816eff196e25385ccc02cb81427952414a64811037bbc8b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8397a3817d7dcdd14bb266283cd1d6fc7264a48c186b986f32e86d86d35fbac5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e0381b4ce23ff92f8170080c97678040fc5b08da85e9e292292aba67fdac6c34"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "23d32a2594cb5d565d358a92e151315d1b2268bc10f4610d098f96b147370136"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ddb2a5c08a4eaaba605340fdee8fc08e406c56617566d9643ad8bf6852778fc7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "26a1dc6285e03f3cc9e839a2da83bcbf31dcb0d004c72d0730e755b33466c30e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "18580f672e44ce1238b82f7fb87d727c4a131f3a9d33a5e0e82b793362bf18b4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "29e0f83f37610f173eb7e7b5562dd71467993495e568e708d99e9d1944f561ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f23e4fe1e8794f74b6027d7cf19dc25f8b63af1483d91d595d4a07eca1fb26c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "db8e58b9d79200c76956cefd14d5c90af54416ff5353c5bfd7cbe58818e26ef0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c7224cab95645c7ab53791022ae77a4509472613e839dab722a72abe5a684575"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "824d6c50492add5da9374875ce72db7a0733b29c2394890aef23d533106e2b15"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "928cecb0ef9d5a7946eb6ff58417ad2fe9375762382f1bf5c55e61645f2c43ad"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "566db86717cf8080b99b58b083b773a908ae40f06681e87e589a976faf8246bf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4.tar.gz"
+        }
+      ],
+      "name": "yarl",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/yarl@1.9.4",
+      "type": "library",
+      "version": "1.9.4"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "aiohttp@3.9.3"
+      ],
+      "ref": "aiohttp-cors@0.7.0"
+    },
+    {
+      "dependsOn": [
+        "aiosignal@1.3.1",
+        "async-timeout@4.0.3",
+        "attrs@23.2.0",
+        "frozenlist@1.4.1",
+        "multidict@6.0.5",
+        "yarl@1.9.4"
+      ],
+      "ref": "aiohttp@3.9.3"
+    },
+    {
+      "dependsOn": [
+        "frozenlist@1.4.1"
+      ],
+      "ref": "aiosignal@1.3.1"
+    },
+    {
+      "ref": "annotated-types@0.6.0"
+    },
+    {
+      "dependsOn": [
+        "exceptiongroup@1.2.0",
+        "idna@3.6",
+        "sniffio@1.3.1",
+        "typing-extensions@4.10.0"
+      ],
+      "ref": "anyio@4.3.0"
+    },
+    {
+      "ref": "async-timeout@4.0.3"
+    },
+    {
+      "ref": "attrs@23.2.0"
+    },
+    {
+      "ref": "cachetools@5.3.3"
+    },
+    {
+      "ref": "certifi@2024.2.2"
+    },
+    {
+      "ref": "charset-normalizer@3.3.2"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6"
+      ],
+      "ref": "click@8.1.7"
+    },
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6"
+      ],
+      "ref": "colorful@0.5.6"
+    },
+    {
+      "ref": "distlib@0.3.8"
+    },
+    {
+      "ref": "exceptiongroup@1.2.0"
+    },
+    {
+      "dependsOn": [
+        "pydantic@2.6.4",
+        "starlette@0.37.2"
+      ],
+      "ref": "fastapi@0.1.17"
+    },
+    {
+      "ref": "filelock@3.13.3"
+    },
+    {
+      "ref": "frozenlist@1.4.1"
+    },
+    {
+      "dependsOn": [
+        "google-auth@2.29.0",
+        "googleapis-common-protos@1.56.1",
+        "protobuf@5.26.1",
+        "requests@2.31.0"
+      ],
+      "ref": "google-api-core@2.8.0"
+    },
+    {
+      "dependsOn": [
+        "cachetools@5.3.3",
+        "pyasn1-modules@0.4.0",
+        "rsa@4.9"
+      ],
+      "ref": "google-auth@2.29.0"
+    },
+    {
+      "dependsOn": [
+        "protobuf@5.26.1"
+      ],
+      "ref": "googleapis-common-protos@1.56.1"
+    },
+    {
+      "ref": "grpcio@1.62.1"
+    },
+    {
+      "ref": "h11@0.14.0"
+    },
+    {
+      "ref": "idna@3.6"
+    },
+    {
+      "dependsOn": [
+        "referencing@0.34.0"
+      ],
+      "ref": "jsonschema-specifications@2023.12.1"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.2.0",
+        "jsonschema-specifications@2023.12.1",
+        "referencing@0.34.0",
+        "rpds-py@0.18.0"
+      ],
+      "ref": "jsonschema@4.21.1"
+    },
+    {
+      "ref": "msgpack@1.0.8"
+    },
+    {
+      "ref": "multidict@6.0.5"
+    },
+    {
+      "ref": "opencensus-context@0.1.3"
+    },
+    {
+      "dependsOn": [
+        "google-api-core@2.8.0",
+        "opencensus-context@0.1.3",
+        "six@1.16.0"
+      ],
+      "ref": "opencensus@0.11.4"
+    },
+    {
+      "ref": "packaging@24.0"
+    },
+    {
+      "ref": "platformdirs@4.2.0"
+    },
+    {
+      "ref": "prometheus-client@0.20.0"
+    },
+    {
+      "ref": "protobuf@5.26.1"
+    },
+    {
+      "ref": "py-spy@0.3.14"
+    },
+    {
+      "dependsOn": [
+        "pyasn1@0.6.0"
+      ],
+      "ref": "pyasn1-modules@0.4.0"
+    },
+    {
+      "ref": "pyasn1@0.6.0"
+    },
+    {
+      "dependsOn": [
+        "typing-extensions@4.10.0"
+      ],
+      "ref": "pydantic-core@2.16.3"
+    },
+    {
+      "dependsOn": [
+        "annotated-types@0.6.0",
+        "pydantic-core@2.16.3",
+        "typing-extensions@4.10.0"
+      ],
+      "ref": "pydantic@2.6.4"
+    },
+    {
+      "ref": "pyyaml@6.0.1"
+    },
+    {
+      "dependsOn": [
+        "aiohttp-cors@0.7.0",
+        "aiohttp@3.9.3",
+        "aiosignal@1.3.1",
+        "click@8.1.7",
+        "colorful@0.5.6",
+        "fastapi@0.1.17",
+        "filelock@3.13.3",
+        "frozenlist@1.4.1",
+        "grpcio@1.62.1",
+        "jsonschema@4.21.1",
+        "msgpack@1.0.8",
+        "opencensus@0.11.4",
+        "packaging@24.0",
+        "prometheus-client@0.20.0",
+        "protobuf@5.26.1",
+        "py-spy@0.3.14",
+        "pydantic@2.6.4",
+        "pyyaml@6.0.1",
+        "requests@2.31.0",
+        "smart-open@7.0.4",
+        "starlette@0.37.2",
+        "uvicorn@0.29.0",
+        "virtualenv@20.25.1",
+        "watchfiles@0.21.0"
+      ],
+      "ref": "ray@2.10.0"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.2.0",
+        "rpds-py@0.18.0"
+      ],
+      "ref": "referencing@0.34.0"
+    },
+    {
+      "dependsOn": [
+        "ray@2.10.0"
+      ],
+      "ref": "regression-issue702"
+    },
+    {
+      "dependsOn": [
+        "certifi@2024.2.2",
+        "charset-normalizer@3.3.2",
+        "idna@3.6",
+        "urllib3@2.2.1"
+      ],
+      "ref": "requests@2.31.0"
+    },
+    {
+      "ref": "rpds-py@0.18.0"
+    },
+    {
+      "dependsOn": [
+        "pyasn1@0.6.0"
+      ],
+      "ref": "rsa@4.9"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "dependsOn": [
+        "wrapt@1.16.0"
+      ],
+      "ref": "smart-open@7.0.4"
+    },
+    {
+      "ref": "sniffio@1.3.1"
+    },
+    {
+      "dependsOn": [
+        "anyio@4.3.0"
+      ],
+      "ref": "starlette@0.37.2"
+    },
+    {
+      "ref": "typing-extensions@4.10.0"
+    },
+    {
+      "ref": "urllib3@2.2.1"
+    },
+    {
+      "dependsOn": [
+        "click@8.1.7",
+        "h11@0.14.0",
+        "typing-extensions@4.10.0"
+      ],
+      "ref": "uvicorn@0.29.0"
+    },
+    {
+      "dependsOn": [
+        "distlib@0.3.8",
+        "filelock@3.13.3",
+        "platformdirs@4.2.0"
+      ],
+      "ref": "virtualenv@20.25.1"
+    },
+    {
+      "dependsOn": [
+        "anyio@4.3.0"
+      ],
+      "ref": "watchfiles@0.21.0"
+    },
+    {
+      "ref": "wrapt@1.16.0"
+    },
+    {
+      "dependsOn": [
+        "idna@3.6",
+        "multidict@6.0.5"
+      ],
+      "ref": "yarl@1.9.4"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "regression-issue702",
+      "description": "regression for issue #702",
+      "name": "regression-issue702",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_regression-issue702_lock11_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_regression-issue702_lock11_1.6.xml.bin
@@ -1,0 +1,8026 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="regression-issue702">
+      <name>regression-issue702</name>
+      <version>0.1.0</version>
+      <description>regression for issue #702</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="aiohttp@3.9.3">
+      <name>aiohttp</name>
+      <version>3.9.3</version>
+      <description>Async http client/server framework (asyncio)</description>
+      <purl>pkg:pypi/aiohttp@3.9.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">939677b61f9d72a4fa2a042a5eee2a99a24001a67c13da113b2e30396567db54</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f5cd333fcf7590a18334c90f8c9147c837a6ec8a178e88d90a9b96ea03194cc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">82e6aa28dd46374f72093eda8bcd142f7771ee1eb9d1e223ff0fa7177a96b4a5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f56455b0c2c7cc3b0c584815264461d07b177f903a04481dfc33e08a89f0c26b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bca77a198bb6e69795ef2f09a5f4c12758487f83f33d63acde5f0d4919815768</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e083c285857b78ee21a96ba1eb1b5339733c3563f72980728ca2b08b53826ca5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ab40e6251c3873d86ea9b30a1ac6d7478c09277b32e14745d0d3c6e76e3c7e29</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">df822ee7feaaeffb99c1a9e5e608800bd8eda6e5f18f5cfb0dc7eeb2eaa6bbec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">acef0899fea7492145d2bbaaaec7b345c87753168589cc7faf0afec9afe9b747</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd73265a9e5ea618014802ab01babf1940cecb90c9762d8b9e7d2cc1e1969ec6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a78ed8a53a1221393d9637c01870248a6f4ea5b214a59a92a36f18151739452c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b0e029353361f1746bac2e4cc19b32f972ec03f0f943b390c4ab3371840aabf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7cf5c9458e1e90e3c390c2639f1017a0379a99a94fdfad3a1fd966a2874bba52</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3e59c23c52765951b69ec45ddbbc9403a8761ee6f57253250c6e1536cacc758b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">055ce4f74b82551678291473f66dc9fb9048a50d8324278751926ff0ae7715e5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b88f9386ff1ad91ace19d2a1c0225896e28815ee09fc6a8932fded8cda97c3d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c46956ed82961e31557b6857a5ca153c67e5476972e5f7190015018760938da2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">07b837ef0d2f252f96009e9b8435ec1fef68ef8b1461933253d318748ec1acdc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dad46e6f620574b3b4801c68255492e0159d1712271cc99d8bdf35f2043ec266</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5ed3e046ea7b14938112ccd53d91c1539af3e6679b222f9469981e3dac7ba1ce</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">039df344b45ae0b34ac885ab5b53940b174530d4dd8a14ed8b0e2155b9dddccb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7943c414d3a8d9235f5f15c22ace69787c140c80b718dcd57caaade95f7cd93b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">84871a243359bb42c12728f04d181a389718710129b36b6aad0fc4655a7647d4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5eafe2c065df5401ba06821b9a054d9cb2848867f3c59801b5d07a0be3a380ae</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9d3c9b50f19704552f23b4eaea1fc082fdd82c63429a6506446cbd8737823da3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f033d80bc6283092613882dfe40419c6a6a1527e04fc69350e87a9df02bbc283</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2c895a656dd7e061b2fd6bb77d971cc38f2afc277229ce7dd3552de8313a483e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f5a71d25cd8106eab05f8704cd9167b6e5187bcdf8f090a66c6d88b634802b4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">50fca156d718f8ced687a373f9e140c1bb765ca16e3d6f4fe116e3df7c05b2c5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5fe9ce6c09668063b8447f85d43b8d1c4e5d3d7e92c63173e6180b2ac5d46dd8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">38a19bc3b686ad55804ae931012f78f7a534cce165d089a2059f658f6c91fa60</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">770d015888c2a598b377bd2f663adfd947d78c0124cfe7b959e1ef39f5b13869</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ee43080e75fc92bf36219926c8e6de497f9b247301bbf88c5c7593d931426679</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">52df73f14ed99cee84865b95a3d9e044f226320a87af208f068ecc33e0c35b96</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dc9b311743a78043b26ffaeeb9715dc360335e5517832f5a8e339f8a43581e4d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b955ed993491f1a5da7f92e98d5dad3c1e14dc175f74517c4e610b1f2456fb11</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">504b6981675ace64c28bf4a05a508af5cde526e36492c98916127f5a02354d53</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a6fe5571784af92b6bc2fda8d1925cccdf24642d49546d3144948a6a1ed58ca5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ba39e9c8627edc56544c8628cc180d88605df3892beeb2b94c9bc857774848ca</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e5e46b578c0e9db71d04c4b506a2121c0cb371dd89af17a0586ff6769d4c58c1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">938a9653e1e0c592053f815f7028e41a3062e902095e5a7dc84617c87267ebd5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c3452ea726c76e92f3b9fae4b34a151981a9ec0a4847a627c43d71a15ac32aa6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ff30218887e62209942f91ac1be902cc80cddb86bf00fbc6783b7a43b2bea26f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">38f307b41e0bea3294a9a2a87833191e4bcf89bb0365e83a8be3a58b31fb7f38</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b791a3143681a520c0a17e26ae7465f1b6f99461a28019d1a2f425236e6eedb5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0ed621426d961df79aa3b963ac7af0d40392956ffa9be022024cd16297b30c8c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7f46acd6a194287b7e41e87957bfe2ad1ad88318d447caf5b090012f2c5bb528</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">feeb18a801aacb098220e2c3eea59a512362eb408d4afd0c242044c33ad6d542</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f734e38fd8666f53da904c52a23ce517f1b07722118d750405af7e4123933511</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b40670ec7e2156d8e57f70aec34a7216407848dfe6c693ef131ddf6e76feb672</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fdd215b7b7fd4a53994f238d0f46b7ba4ac4c0adb12452beee724ddd0743ae5d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">017a21b0df49039c8f46ca0971b3a7fdc1f56741ab1240cb90ca408049766168</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e99abf0bba688259a496f966211c49a514e65afa9b3073a1fcee08856e04425b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">648056db9a9fa565d3fa851880f99f45e3f9a771dd3ff3bb0c048ea83fb28194</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8aacb477dc26797ee089721536a292a664846489c49d3ef9725f992449eda5a8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">522a11c934ea660ff8953eda090dcd2154d367dec1ae3c540aff9f8a5c109ab4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5bce0dc147ca85caa5d33debc4f4d65e8e8b5c97c7f9f660f215fa74fc49a321</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4b4af9f25b49a7be47c0972139e59ec0e8285c371049df1a63b6ca81fdd216a2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">298abd678033b8571995650ccee753d9458dfa0377be4dba91e4491da3f2be63</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">69361bfdca5468c0488d7017b9b1e5ce769d40b46a9f4a2eed26b78619e9396c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0fa43c32d1643f518491d9d3a730f85f5bbaedcbd7fbcae27435bb8b7a061b29</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">835a55b7ca49468aaaac0b217092dfdff370e6c215c9224c52f30daaa735c1c1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">06a9b2c8837d9a94fae16c6223acc14b4dfdff216ab9b7202e07a9a09541168f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">abf151955990d23f84205286938796c55ff11bbfb4ccfada8c9c83ae6b3c89a3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">59c26c95975f26e662ca78fdf543d4eeaef70e533a672b4113dd888bd2423caa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f95511dd5d0e05fd9728bac4096319f80615aaef4acbecb35a990afebe953b0e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">595f105710293e76b9dc09f52e0dd896bd064a79346234b521f6b968ffdd8e58</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c7c8b816c2b5af5c8a436df44ca08258fc1a13b449393a91484225fcb7545533</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f1088fa100bf46e7b398ffd9904f4808a0612e1d966b4aa43baa535d1b6341eb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f59dfe57bb1ec82ac0698ebfcdb7bcd0e99c255bd637ff613760d5f33e7c81b3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">361a1026c9dd4aba0109e4040e2aecf9884f5cfe1b1b1bd3d09419c205e2e53d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">363afe77cfcbe3a36353d8ea133e904b108feea505aa4792dad6585a8192c55a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8e2c45c208c62e955e8256949eb225bd8b66a4c9b6865729a786f2aa79b72e9d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f7217af2e14da0856e082e96ff637f14ae45c10a5714b63c77f26d8884cf1051</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">27468897f628c627230dba07ec65dc8d0db566923c48f29e084ce382119802bc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">90842933e5d1ff760fae6caca4b2b3edba53ba8f4b71e95dacf2818a2aca06f7</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="aiohttp-cors@0.7.0">
+      <name>aiohttp-cors</name>
+      <version>0.7.0</version>
+      <description>CORS support for aiohttp</description>
+      <purl>pkg:pypi/aiohttp-cors@0.7.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp-cors/#aiohttp-cors-0.7.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d39c6d7100fd9764ed1caf8cebf0eb01bf5e3f24e2e073fda6234bc48b19f5d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp-cors/#aiohttp_cors-0.7.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0451ba59fdf6909d0e2cd21e4c0a43752bc0703d33fc78ae94d9d9321710193e</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="aiosignal@1.3.1">
+      <name>aiosignal</name>
+      <version>1.3.1</version>
+      <description>aiosignal: a list of registered asynchronous callbacks</description>
+      <purl>pkg:pypi/aiosignal@1.3.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiosignal/#aiosignal-1.3.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f8376fb07dd1e86a584e4fcdec80b36b7f81aac666ebc724e2c090300dd83b17</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiosignal/#aiosignal-1.3.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">54cd96e15e1649b75d6c87526a6ff0b6c1b0dd3459f43d9ca11d48c339b68cfc</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="annotated-types@0.6.0">
+      <name>annotated-types</name>
+      <version>0.6.0</version>
+      <description>Reusable constraint types to use with typing.Annotated</description>
+      <purl>pkg:pypi/annotated-types@0.6.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/annotated-types/#annotated_types-0.6.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0641064de18ba7a25dee8f96403ebc39113d0cb953a01429249d5c7564666a43</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/annotated-types/#annotated_types-0.6.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">563339e807e53ffd9c267e99fc6d9ea23eb8443c08f112651963e24e22f84a5d</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="anyio@4.3.0">
+      <name>anyio</name>
+      <version>4.3.0</version>
+      <description>High level compatibility layer for multiple asynchronous event loop implementations</description>
+      <purl>pkg:pypi/anyio@4.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/anyio/#anyio-4.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/anyio/#anyio-4.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="async-timeout@4.0.3">
+      <name>async-timeout</name>
+      <version>4.0.3</version>
+      <description>Timeout context manager for asyncio programs</description>
+      <purl>pkg:pypi/async-timeout@4.0.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/async-timeout/#async-timeout-4.0.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/async-timeout/#async_timeout-4.0.3-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="attrs@23.2.0">
+      <name>attrs</name>
+      <version>23.2.0</version>
+      <description>Classes Without Boilerplate</description>
+      <purl>pkg:pypi/attrs@23.2.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/#attrs-23.2.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/#attrs-23.2.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="cachetools@5.3.3">
+      <name>cachetools</name>
+      <version>5.3.3</version>
+      <description>Extensible memoizing collections and decorators</description>
+      <purl>pkg:pypi/cachetools@5.3.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/cachetools/#cachetools-5.3.3-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0abad1021d3f8325b2fc1d2e9c8b9c9d57b04c3932657a72465447332c24d945</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/cachetools/#cachetools-5.3.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ba29e2dfa0b8b556606f097407ed1aa62080ee108ab0dc5ec9d6a723a007d105</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="certifi@2024.2.2">
+      <name>certifi</name>
+      <version>2024.2.2</version>
+      <description>Python package for providing Mozilla's CA Bundle.</description>
+      <purl>pkg:pypi/certifi@2024.2.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/#certifi-2024.2.2-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/#certifi-2024.2.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="charset-normalizer@3.3.2">
+      <name>charset-normalizer</name>
+      <version>3.3.2</version>
+      <description>The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet.</description>
+      <purl>pkg:pypi/charset-normalizer@3.3.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset-normalizer-3.3.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2127566c664442652f024c837091890cb1942c30937add288223dc895793f898</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="click@8.1.7">
+      <name>click</name>
+      <version>8.1.7</version>
+      <description>Composable command line interface toolkit</description>
+      <purl>pkg:pypi/click@8.1.7</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/click/#click-8.1.7-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/click/#click-8.1.7.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorful@0.5.6">
+      <name>colorful</name>
+      <version>0.5.6</version>
+      <description>Terminal string styling done right, in Python.</description>
+      <purl>pkg:pypi/colorful@0.5.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorful/#colorful-0.5.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eab8c1c809f5025ad2b5238a50bd691e26850da8cac8f90d660ede6ea1af9f1e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorful/#colorful-0.5.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b56d5c01db1dac4898308ea889edcb113fbee3e6ec5df4bacffd61d5241b5b8d</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="distlib@0.3.8">
+      <name>distlib</name>
+      <version>0.3.8</version>
+      <description>Distribution utilities</description>
+      <purl>pkg:pypi/distlib@0.3.8</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/distlib/#distlib-0.3.8-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/distlib/#distlib-0.3.8.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="exceptiongroup@1.2.0">
+      <name>exceptiongroup</name>
+      <version>1.2.0</version>
+      <description>Backport of PEP 654 (exception groups)</description>
+      <purl>pkg:pypi/exceptiongroup@1.2.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/exceptiongroup/#exceptiongroup-1.2.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/exceptiongroup/#exceptiongroup-1.2.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="fastapi@0.1.17">
+      <name>fastapi</name>
+      <version>0.1.17</version>
+      <description>FastAPI framework, high performance, easy to learn, fast to code, ready for production</description>
+      <purl>pkg:pypi/fastapi@0.1.17</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fastapi/#fastapi-0.1.17-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a6aaad2f60684477480ac9d7a1c95e67f4696a722f184db467494bfdd5b8f29d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fastapi/#fastapi-0.1.17.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a9a9b6cc32c38bab27a6549b94c44a30c70b485bc789d03de3aa8725f3394be5</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="filelock@3.13.3">
+      <name>filelock</name>
+      <version>3.13.3</version>
+      <description>A platform independent file lock.</description>
+      <purl>pkg:pypi/filelock@3.13.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/filelock/#filelock-3.13.3-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5ffa845303983e7a0b7ae17636509bc97997d58afeafa72fb141a17b152284cb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/filelock/#filelock-3.13.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a79895a25bbefdf55d1a2a0a80968f7dbb28edcd6d4234a0afb3f37ecde4b546</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="frozenlist@1.4.1">
+      <name>frozenlist</name>
+      <version>1.4.1</version>
+      <description>A list-like structure which implements collections.abc.MutableSequence</description>
+      <purl>pkg:pypi/frozenlist@1.4.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f9aa1878d1083b276b0196f2dfbe00c9b7e752475ed3b682025ff20c1c1f51ac</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">29acab3f66f0f24674b7dc4736477bcd4bc3ad4b896f5f45379a67bce8b96868</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">74fb4bee6880b529a0c6560885fce4dc95936920f9f20f53d99a213f7bf66776</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">590344787a90ae57d62511dd7c736ed56b428f04cd8c161fcc5e7232c130c69a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">068b63f23b17df8569b7fdca5517edef76171cf3897eb68beb01341131fbd2ad</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5c849d495bf5154cd8da18a9eb15db127d4dba2968d88831aff6f0331ea9bd4c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9750cc7fe1ae3b1611bb8cfc3f9ec11d532244235d75901fb6b8e42ce9229dfe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a9b2de4cf0cdd5bd2dee4c4f63a653c61d2408055ab77b151c1957f221cabf2a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0633c8d5337cb5c77acbccc6357ac49a1770b8c487e5b3505c57b949b4b82e98</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">27657df69e8801be6c3638054e202a135c7f299267f1a55ed3a598934f6c0d75</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f9a3ea26252bd92f570600098783d1371354d89d5f6b7dfd87359d669f2109b5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f57dab5fe3407b6c0c1cc907ac98e8a189f9e418f3b6e54d65a718aaafe3950</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e02a0e11cf6597299b9f3bbd3f93d79217cb90cfd1411aec33848b13f5c656cc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a828c57f00f729620a442881cc60e57cfcec6842ba38e1b19fd3e47ac0ff8dc1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f56e2333dda1fe0f909e7cc59f021eba0d2307bc6f012a1ccf2beca6ba362439</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a0cb6f11204443f27a1628b0e460f37fb30f624be6051d490fa7d7e26d4af3d0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b46c8ae3a8f1f41a0d2ef350c0b6e65822d80772fe46b653ab6b6274f61d4a49</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fde5bd59ab5357e3853313127f4d3565fc7dad314a74d7b5d43c22c6a5ed2ced</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">722e1124aec435320ae01ee3ac7bec11a5d47f25d0ed6328f2273d287bc3abb0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2471c201b70d58a0f0c1f91261542a03d9a5e088ed3dc6c160d614c01649c106</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c757a9dd70d72b076d6f68efdbb9bc943665ae954dad2801b874c8c69e185068</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f146e0911cb2f1da549fc58fc7bcd2b836a44b79ef871980d605ec392ff6b0d2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f9c515e7914626b2a2e1e311794b4c35720a0be87af52b79ff8e1429fc25f19</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c302220494f5c1ebeb0912ea782bcd5e2f8308037b3c7553fad0e48ebad6ad82</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">442acde1e068288a4ba7acfe05f5f343e19fac87bfc96d89eb886b0363e977ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1b280e6507ea8a4fa0c0a7150b4e526a8d113989e28eaaef946cc77ffd7efc0a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fe1a06da377e3a1062ae5fe0926e12b84eceb8a50b350ddca72dc85015873f74</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">db9e724bebd621d9beca794f2a4ff1d26eed5965b004a97f1f1685a173b869c2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e774d53b1a477a67838a904131c4b0eef6b3d8a651f8b138b04f748fccfefe17</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fb3c2db03683b5767dedb5769b8a40ebb47d6f7f45b1b3e3b4b51ec8ad9d9825</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1979bc0aeb89b33b588c51c54ab0161791149f2461ea7c7c946d95d5f93b56ae</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cc7b01b3754ea68a62bd77ce6020afaffb44a590c2289089289363472d13aedb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c9c92be9fd329ac801cc420e08452b70e7aeab94ea4233a4804f0915c14eba9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5c3894db91f5a489fc8fa6a9991820f368f0b3cbdb9cd8849547ccfab3392d86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ba60bb19387e13597fb059f32cd4d59445d7b18b69a745b8f8e5db0346f33480</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8aefbba5f69d42246543407ed2461db31006b0f76c4e32dfd6f42215a2c41d09</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">780d3a35680ced9ce682fbcf4cb9c2bad3136eeff760ab33707b71db84664e3a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9acbb16f06fe7f52f441bb6f413ebae6c37baa6ef9edd49cdd567216da8600cd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">23b701e65c7b36e4bf15546a89279bd4d8675faabc287d06bbcfac7d3c33e1e6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3e0153a805a98f5ada7e09826255ba99fb4f7524bb81bf6b47fb702666484ae1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dd9b1baec094d91bf36ec729445f7769d0d0cf6b64d04d86e45baf89e2b9059b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1a4471094e146b6790f61b98616ab8e44f72661879cc63fa1049d13ef711e71e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5667ed53d68d91920defdf4035d1cdaa3c3121dc0b113255124bcfada1cfa1b8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">beee944ae828747fd7cb216a70f120767fc9f4f00bacae8543c14a6831673f89</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">64536573d0a2cb6e625cf309984e2d873979709f2cf22839bf2d61790b448ad5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">20b51fa3f588ff2fe658663db52a41a4f7aa6c04f6201449c6c7c476bd255c0d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">410478a0c562d1a5bcc2f7ea448359fcb050ed48b3c6f6f4f18c313a9bdb1826</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c6321c9efe29975232da3bd0af0ad216800a47e93d763ce64f291917a381b8eb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48f6a4533887e189dae092f1cf981f2e3885175f7a0f33c91fb5b7b682b6bab6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6eb73fa5426ea69ee0e012fb59cdc76a15b1283d6e32e4f8dc4482ec67d1194d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fbeb989b5cc29e8daf7f976b421c220f1b8c731cbf22b9130d8815418ea45887</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">32453c1de775c889eb4e22f1197fe3bdfe457d16476ea407472b9442e6295f7a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">693945278a31f2086d9bf3df0fe8254bbeaef1fe71e1351c3bd730aa7d31c41b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1d0ce09d36d53bbbe566fe296965b23b961764c0bcf3ce2fa45f463745c04701</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a670dc61eb0d0eb7080890c13de3066790f9049b47b0de04007090807c776b0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dca69045298ce5c11fd539682cff879cc1e664c245d1c64da929813e54241d11</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a06339f38e9ed3a64e4c4e43aec7f59084033647f908e4259d279a52d3757d09</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b7f2f9f912dca3934c1baec2e4585a674ef16fe00218d833856408c48d5beee7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e7004be74cbb7d9f34553a5ce5fb08be14fb33bc86f332fb71cbe5216362a497</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5a7d70357e7cee13f470c7883a063aae5fe209a493c57d86eb7f5a6f910fae09</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bfa4a17e17ce9abf47a74ae02f32d014c5e9404b6d9ac7f729e01562bbee601e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b7e3ed87d4138356775346e6845cccbe66cd9e207f3cd11d2f0b9fd13681359d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c99169d4ff810155ca50b4da3b075cbde79752443117d89429595c2e8e37fed8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">edb678da49d9f72c9f6c609fbe41a5dfb9a9282f9e6a2253d5a91e0fc382d7c0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6db4667b187a6742b33afbbaf05a7bc551ffcf1ced0000a571aedbb4aa42fc7b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">55fdc093b5a3cb41d420884cdaf37a1e74c3c37a31f46e66286d9145d2063bd0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">82e8211d69a4f4bc360ea22cd6555f8e61a1bd211d1d5d39d3d228b48c83a897</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">89aa2c2eeb20957be2d950b85974b30a01a762f3308cd02bb15e1ad632e22dc7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9d3e0c25a2350080e9319724dede4f31f43a6c9779be48021a7f4ebde8b2d742</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7268252af60904bf52c26173cbadc3a071cece75f873705419c8681f24d3edea</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0c250a29735d4f15321007fb02865f0e6b6a41a6b88f1f523ca1596ab5f50bd5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">96ec70beabbd3b10e8bfe52616a13561e58fe84c0101dd031dc78f250d5128b9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">23b2d7679b73fe0e5a4560b672a39f98dfc6f60df63823b0a9970525325b95f6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a7496bfe1da7fb1a4e1cc23bb67c58fab69311cc7d32b5a99c2007b4b2a0e932</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e6a20a581f9ce92d389a8c7d7c3dd47c81fd5d6e655c8dddf341e14aa48659d0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">04ced3e6a46b4cfffe20f9ae482818e34eba9b5fb0ce4056e4cc9b6e212d09b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c037a86e8513059a2613aaba4d817bb90b9d9b6b69aace3ce9c877e8c8ed402b</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="google-api-core@2.8.0">
+      <name>google-api-core</name>
+      <version>2.8.0</version>
+      <description>Google API client core library</description>
+      <purl>pkg:pypi/google-api-core@2.8.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/google-api-core/#google-api-core-2.8.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">065bb8e11c605fd232707ae50963dc1c8af5b3c95b4568887515985e6c1156b3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/google-api-core/#google_api_core-2.8.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1b9f59236ce1bae9a687c1d4f22957e79a2669e53d032893f6bf0fca54f6931d</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="google-auth@2.29.0">
+      <name>google-auth</name>
+      <version>2.29.0</version>
+      <description>Google Authentication Library</description>
+      <purl>pkg:pypi/google-auth@2.29.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/google-auth/#google-auth-2.29.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">672dff332d073227550ffc7457868ac4218d6c500b155fe6cc17d2b13602c360</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/google-auth/#google_auth-2.29.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d452ad095688cd52bae0ad6fafe027f6a6d6f560e810fec20914e17a09526415</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="googleapis-common-protos@1.56.1">
+      <name>googleapis-common-protos</name>
+      <version>1.56.1</version>
+      <description>Common protobufs used in Google APIs</description>
+      <purl>pkg:pypi/googleapis-common-protos@1.56.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/googleapis-common-protos/#googleapis-common-protos-1.56.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b5ee59dc646eb61a8eb65ee1db186d3df6687c8804830024f32573298bca19b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/googleapis-common-protos/#googleapis_common_protos-1.56.1-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ddcd955b5bb6589368f659fa475373faa1ed7d09cde5ba25e88513d87007e174</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="grpcio@1.62.1">
+      <name>grpcio</name>
+      <version>1.62.1</version>
+      <description>HTTP/2-based RPC framework</description>
+      <purl>pkg:pypi/grpcio@1.62.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-linux_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">179bee6f5ed7b5f618844f760b6acf7e910988de77a4f75b95bbfaa8106f3c1e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-macosx_12_0_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48611e4fa010e823ba2de8fd3f77c1322dd60cb0d180dc6630a7e157b205f7ea</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-manylinux_2_17_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2a0e71b0a2158aa4bce48be9f8f9eb45cbd17c78c7443616d00abbe2a509f6d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fbe80577c7880911d3ad65e5ecc997416c98f354efeba2f8d0f9112a67ed65a5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">58f6c693d446964e3292425e1d16e21a97a48ba9172f2d0df9d7b640acb99243</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">77c339403db5a20ef4fed02e4d1a9a3d9866bf9c0afc77a42234677313ea22f3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b5a4ea906db7dec694098435d84bf2854fe158eb3cd51e1107e571246d4d1d70</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4187201a53f8561c015bc745b81a1b2d278967b8de35f3399b84b0695e281d5f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">844d1f3fb11bd1ed362d3fdc495d0770cfab75761836193af166fee113421d66</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-linux_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">833379943d1728a005e44103f17ecd73d058d37d95783eb8f0b28ddc1f54d7b2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-macosx_10_10_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c7fcc6a32e7b7b58f5a7d27530669337a5d587d4066060bcb9dee7a8c833dfb7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-manylinux_2_17_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fa7d28eb4d50b7cbe75bb8b45ed0da9a1dc5b219a0af59449676a29c2eed9698</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48f7135c3de2f298b833be8b4ae20cafe37091634e91f61f5a7eb3d61ec6f660</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">71f11fd63365ade276c9d4a7b7df5c136f9030e3457107e1791b3737a9b9ed6a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4b49fd8fe9f9ac23b78437da94c54aa7e9996fbb220bac024a67469ce5d0825f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">482ae2ae78679ba9ed5752099b32e5fe580443b4f798e1b71df412abf43375db</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1faa02530b6c7426404372515fe5ddf66e199c2ee613f88f025c6f3bd816450c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5bd90b8c395f39bc82a5fb32a0173e220e3f401ff697840f4003e15b96d1befc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-linux_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b134d5d71b4e0837fff574c00e49176051a1c532d26c052a1e43231f252d813b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-macosx_10_10_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d1f6c96573dc09d50dbcbd91dbf71d5cf97640c9427c32584010fbbd4c0e0037</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-manylinux_2_17_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">359f821d4578f80f41909b9ee9b76fb249a21035a061a327f91c953493782c31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a485f0c2010c696be269184bdb5ae72781344cb4e60db976c59d84dd6354fac9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b50b09b4dc01767163d67e1532f948264167cd27f49e9377e3556c3cba1268e1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3227c667dccbe38f2c4d943238b887bac588d97c104815aecc62d2fd976e014b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3952b581eb121324853ce2b191dae08badb75cd493cb4e0243368aa9e61cfd41</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">83a17b303425104d6329c10eb34bba186ffa67161e63fa6cdae7776ff76df73f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6696ffe440333a19d8d128e88d440f91fb92c75a80ce4b44d55800e656a3ef1d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-linux_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e3393b0823f938253370ebef033c9fd23d27f3eae8eb9a8f6264900c7ea3fb5a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-macosx_10_10_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">83e7ccb85a74beaeae2634f10eb858a0ed1a63081172649ff4261f929bacfd22</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-manylinux_2_17_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">882020c87999d54667a284c7ddf065b359bd00251fcd70279ac486776dbf84ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a10383035e864f386fe096fed5c47d27a2bf7173c56a6e26cffaaa5a361addb1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">960edebedc6b9ada1ef58e1c71156f28689978188cd8cff3b646b57288a927d9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">23e2e04b83f347d0aadde0c9b616f4726c3d76db04b438fd3904b289a725267f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">978121758711916d34fe57c1f75b79cdfc73952f1481bb9583399331682d36f7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9084086190cc6d628f282e5615f987288b95457292e969b9205e45b442276407</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-linux_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">22bccdd7b23c420a27fd28540fb5dcbc97dc6be105f7698cb0e7d7a420d0e362</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-macosx_10_10_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8999bf1b57172dbc7c3e4bb3c732658e918f5c333b2942243f10d0d653953ba9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-manylinux_2_17_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d9e52558b8b8c2f4ac05ac86344a7417ccdd2b460a59616de49eb6933b07a0bd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1714e7bc935780bc3de1b3fcbc7674209adf5208ff825799d579ffd6cd0bd505</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c8842ccbd8c0e253c1f189088228f9b433f7a93b7196b9e5b6f87dba393f5d5d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f1e7b36bdff50103af95a80923bf1853f6823dd62f2d2a2524b66ed74103e49</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bba97b8e8883a8038606480d6b6772289f4c907f6ba780fa1f7b7da7dfd76f06</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a7f615270fe534548112a74e790cd9d4f5509d744dd718cd442bf016626c22e4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e6c8c8693df718c5ecbc7babb12c69a4e3677fd11de8886f05ab22d4e6b1c43b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-linux_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">73db2dc1b201d20ab7083e7041946910bb991e7e9761a0394bbc3c2632326483</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-macosx_10_10_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">407b26b7f7bbd4f4751dbc9767a1f0716f9fe72d3d7e96bb3ccfc4aace07c8de</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-manylinux_2_17_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f8de7c8cef9261a2d0a62edf2ccea3d741a523c6b8a6477a340a1f2e417658de</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9bd5c8a1af40ec305d001c60236308a67e25419003e9bb3ebfab5695a8d0b369</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">be0477cb31da67846a33b1a75c611f88bfbcd427fe17701b6317aefceee1b96f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">60dcd824df166ba266ee0cfaf35a31406cd16ef602b49f5d4dfb21f014b0dedd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">973c49086cabab773525f6077f95e5a993bfc03ba8fc32e32f2c279497780585</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">12859468e8918d3bd243d213cd6fd6ab07208195dc140763c00dfe901ce1e1b4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b7209117bbeebdfa5d898205cc55153a51285757902dd73c47de498ad4d11332</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6c455e008fa86d9e9a9d85bb76da4277c0d7d9668a3bfa70dbe86e9f3c759947</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="h11@0.14.0">
+      <name>h11</name>
+      <version>0.14.0</version>
+      <description>A pure-Python, bring-your-own-I/O implementation of HTTP/1.1</description>
+      <purl>pkg:pypi/h11@0.14.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/h11/#h11-0.14.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/h11/#h11-0.14.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="idna@3.6">
+      <name>idna</name>
+      <version>3.6</version>
+      <description>Internationalized Domain Names in Applications (IDNA)</description>
+      <purl>pkg:pypi/idna@3.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/#idna-3.6-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/#idna-3.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema@4.21.1">
+      <name>jsonschema</name>
+      <version>4.21.1</version>
+      <description>An implementation of JSON Schema validation for Python</description>
+      <purl>pkg:pypi/jsonschema@4.21.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema/#jsonschema-4.21.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7996507afae316306f9e2290407761157c6f78002dcf7419acb99822143d1c6f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema/#jsonschema-4.21.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">85727c00279f5fa6bedbe6238d2aa6403bedd8b4864ab11207d07df3cc1b2ee5</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema-specifications@2023.12.1">
+      <name>jsonschema-specifications</name>
+      <version>2023.12.1</version>
+      <description>The JSON Schema meta-schemas and vocabularies, exposed as a Registry</description>
+      <purl>pkg:pypi/jsonschema-specifications@2023.12.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.12.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">87e4fdf3a94858b8a2ba2778d9ba57d8a9cafca7c7489c46ba0d30a8bc6a9c3c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.12.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48a76787b3e70f5ed53f1160d2b81f586e4ca6d1548c5de7085d1682674764cc</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="msgpack@1.0.8">
+      <name>msgpack</name>
+      <version>1.0.8</version>
+      <description>MessagePack serializer</description>
+      <purl>pkg:pypi/msgpack@1.0.8</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">505fe3d03856ac7d215dbe005414bc28505d26f0c128906037e66d98c4e95868</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e6b7842518a63a9f17107eb176320960ec095a8ee3b4420b5f688e24bf50c53c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">376081f471a2ef24828b83a641a02c575d6103a3ad7fd7dade5486cad10ea659</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5e390971d082dba073c05dbd56322427d3280b7cc8b53484c9377adfbae67dc2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">00e073efcba9ea99db5acef3959efa45b52bc67b61b00823d2a1a6944bf45982</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">82d92c773fbc6942a7a8b520d22c11cfc8fd83bba86116bfcf962c2f5c2ecdaa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9ee32dcb8e531adae1f1ca568822e9b3a738369b3b686d1477cbc643c4a9c128</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e3aa7e51d738e0ec0afbed661261513b38b3014754c9459508399baf14ae0c9d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">69284049d07fce531c17404fcba2bb1df472bc2dcdac642ae71a2d079d950653</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">13577ec9e247f8741c84d06b9ece5f654920d8365a4b636ce0e44f15e07ec693</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e532dbd6ddfe13946de050d7474e3f5fb6ec774fbb1a188aaf469b08cf04189a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9517004e21664f2b5a5fd6333b0731b9cf0817403a941b393d89a2f1dc2bd836</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d16a786905034e7e34098634b184a7d81f91d4c3d246edc6bd7aefb2fd8ea6ad</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e2872993e209f7ed04d963e4b4fbae72d034844ec66bc4ca403329db2074377b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5c330eace3dd100bdb54b5653b966de7f51c26ec4a7d4e87132d9b4f738220ba</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">83b5c044f3eff2a6534768ccfd50425939e7a8b5cf9a7261c385de1e20dcfc85</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1876b0b653a808fcd50123b953af170c535027bf1d053b59790eebb0aeb38950</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dfe1f0f0ed5785c187144c46a292b8c34c1295c01da12e10ccddfc16def4448a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3528807cbbb7f315bb81959d5961855e7ba52aa60a3097151cb21956fbc7502b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e2f879ab92ce502a1e65fce390eab619774dda6a6ff719718069ac94084098ce</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">26ee97a8261e6e35885c2ecd2fd4a6d38252246f94a2aec23665a4e66d066305</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eadb9f826c138e6cf3c49d6f8de88225a3c0ab181a9b4ba792e006e5292d150e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">114be227f5213ef8b215c22dde19532f5da9652e56e8ce969bf0a26d7c419fee</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d661dc4785affa9d0edfdd1e59ec056a58b3dbb9f196fa43587f3ddac654ac7b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d56fd9f1f1cdc8227d7b7918f55091349741904d9520c65f0139a9755952c9e8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0726c282d188e204281ebd8de31724b7d749adebc086873a59efb8cf7ae27df3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8db8e423192303ed77cff4dce3a4b88dbfaf43979d280181558af5e2c3c71afc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">99881222f4a8c2f641f25703963a5cefb076adffd959e0558dc9f803a52d6a58</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b5505774ea2a73a86ea176e8a9a4a7c8bf5d521050f0f6f8426afe798689243f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ef254a06bcea461e65ff0373d8a0dd1ed3aa004af48839f002a0c994a6f72d04</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e1dd7839443592d00e96db831eddb4111a2a81a46b028f0facd60a09ebbdd543</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">64d0fcd436c5683fdd7c907eeae5e2cbb5eb872fafbc03a43609d7941840995c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">74398a4cf19de42e1498368c36eed45d9528f5fd0155241e82c4082b7e16cffd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0ceea77719d45c839fd73abcb190b8390412a890df2f83fb8cf49b2a4b5c2f40</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1ab0bbcd4d1f7b6991ee7c753655b481c50084294218de69365f8f1970d4c151</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1cce488457370ffd1f953846f82323cb6b2ad2190987cd4d70b2713e17268d24</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3923a1778f7e5ef31865893fdca12a8d7dc03a44b33e2a5f3295416314c09f5d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a22e47578b30a3e199ab067a4d43d790249b3c0587d9a771921f86250c8435db</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bd739c9251d01e0279ce729e37b39d49a08c0420d3fee7f2a4968c0576678f77</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d3420522057ebab1728b21ad473aa950026d07cb09da41103f8e597dfbfaeb13</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5845fdf5e5d5b78a49b826fcdc0eb2e2aa7191980e3d2cfd2a30303a74f212e2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6a0e76621f6e1f908ae52860bdcb58e1ca85231a9b0545e64509c931dd34275a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">374a8e88ddab84b9ada695d255679fb99c53513c0a51778796fcf0944d6c789c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f3709997b228685fe53e8c433e2df9f0cdb5f4542bd5114ed17ac3c0129b0480</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f51bab98d52739c50c56658cc303f190785f9a2cd97b823357e7aeae54c8f68a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">73ee792784d48aa338bba28063e19a27e8d989344f34aad14ea6e1b9bd83f596</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f9904e24646570539a8950400602d66d2b2c492b9010ea7e965025cb71d0c86d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e75753aeda0ddc4c28dce4c32ba2f6ec30b1b02f6c0b14e547841ba5b24f753f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5dbf059fb4b7c240c873c1245ee112505be27497e90f7c6591261c7d3c3a8228</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4916727e31c28be8beaf11cf117d6f6f188dcc36daae4e851fee88646f5b6b18</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7938111ed1358f536daf311be244f34df7bf3cdedb3ed883787aca97778b28d8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">493c5c5e44b06d6c9268ce21b302c9ca055c1fd3484c25ba41d34476c76ee746</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="multidict@6.0.5">
+      <name>multidict</name>
+      <version>6.0.5</version>
+      <description>multidict implementation</description>
+      <purl>pkg:pypi/multidict@6.0.5</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">228b644ae063c10e7f324ab1ab6b548bdf6f8b47f3ec234fef1093bc2735e5f9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">896ebdcf62683551312c30e20614305f53125750803b614e9e6ce74a96232604</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">411bf8515f3be9813d06004cac41ccf7d1cd46dfe233705933dd163b60e37600</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1d147090048129ce3c453f0292e7697d333db95e52616b3793922945804a433c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">215ed703caf15f578dca76ee6f6b21b7603791ae090fbf1ef9d865571039ade5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7c6390cf87ff6234643428991b7359b5f59cc15155695deb4eda5c777d2b880f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">21fd81c4ebdb4f214161be351eb5bcf385426bf023041da2fd9e60681f3cebae</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3cc2ad10255f903656017363cd59436f2111443a76f996584d1077e43ee51182</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6939c95381e003f54cd4c5516740faba40cf5ad3eeff460c3ad1d3e0ea2549bf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">220dd781e3f7af2c2c1053da9fa96d9cf3072ca58f057f4c5adaaa1cab8fc442</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">766c8f7511df26d9f11cd3a8be623e59cca73d44643abab3f8c8c07620524e4a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fe5d7785250541f7f5019ab9cba2c71169dc7d74d0f45253f8313f436458a4ef</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c1c1496e73051918fcd4f58ff2e0f2f3066d1c76a0c6aeffd9b45d53243702cc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7afcdd1fc07befad18ec4523a782cde4e93e0a2bf71239894b8d61ee578c1319</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">99f60d34c048c5c2fabc766108c103612344c46e35d4ed9ae0673d33c8fb26e8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f285e862d2f153a70586579c15c44656f888806ed0e5b56b64489afe4a2dbfba</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">53689bb4e102200a4fafa9de9c7c3c212ab40a7ab2c8e474491914d2305f187e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">612d1156111ae11d14afaf3a0669ebf6c170dbb735e510a7438ffe2369a847fd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7be7047bd08accdb7487737631d25735c9a04327911de89ff1b26b81745bd4e3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">de170c7b4fe6859beb8926e84f7d7d6c693dfe8e27372ce3b76f01c46e489fcf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">04bde7a7b3de05732a4eb39c94574db1ec99abb56162d6c520ad26f83267de29</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">85f67aed7bb647f93e7520633d8f51d3cbc6ab96957c71272b286b2f30dc70ed</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">425bf820055005bfc8aa9a0b99ccb52cc2f4070153e34b701acc98d201693733</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d3eb1ceec286eba8220c26f3b0096cf189aea7057b6e7b7a2e60ed36b373b77f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7901c05ead4b3fb75113fb1dd33eb1253c6d3ee37ce93305acd9d38e0b5f21a4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e0e79d91e71b9867c73323a3444724d496c037e578a0e1755ae159ba14f4f3d1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">29bfeb0dff5cb5fdab2023a7a9947b3b4af63e9c47cae2a10ad58394b517fddc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e030047e85cbcedbfc073f71836d62dd5dadfbe7531cae27789ff66bc551bd5e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2f4848aa3baa109e6ab81fe2006c77ed4d3cd1e0ac2c1fbddb7b1277c168788c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2faa5ae9376faba05f630d7e5e6be05be22913782b927b19d12b8145968a85ea</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">51d035609b86722963404f711db441cf7134f1889107fb171a970c9701f92e1e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cbebcd5bcaf1eaf302617c114aa67569dd3f090dd0ce8ba9e35e9985b41ac35b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2ffc42c922dbfddb4a4c3b438eb056828719f07608af27d163191cb3e3aa6cc5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ceb3b7e6a0135e092de86110c5a74e46bda4bd4fbfeeb3a3bcec79c0f861e450</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">79660376075cfd4b2c80f295528aa6beb2058fd289f4c9252f986751a4cd0496</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e4428b29611e989719874670fd152b6625500ad6c686d464e99f5aaeeaca175a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d84a5c3a5f7ce6db1f999fb9438f686bc2e09d38143f2d93d8406ed2dd6b9226</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">76c0de87358b192de7ea9649beb392f107dcad9ad27276324c24c91774ca5271</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">79a6d2ba910adb2cbafc95dad936f8b9386e77c84c35bc0add315b856d7c3abb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">92d16a3e275e38293623ebf639c471d3e03bb20b8ebb845237e0d3664914caef</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fb616be3538599e797a2017cccca78e354c767165e8858ab5116813146041a24</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">14c2976aa9038c2629efa2c148022ed5eb4cb939e15ec7aace7ca932f48f9ba6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">435a0984199d81ca178b9ae2c26ec3d49692d20ee29bc4c11a2a8d4514c67eda</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9fe7b0653ba3d9d65cbe7698cca585bf0f8c83dbbcc710db9c90f478e175f2d5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">01265f5e40f5a17f8241d52656ed27192be03bfa8764d88e8220141d1e4b3556</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">19fe01cea168585ba0f678cad6f58133db2aa14eccaf22f88e4a6dccadfad8b3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6bf7a982604375a8d49b6cc1b781c1747f243d91b81035a9b43a2126c04766f5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">107c0cdefe028703fb5dafe640a409cb146d44a6ae201e55b35a4af8e95457dd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">403c0911cd5d5791605808b942c88a8155c2592e05332d2bf78f18697a5fa15e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aeaf541ddbad8311a87dd695ed9642401131ea39ad7bc8cf3ef3967fd093b626</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e4972624066095e52b569e02b5ca97dbd7a7ddd4294bf4e7247d52635630dd83</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d946b0a9eb8aaa590df1fe082cee553ceab173e6cb5b03239716338629c50c7a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b55358304d7a73d7bdf5de62494aaf70bd33015831ffd98bc498b433dfe5b10c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a3145cb08d8625b2d3fee1b2d596a8766352979c9bffe5d7833e0503d0f0b5e5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d65f25da8e248202bd47445cec78e0025c0fe7582b23ec69c3b27a640dd7a8e3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c9bf56195c6bbd293340ea82eafd0071cb3d450c703d2c93afb89f93b8386ccc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">69db76c09796b313331bb7048229e3bee7928eb62bab5e071e9f7fcc4879caee</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fce28b3c8a81b6b36dfac9feb1de115bab619b3c13905b419ec71d03a3fc1423</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">76f067f5121dcecf0d63a67f29080b26c43c71a98b10c701b0677e4a065fbd54</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b82cc8ace10ab5bd93235dfaab2021c70637005e1ac787031f4d1da63d493c1d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5cb241881eefd96b46f89b1a056187ea8e9ba14ab88ba632e68d7a2ecb7aadf7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e8e94e6912639a02ce173341ff62cc1201232ab86b8a8fcc05572741a5dc7d93</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">09a892e4a9fb47331da06948690ae38eaa2426de97b4ccbfafbdcbe5c8f37ff8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">55205d03e8a598cfc688c71ca8ea5f66447164efff8869517f175ea632c7cb7b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">37b15024f864916b4951adb95d3a80c9431299080341ab9544ed148091b53f50</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f2a1dee728b52b33eebff5072817176c172050d44d67befd681609b4746e1c2e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">edd08e6f2f1a390bf137080507e44ccc086353c8e98c657e666c017718561b89</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">60d698e8179a42ec85172d12f50b1668254628425a6bd611aba022257cac1386</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3d25f19500588cbc47dc19081d78131c32637c25804df8414463ec908631e453</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4cc0ef8b962ac7a5e62b9e826bd0cd5040e7d401bc45a6835910ed699037a461</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eca2e9d0cc5a889850e9bbd68e98314ada174ff6ccd1129500103df7a94a7a44</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4a6a4f196f08c58c59e0b8ef8ec441d12aee4125a7d4f4fef000ccb22f8d7241</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0275e35209c27a3f7951e1ce7aaf93ce0d163b28948444bec61dd7badc6d3f8c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e7be68734bd8c9a513f2b0cfd508802d6609da068f40dc57d4e3494cefc92929</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1d9ea7a7e779d7a3561aade7d596649fbecfa5c08a7674b11b423783217933f9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ea1456df2a27c73ce51120fa2f519f1bea2f4a03a917f4a43c8707cf4cbbae1a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cf590b134eb70629e350691ecca88eac3e3b8b3c86992042fb82e3cb1830d5e1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5c0631926c4f58e9a5ccce555ad7747d9a9f8b10619621f22f9635f069f6233e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dce1c6912ab9ff5f179eaf6efe7365c1f425ed690b03341911bf4939ef2f3046</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c0868d64af83169e4d4152ec612637a543f7a336e4a307b119e98042e852ad9c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">141b43360bfd3bdd75f15ed811850763555a251e38b2405967f8e25fb43f7d40</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7df704ca8cf4a073334e0427ae2345323613e4df18cc224f647f251e5e75a527</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6214c5a5571802c33f80e6c84713b2c79e024995b9c5897f794b43e714daeec9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd6c8fca38178e12c00418de737aef1261576bd1b6e8c6134d3e729a4e858b38</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e02021f87a5b6932fa6ce916ca004c4d441509d33bbdbeca70d05dff5e9d2479</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ebd8d160f91a764652d3e51ce0d2956b38efe37c9231cd82cfc0bed2e40b581c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">04da1bb8c8dbadf2a18a452639771951c662c5ad03aefe4884775454be322c9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d6f6d4f185481c9669b9447bf9d9cf3b95a0e9df9d169bbc17e363b7d5487755</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0d63c74e3d7ab26de115c49bffc92cc77ed23395303d496eae515d4204a625e7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f7e301075edaf50500f0b341543c41194d8df3ae5caf4702f2095f3ca73dd8da</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="opencensus@0.11.4">
+      <name>opencensus</name>
+      <version>0.11.4</version>
+      <description>A stats collection and distributed tracing framework</description>
+      <purl>pkg:pypi/opencensus@0.11.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/opencensus/#opencensus-0.11.4-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a18487ce68bc19900336e0ff4655c5a116daf10c1b3685ece8d971bddad6a864</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/opencensus/#opencensus-0.11.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="opencensus-context@0.1.3">
+      <name>opencensus-context</name>
+      <version>0.1.3</version>
+      <description>OpenCensus Runtime Context</description>
+      <purl>pkg:pypi/opencensus-context@0.1.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/opencensus-context/#opencensus-context-0.1.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a03108c3c10d8c80bb5ddf5c8a1f033161fa61972a9917f9b9b3a18517f0088c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/opencensus-context/#opencensus_context-0.1.3-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">073bb0590007af276853009fac7e4bab1d523c3f03baf4cb4511ca38967c6039</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="packaging@24.0">
+      <name>packaging</name>
+      <version>24.0</version>
+      <description>Core utilities for Python packages</description>
+      <purl>pkg:pypi/packaging@24.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/packaging/#packaging-24.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/packaging/#packaging-24.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="platformdirs@4.2.0">
+      <name>platformdirs</name>
+      <version>4.2.0</version>
+      <description>A small Python package for determining appropriate platform-specific dirs, e.g. a &quot;user data dir&quot;.</description>
+      <purl>pkg:pypi/platformdirs@4.2.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/platformdirs/#platformdirs-4.2.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/platformdirs/#platformdirs-4.2.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="prometheus-client@0.20.0">
+      <name>prometheus-client</name>
+      <version>0.20.0</version>
+      <description>Python client for the Prometheus monitoring system.</description>
+      <purl>pkg:pypi/prometheus-client@0.20.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/prometheus-client/#prometheus_client-0.20.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cde524a85bce83ca359cc837f28b8c0db5cac7aa653a588fd7e84ba061c329e7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/prometheus-client/#prometheus_client-0.20.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">287629d00b147a32dcb2be0b9df905da599b2d82f80377083ec8463309a4bb89</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="protobuf@5.26.1">
+      <name>protobuf</name>
+      <version>5.26.1</version>
+      <description/>
+      <purl>pkg:pypi/protobuf@5.26.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp310-abi3-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3c388ea6ddfe735f8cf69e3f7dc7611e73107b60bdfcf5d0f024c3ccd3794e23</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp310-abi3-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e6039957449cb918f331d32ffafa8eb9255769c96aa0560d9a5bf0b4e00a2a33</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp37-abi3-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">38aa5f535721d5bb99861166c445c4105c4e285c765fbb2ac10f116e32dcd46d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp37-abi3-manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fbfe61e7ee8c1860855696e3ac6cfd1b01af5498facc6834fcc345c9684fb2ca</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp37-abi3-manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f7417703f841167e5a27d48be13389d52ad705ec09eade63dfc3180a959215d7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d693d2504ca96750d92d9de8a103102dd648fda04540495535f0fec7577ed8fc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9b557c317ebe6836835ec4ef74ec3e994ad0894ea424314ad3552bc6e8835b4e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b9ba3ca83c2e31219ffbeb9d76b63aad35a3eb1544170c55336993d7a18ae72c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7ee014c2c87582e101d6b54260af03b6596728505c79f17c8586e7523aaa8f8c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">da612f2720c0183417194eeaa2523215c4fcc1a1949772dc65f05047e08d5932</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8ca2a1d97c290ec7b16e4e5dff2e5ae150cc1582f55b5ab300d45cb0dfa90e51</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="py-spy@0.3.14">
+      <name>py-spy</name>
+      <version>0.3.14</version>
+      <description>Sampling profiler for Python programs</description>
+      <purl>pkg:pypi/py-spy@0.3.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5b342cc5feb8d160d57a7ff308de153f6be68dcf506ad02b4d67065f2bae7f45</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fe7efe6c91f723442259d428bf1f9ddb9c1679828866b353d539345ca40d9dd2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">590905447241d789d9de36cff9f52067b6f18d8b5e9fb399242041568d414461</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fd6211fe7f587b3532ba9d300784326d9a6f2b890af7bf6fff21a029ebbc812b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3e8e48032e71c94c3dd51694c39e762e4bbfec250df5bf514adcdd64e79371e0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f59b0b52e56ba9566305236375e6fc68888261d0d36b5addbe3cf85affbefc0e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8f5b311d09f3a8e33dbd0d44fc6e37b715e8e0c7efefafcda8bfd63b31ab5a31</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pyasn1@0.6.0">
+      <name>pyasn1</name>
+      <version>0.6.0</version>
+      <description>Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)</description>
+      <purl>pkg:pypi/pyasn1@0.6.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyasn1/#pyasn1-0.6.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cca4bb0f2df5504f02f6f8a775b6e416ff9b0b3b16f7ee80b5a3153d9b804473</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyasn1/#pyasn1-0.6.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a35ab2c4b5ef98e17dfdec8ab074046fbda76e281c5a706ccd82328cfc8f64c</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pyasn1-modules@0.4.0">
+      <name>pyasn1-modules</name>
+      <version>0.4.0</version>
+      <description>A collection of ASN.1-based protocols modules</description>
+      <purl>pkg:pypi/pyasn1-modules@0.4.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyasn1-modules/#pyasn1_modules-0.4.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">be04f15b66c206eed667e0bb5ab27e2b1855ea54a842e5037738099e8ca4ae0b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyasn1-modules/#pyasn1_modules-0.4.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">831dbcea1b177b28c9baddf4c6d1013c24c3accd14a1873fffaa6a2e905f17b6</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pydantic@2.6.4">
+      <name>pydantic</name>
+      <version>2.6.4</version>
+      <description>Data validation using Python type hints</description>
+      <purl>pkg:pypi/pydantic@2.6.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic/#pydantic-2.6.4-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cc46fce86607580867bdc3361ad462bab9c222ef042d3da86f2fb333e1d916c5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic/#pydantic-2.6.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b1704e0847db01817624a6b86766967f552dd9dbf3afba4004409f908dcc84e6</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pydantic-core@2.16.3">
+      <name>pydantic-core</name>
+      <version>2.16.3</version>
+      <description/>
+      <purl>pkg:pypi/pydantic-core@2.16.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">75b81e678d1c1ede0785c7f46690621e4c6e63ccd9192af1f0bd9d504bbb6bf4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9c865a7ee6f93783bd5d781af5a4c43dadc37053a5b42f7d18dc019f8c9d2bd1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">162e498303d2b1c036b957a1278fa0899d02b2842f1ff901b6395104c5554a45</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2f583bd01bbfbff4eaee0868e6fc607efdfcc2b03c1c766b06a707abbc856187</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b926dd38db1519ed3043a4de50214e0d600d404099c3392f098a7f9d75029ff8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">716b542728d4c742353448765aa7cdaa519a7b82f9564130e2b3f6766018c9ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fc4ad7f7ee1a13d9cb49d8198cd7d7e3aa93e425f371a68235f784e99741561f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bd87f48924f360e5d1c5f770d6155ce0e7d83f7b4e10c2f9ec001c73cf475c99</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0df446663464884297c793874573549229f9eca73b59360878f382a0fc085979</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4df8a199d9f6afc5ae9a65f8f95ee52cae389a8c6b20163762bde0426275b7db</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">456855f57b413f077dff513a5a28ed838dbbb15082ba00f80750377eed23d132</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">732da3243e1b8d3eab8c6ae23ae6a58548849d2e4a4e03a1924c8ddf71a387cb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">519ae0312616026bf4cedc0fe459e982734f3ca82ee8c7246c19b650b60a5ee4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3992a322a5617ded0a9f23fd06dbc1e4bd7cf39bc4ccf344b10f80af58beacd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8d62da299c6ecb04df729e4b5c52dc0d53f4f8430b4492b93aa8de1f541c4aac</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2acca2be4bb2f2147ada8cac612f8a98fc09f41c89f87add7256ad27332c2fda</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1b662180108c55dfbf1280d865b2d116633d436cfc0bba82323554873967b340</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e7c6ed0dc9d8e65f24f5824291550139fe6f37fac03788d4580da0d33bc00c97</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a6b1bb0827f56654b4437955555dc3aeeebeddc47c2d7ed575477f082622c49e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e56f8186d6210ac7ece503193ec84104da7ceb98f68ce18c07282fcc2452e76f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">936e5db01dd49476fa8f4383c259b8b1303d5dd5fb34c97de194560698cc2c5e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">33809aebac276089b78db106ee692bdc9044710e26f24a9a2eaa35a0f9fa70ba</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ded1c35f15c9dea16ead9bffcde9bb5c7c031bff076355dc58dcb1cb436c4721</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d89ca19cdd0dd5f31606a9329e309d4fcbb3df860960acec32630297d61820df</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-none-win_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6162f8d2dc27ba21027f261e4fa26f8bcb3cf9784b7f9499466a311ac284b5b9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0f56ae86b60ea987ae8bcd6654a887238fd53d1384f9b222ac457070b7ac4cff</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c9bd22a2a639e26171068f8ebb5400ce2c1bc7d17959f60a3b753ae13c632975</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4204e773b4b408062960e65468d5346bdfe139247ee5f1ca2a378983e11388a2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f651dd19363c632f4abe3480a7c87a9773be27cfe1341aef06e8759599454120</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aaf09e615a0bf98d406657e0008e4a8701b11481840be7d31755dc9f97c44053</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8e47755d8152c1ab5b55928ab422a76e2e7b22b5ed8e90a7d584268dd49e9c6b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">500960cb3a0543a724a81ba859da816e8cf01b0e6aaeedf2c3775d12ee49cade</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cf6204fe865da605285c34cf1172879d0314ff267b1c35ff59de7154f35fdc2e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d33dd21f572545649f90c38c227cc8631268ba25c460b5569abebdd0ec5974ca</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">49d5d58abd4b83fb8ce763be7794d09b2f50f10aa65c0f0c1696c677edeb7cbf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f53aace168a2a10582e570b7736cc5bef12cae9cf21775e3eafac597e8551fbe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0d32576b1de5a30d9a97f300cc6a3f4694c428d956adbc7e6e2f9cad279e45ed</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-none-win_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ec08be75bb268473677edb83ba71e7e74b43c008e4a7b1907c6d57e940bf34b6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b1f6f5938d63c6139860f044e2538baeee6f0b251a1816e7adb6cbce106a1f01</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2a1ef6a36fdbf71538142ed604ad19b82f67b05749512e47f247a6ddd06afdc7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">704d35ecc7e9c31d48926150afada60401c55efa3b46cd1ded5a01bdffaf1d48</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d937653a696465677ed583124b94a4b2d79f5e30b2c46115a68e482c6a591c8a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c9803edf8e29bd825f43481f19c37f50d2b01899448273b3a7758441b512acf8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">72282ad4892a9fb2da25defeac8c2e84352c108705c972db82ab121d15f14e6d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7f752826b5b8361193df55afcdf8ca6a57d0232653494ba473630a83ba50d8c9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4384a8f68ddb31a0b0c3deae88765f5868a1b9148939c3f4121233314ad5532c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a4b2bf78342c40b3dc830880106f54328928ff03e357935ad26c7128bbd66ce8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">13dcc4802961b5f843a9385fc821a0b0135e8c07fc3d9949fd49627c1a5e6ae5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e3e70c94a0c3841e6aa831edab1619ad5c511199be94d0c11ba75fe06efe107a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ecdf6bf5f578615f2e985a5e1f6572e23aa632c4bd1dc67f8f406d445ac115ed</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bda1ee3e08252b8d41fa5537413ffdddd58fa73107171a126d3b9ff001b9b820</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">21b888c973e4f26b7a96491c0965a8a312e13be108022ee510248fe379a5fa23</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">be0ec334369316fa73448cc8c982c01e5d2a81c95969d58b8f6e272884df0074</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b5b6079cc452a7c53dd378c6f881ac528246b3ac9aae0f8eef98498a75657805</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7ee8d5f878dccb6d499ba4d30d757111847b6849ae07acdd1205fffa1fc1253c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7233d65d9d651242a68801159763d09e9ec96e8a158dbf118dc090cd77a104c9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c6119dc90483a5cb50a1306adb8d52c66e447da88ea44f323e0ae1a5fcb14256</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">578114bc803a4c1ff9946d977c221e4376620a46cf78da267d946397dc9514a8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d8f99b147ff3fcf6b3cc60cb0c39ea443884d5559a30b1481e92495f2310ff2b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4ac6b4ce1e7283d715c4b729d8f9dab9627586dafce81d9eaa009dd7f25dd972</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e7774b570e61cb998490c5235740d475413a1f6de823169b4cf94e2fe9e9f6b2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9091632a25b8b87b9a605ec0e61f241c456e9248bfdcf7abdf344fdb169c81cf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">36fa178aacbc277bc6b62a2c3da95226520da4f4e9e206fdf076484363895d2c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dcca5d2bf65c6fb591fff92da03f94cd4f315972f97c21975398bd4bd046854a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2a72fb9963cba4cd5793854fd12f4cfee731e86df140f59ff52a49b3552db241</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b60cc1a081f80a2105a59385b92d82278b15d80ebb3adb200542ae165cd7d183</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cbcc558401de90a746d02ef330c528f2e668c83350f045833543cd57ecead1ad</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fee427241c2d9fb7192b658190f9f5fd6dfe41e02f3c1489d2ec1e6a5ab1e04a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f4cb85f693044e0f71f394ff76c98ddc1bc0953e48c061725e540396d5c8a2e1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b29eeb887aa931c2fcef5aa515d9d176d25006794610c264ddc114c053bf96fe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a425479ee40ff021f8216c9d07a6a3b54b31c8267c6e17aa88b70d7ebd0e5e5b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5c5cbc703168d1b7a838668998308018a2718c2130595e8e190220238addc96f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">99b6add4c0b39a513d323d3b93bc173dac663c27b99860dd5bf491b240d26137</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">75f76ee558751746d6a38f89d60b6228fa174e5172d143886af0f85aa306fd89</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">00ee1c97b5364b84cb0bd82e9bbf645d5e2871fb8c58059d158412fee2d33d8a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">287073c66748f624be4cef893ef9174e3eb88fe0b8a78dc22e88eca4bc357ca6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ed25e1835c00a332cb10c683cd39da96a719ab1dfc08427d476bce41b92531fc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">86b3d0033580bd6bbe07590152007275bd7af95f98eaa5bd36f3da219dcd93da</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1cac689f80a3abab2d3c0048b29eea5751114054f032a941a32de4c852c59cad</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pyyaml@6.0.1">
+      <name>pyyaml</name>
+      <version>6.0.1</version>
+      <description>YAML parser and emitter for Python</description>
+      <purl>pkg:pypi/pyyaml@6.0.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="ray@2.10.0">
+      <name>ray</name>
+      <version>2.10.0</version>
+      <description>Ray provides a simple, universal API for building distributed applications.</description>
+      <purl>pkg:pypi/ray@2.10.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-macosx_10_15_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8a174268c7b6ca9826e4884b837395b695a45c17049927965d1b4cc370184ba2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c193deed7e3f604cdb37047f5646cab14f4337693dd32add8bc902dfadb89f75</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a3db89d22afc7a0a976249715dd90ffe69f7692d32cb599cd1afbc38482060f7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cb74f7d2aa5a21e5f9dcb315a4f9bde822328e76ba95cd0ba370cfda098a67f4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">44ab600fe0b5a12675d0d42d564994ac4e53286217c4de1c4eb00d74ae79ef24</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-macosx_10_15_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8eb606b7d247213b377ccca0f8d425f9c61a48b23e9b2e4566bc75f66d797bb5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8eb11aec8a65946f7546d0e703158c03a85a8be27332dbbf86d9411802700e7e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5b4ec4b5707e18382685d0703ed04afd1602359a3056f6ae4b37588a0551eef3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c7d1438cba8726ec9a59c96964e007b60a0728436647f48c383228692c2f2ee0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eceecea4133e63f5d607cc9f2a4278de51eeeeef552f694895e381aae9ff8522</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-macosx_10_15_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fb92f2d6d4eca602dfb0d3d459a09be59668e1560ce4bd89b692892f25b1933b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">31aa60373fc7291752ee89a5f5ad8effec682b1f165911f38ae95fc43bc668a9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5b7d41eb04f6b67c38170edc0406dc71537eabfd6e5d4e3399a36385ff8b0194</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8a44535e6266fa09e3eb4fc9035906decfc9f3aeda86fe66b1e738a01a51939a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">77ba4120d694e7c3dc7d93a9d3cb33925827d04ad11af2d21fa0db66f227d27a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-macosx_10_15_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b49a8c2b40f02a56a2af2b6026c1eedd485747c6e4c2cf9ac433af6e572bdbb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5fe8fb8847304dd3a6e435b95af9e5436309f2b3612c63c56bf4ac8dea73f9f4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f215eb704f2cb72e984d5a85fe435b4d74808c906950176789ba2101ce739082</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">32d97e5343578a3d37ab5f30148fa193dec46a21fa21f15b6f23fe48a420831a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">917d081fc98500f244ebc0e8da836025e1e4fa52f21030b8336cb0a2c79e84e2</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:required-extra">serve</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="referencing@0.34.0">
+      <name>referencing</name>
+      <version>0.34.0</version>
+      <description>JSON Referencing + Python</description>
+      <purl>pkg:pypi/referencing@0.34.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/#referencing-0.34.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d53ae300ceddd3169f1ffa9caf2cb7b769e92657e4fafb23d34b93679116dfd4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/#referencing-0.34.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5773bd84ef41799a5a8ca72dc34590c041eb01bf9aa02632b4a973fb0181a844</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="requests@2.31.0">
+      <name>requests</name>
+      <version>2.31.0</version>
+      <description>Python HTTP for Humans.</description>
+      <purl>pkg:pypi/requests@2.31.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/requests/#requests-2.31.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/requests/#requests-2.31.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rpds-py@0.18.0">
+      <name>rpds-py</name>
+      <version>0.18.0</version>
+      <description>Python bindings to Rust's persistent data structures (rpds)</description>
+      <purl>pkg:pypi/rpds-py@0.18.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5b4e7d8d6c9b2e8ee2d55c90b59c707ca59bc30058269b3db7b1f8df5763557e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c463ed05f9dfb9baebef68048aed8dcdc94411e4bf3d33a39ba97e271624f8f7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">01e36a39af54a30f28b73096dd39b6802eddd04c90dbe161c1b8dbe22353189f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d62dec4976954a23d7f91f2f4530852b0c7608116c257833922a896101336c51</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dd18772815d5f008fa03d2b9a681ae38d5ae9f0e599f7dda233c439fcaa00d40</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">923d39efa3cfb7279a0327e337a7958bff00cc447fd07a25cddb0a1cc9a6d2da</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">39514da80f971362f9267c600b6d459bfbbc549cffc2cef8e47474fddc9b45b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a34d557a42aa28bd5c48a023c570219ba2593bcbbb8dc1b98d8cf5d529ab1434</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">93df1de2f7f7239dc9cc5a4a12408ee1598725036bd2dedadc14d94525192fc3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">34b18ba135c687f4dac449aa5157d36e2cbb7c03cbea4ddbd88604e076aa836e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c0b5dcf9193625afd8ecc92312d6ed78781c46ecbf39af9ad4681fc9f464af88</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c4325ff0442a12113a6379af66978c3fe562f846763287ef66bdc1d57925d337</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7223a2a5fe0d217e60a60cdae28d6949140dde9c3bcc714063c5b463065e3d66</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a96e0c6a41dcdba3a0a581bbf6c44bb863f27c541547fb4b9711fd8cf0ffad4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">30f43887bbae0d49113cbaab729a112251a940e9b274536613097ab8b4899cf6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fcb25daa9219b4cf3a0ab24b0eb9a5cc8949ed4dc72acb8fa16b7e1681aa3c58</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d68c93e381010662ab873fea609bf6c0f428b6d0bb00f2c6939782e0818d37bf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b34b7aa8b261c1dbf7720b5d6f01f38243e9b9daf7e6b8bc1fd4657000062f2c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2e6d75ab12b0bbab7215e5d40f1e5b738aa539598db27ef83b2ec46747df90e1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0b8612cd233543a3781bc659c731b9d607de65890085098986dfd573fc2befe5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aec493917dd45e3c69d00a8874e7cbed844efd935595ef78a0f25f14312e33c6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">661d25cbffaf8cc42e971dd570d87cb29a665f49f4abe1f9e76be9a5182c4688</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1df3659d26f539ac74fb3b0c481cdf9d725386e3552c6fa2974f4d33d78e544b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a1ce3ba137ed54f83e56fb983a5859a27d43a40188ba798993812fed73c70836</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">69e64831e22a6b377772e7fb337533c365085b31619005802a79242fee620bc1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">998e33ad22dc7ec7e030b3df701c43630b5bc0d8fbc2267653577e3fec279afa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7f2facbd386dd60cbbf1a794181e6aa0bd429bd78bfdf775436020172e2a23f0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1d9a5be316c15ffb2b3c405c4ff14448c36b4435be062a7f578ccd8b01f0c4d8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd5bf1af8efe569654bbef5a3e0a56eca45f87cfcffab31dd8dde70da5982475</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5417558f6887e9b6b65b4527232553c139b57ec42c64570569b155262ac0754f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">56a737287efecafc16f6d067c2ea0117abadcd078d58721f967952db329a3e5c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8f03bccbd8586e9dd37219bce4d4e0d3ab492e6b3b533e973fa08a112cb2ffc9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4457a94da0d5c53dc4b3e4de1158bdab077db23c53232f37a3cb7afdb053a4e3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0ab39c1ba9023914297dd88ec3b3b3c3f33671baeb6acf82ad7ce883f6e8e157</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9d54553c1136b50fd12cc17e5b11ad07374c316df307e4cfd6441bea5fb68496</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0af039631b6de0397ab2ba16eaf2872e9f8fca391b44d3d8cac317860a700a3f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">84ffab12db93b5f6bad84c712c92060a2d321b35c3c9960b43d08d0f639d60d7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">685537e07897f173abcf67258bee3c05c374fa6fff89d4c7e42fb391b0605e98</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e003b002ec72c8d5a3e3da2989c7d6065b47d9eaa70cd8808b5384fbb970f4ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08f9ad53c3f31dfb4baa00da22f1e862900f45908383c062c27628754af2e88e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c0013fe6b46aa496a6749c77e00a3eb07952832ad6166bd481c74bda0dcb6d58</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e32a92116d4f2a80b629778280103d2a510a5b3f6314ceccd6e38006b5e92dcb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e541ec6f2ec456934fd279a3120f856cd0aedd209fc3852eca563f81738f6861</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bed88b9a458e354014d662d47e7a5baafd7ff81c780fd91584a10d6ec842cb73</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2644e47de560eb7bd55c20fc59f6daa04682655c58d08185a9b95c1970fa1e07</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8e8916ae4c720529e18afa0b879473049e95949bf97042e938530e072fde061d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">465a3eb5659338cf2a9243e50ad9b2296fa15061736d6e26240e713522b6235c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ea7d4a99f3b38c37eac212dbd6ec42b7a5ec51e2c74b5d3223e43c811609e65f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">67071a6171e92b6da534b8ae326505f7c18022c6f19072a81dcf40db2638767c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">41ef53e7c58aa4ef281da975f62c258950f54b76ec8e45941e93a3d1d8580594</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fdea4952db2793c4ad0bdccd27c1d8fdd1423a92f04598bc39425bcc2b8ee46e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7cd863afe7336c62ec78d7d1349a2f34c007a3cc6c2369d667c65aeec412a5b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5307def11a35f5ae4581a0b658b0af8178c65c530e94893345bebf41cc139d33</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">77f195baa60a54ef9d2de16fbbfd3ff8b04edc0c0140a761b56c267ac11aa467</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">39f5441553f1c2aed4de4377178ad8ff8f9d733723d6c66d983d75341de265ab</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9a00312dea9310d4cb7dbd7787e722d2e86a95c2db92fbd7d0155f97127bcb40</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8f2fc11e8fe034ee3c34d316d0ad8808f45bc3b9ce5857ff29d513f3ff2923a1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">586f8204935b9ec884500498ccc91aa869fc652c40c093bd9e1471fbcc25c022</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ddc2f4dfd396c7bfa18e6ce371cba60e4cf9d2e5cdb71376aa2da264605b60b9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5ddcba87675b6d509139d1b521e0c8250e967e63b5909a7e8f8944d0f90ff36f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7bd339195d84439cbe5771546fe8a4e8a7a045417d8f9de9a368c434e42a721e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d7c36232a90d4755b720fbd76739d8891732b18cf240a9c645d75f00639a9024</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b0817e34942b2ca527b0e9298373e7cc75f429e8da2055607f4931fded23e20</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">99f70b740dc04d09e6b2699b675874367885217a2e9f782bdf5395632ac663b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6ef687afab047554a2d366e112dd187b62d261d49eb79b77e386f94644363294</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ad36cfb355e24f1bd37cac88c112cd7730873f20fb0bdaf8ba59eedf8216079f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">36b3ee798c58ace201289024b52788161e1ea133e4ac93fba7d49da5fec0ef9e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f8a2f084546cc59ea99fda8e070be2fd140c3092dc11524a71aa8f0f3d5a55ca</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e4461d0f003a0aa9be2bdd1b798a041f177189c1a0f7619fe8c95ad08d9a45d7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8db715ebe3bb7d86d77ac1826f7d67ec11a70dbd2376b7cc214199360517b641</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">793968759cd0d96cac1e367afd70c235867831983f876a53389ad869b043c948</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">66e6a3af5a75363d2c9a48b07cb27c4ea542938b1a2e93b15a503cdfa8490795</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6ef0befbb5d79cf32d0266f5cff01545602344eda89480e1dd88aca964260b18</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1d4acf42190d449d5e89654d5c1ed3a4f17925eec71f05e2a41414689cda02d1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a5f446dd5055667aabaee78487f2b5ab72e244f9bc0b2ffebfeec79051679984</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9dbbeb27f4e70bfd9eec1be5477517365afe05a9b2c441a0b21929ee61048124</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">22806714311a69fd0af9b35b7be97c18a0fc2826e6827dbb3a8c94eac6cf7eeb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b34ae4636dfc4e76a438ab826a0d1eed2589ca7d9a1b2d5bb546978ac6485461</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8c8370641f1a7f0e0669ddccca22f1da893cef7628396431eb445d46d893e5cd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c8362467a0fdeccd47935f22c256bec5e6abe543bf0d66e3d3d57a8fb5731863</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">11a8c85ef4a07a7638180bf04fe189d12757c696eb41f310d2426895356dcf05</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b316144e85316da2723f9d8dc75bada12fa58489a527091fa1d5a612643d1a0e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cf1ea2e34868f6fbf070e1af291c8180480310173de0b0c43fc38a02929fc0e3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e546e768d08ad55b20b11dbb78a745151acbd938f8f00d0cfbabe8b0199b9880</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4901165d170a5fde6f589acb90a6b33629ad1ec976d4529e769c6f3d885e3e80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">618a3d6cae6ef8ec88bb76dd80b83cfe415ad4f1d942ca2a903bf6b6ff97a2da</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ed4eb745efbff0a8e9587d22a84be94a5eb7d2d99c02dacf7bd0911713ed14dd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6c81e5f372cd0dc5dc4809553d34f832f60a46034a5f187756d9b90586c2c307</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">43fbac5f22e25bee1d482c97474f930a353542855f05c1161fd804c9dc74a09d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6d7faa6f14017c0b1e69f5e2c357b998731ea75a442ab3841c0dbbbfe902d2c4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08231ac30a842bd04daabc4d71fddd7e6d26189406d5a69535638e4dcb88fe76</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">044a3e61a7c2dafacae99d1e722cc2d4c05280790ec5a05031b3876809d89a5c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3f26b5bd1079acdb0c7a5645e350fe54d16b17bfc5e71f371c449383d3342e17</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">482103aed1dfe2f3b71a58eff35ba105289b8d862551ea576bd15479aba01f66</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1374f4129f9bcca53a1bba0bb86bf78325a0374577cf7e9e4cd046b1e6f20e24</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">635dc434ff724b178cb192c70016cc0ad25a275228f749ee0daf0eddbc8183b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bc362ee4e314870a70f4ae88772d72d877246537d9f8cb8f7eacf10884862432</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4832d7d380477521a8c1644bbab6588dfedea5e30a7d967b5fb75977c45fd77f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">42821446ee7a76f5d9f71f9e33a4fb2ffd724bb3e7f93386150b61a43115788d</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rsa@4.9">
+      <name>rsa</name>
+      <version>4.9</version>
+      <description>Pure-Python RSA implementation</description>
+      <purl>pkg:pypi/rsa@4.9</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rsa/#rsa-4.9-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rsa/#rsa-4.9.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="smart-open@7.0.4">
+      <name>smart-open</name>
+      <version>7.0.4</version>
+      <description>Utils for streaming large files (S3, HDFS, GCS, Azure Blob Storage, gzip, bz2...)</description>
+      <purl>pkg:pypi/smart-open@7.0.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/smart-open/#smart_open-7.0.4-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4e98489932b3372595cddc075e6033194775165702887216b65eba760dfd8d47</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/smart-open/#smart_open-7.0.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">62b65852bdd1d1d516839fcb1f6bc50cd0f16e05b4ec44b52f43d38bcb838524</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="sniffio@1.3.1">
+      <name>sniffio</name>
+      <version>1.3.1</version>
+      <description>Sniff out which async library your code is running under</description>
+      <purl>pkg:pypi/sniffio@1.3.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/sniffio/#sniffio-1.3.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/sniffio/#sniffio-1.3.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="starlette@0.37.2">
+      <name>starlette</name>
+      <version>0.37.2</version>
+      <description>The little ASGI library that shines.</description>
+      <purl>pkg:pypi/starlette@0.37.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/starlette/#starlette-0.37.2-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6fe59f29268538e5d0d182f2791a479a0c64638e6935d1c6989e63fb2699c6ee</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/starlette/#starlette-0.37.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9af890290133b79fc3db55474ade20f6220a364a0402e0b556e7cd5e1e093823</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="typing-extensions@4.10.0">
+      <name>typing-extensions</name>
+      <version>4.10.0</version>
+      <description>Backported and Experimental Type Hints for Python 3.8+</description>
+      <purl>pkg:pypi/typing-extensions@4.10.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/typing-extensions/#typing_extensions-4.10.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/typing-extensions/#typing_extensions-4.10.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="urllib3@2.2.1">
+      <name>urllib3</name>
+      <version>2.2.1</version>
+      <description>HTTP library with thread-safe connection pooling, file post, and more.</description>
+      <purl>pkg:pypi/urllib3@2.2.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/urllib3/#urllib3-2.2.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/urllib3/#urllib3-2.2.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="uvicorn@0.29.0">
+      <name>uvicorn</name>
+      <version>0.29.0</version>
+      <description>The lightning-fast ASGI server.</description>
+      <purl>pkg:pypi/uvicorn@0.29.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvicorn/#uvicorn-0.29.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2c2aac7ff4f4365c206fd773a39bf4ebd1047c238f8b8268ad996829323473de</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvicorn/#uvicorn-0.29.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6a69214c0b6a087462412670b3ef21224fa48cae0e452b5883e8e8bdfdd11dd0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="virtualenv@20.25.1">
+      <name>virtualenv</name>
+      <version>20.25.1</version>
+      <description>Virtual Python Environment builder</description>
+      <purl>pkg:pypi/virtualenv@20.25.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/virtualenv/#virtualenv-20.25.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961c026ac520bac5f69acb8ea063e8a4f071bcc9457b9c1f28f6b085c511583a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/virtualenv/#virtualenv-20.25.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e08e13ecdca7a0bd53798f356d5831434afa5b07b93f0abdf0797b7a06ffe197</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="watchfiles@0.21.0">
+      <name>watchfiles</name>
+      <version>0.21.0</version>
+      <description>Simple, modern and high performance file watching and code reload in python.</description>
+      <purl>pkg:pypi/watchfiles@0.21.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">27b4035013f1ea49c6c0b42d983133b136637a527e48c132d368eb19bf1ac6aa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c81818595eff6e92535ff32825f31c116f867f64ff8cdf6562cd1d6b2e1e8f3e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6c107ea3cf2bd07199d66f156e3ea756d1b84dfd43b542b2d870b77868c98c03</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0d9ac347653ebd95839a7c607608703b20bc07e577e870d824fa4801bc1cb124</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5eb86c6acb498208e7663ca22dbe68ca2cf42ab5bf1c776670a50919a56e64ab</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f564bf68404144ea6b87a78a3f910cc8de216c6b12a4cf0b27718bf4ec38d303</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3d0f32ebfaa9c6011f8454994f86108c2eb9c79b8b7de00b36d558cadcedaa3d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b6d45d9b699ecbac6c7bd8e0a2609767491540403610962968d258fd6405c17c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aff06b2cac3ef4616e26ba17a9c250c1fe9dd8a5d907d0193f84c499b1b6e6a9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d9792dff410f266051025ecfaa927078b94cc7478954b06796a9756ccc7e14a9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">214cee7f9e09150d4fb42e24919a1e74d8c9b8a9306ed1474ecaddcd5479c293</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1ad7247d79f9f55bb25ab1778fd47f32d70cf36053941f07de0b7c4e96b5d235</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">668c265d90de8ae914f860d3eeb164534ba2e836811f91fecc7050416ee70aa7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a23092a992e61c3a6a70f350a56db7197242f3490da9c87b500f389b2d01eef</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e7941bbcfdded9c26b0bf720cb7e6fd803d95a55d2c14b4bd1f6a2772230c586</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">11cd0c3100e2233e9c53106265da31d574355c288e15259c0d40a4405cbae317</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d78f30cbe8b2ce770160d3c08cff01b2ae9306fe66ce899b73f0409dc1846c1b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6674b00b9756b0af620aa2a3346b01f8e2a3dc729d25617e1b89cf6af4a54eb1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fd7ac678b92b29ba630d8c842d8ad6c555abda1b9ef044d6cc092dacbfc9719d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9c873345680c1b87f1e09e0eaf8cf6c891b9851d8b4d3645e7efe2ec20a20cc7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">49f56e6ecc2503e7dbe233fa328b2be1a7797d31548e7a193237dcdf1ad0eee0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">02d91cbac553a3ad141db016e3350b03184deaafeba09b9d6439826ee594b365</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ebe684d7d26239e23d102a2bad2a358dedf18e462e8808778703427d1f584400</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4566006aa44cb0d21b8ab53baf4b9c667a0ed23efe4aaad8c227bfba0bf15cbe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-none-win_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c550a56bf209a3d987d5a975cdf2063b3389a5d16caf29db4bdddeae49f22078</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">51ddac60b96a42c15d24fbdc7a4bfcd02b5a29c047b7f8bf63d3f6f5a860949a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">511f0b034120cd1989932bf1e9081aa9fb00f1f949fbd2d9cab6264916ae89b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cfb92d49dbb95ec7a07511bc9efb0faff8fe24ef3805662b8d6808ba8409a71a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3f92944efc564867bbf841c823c8b71bb0be75e06b8ce45c084b46411475a915</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">642d66b75eda909fd1112d35c53816d59789a4b38c141a96d62f50a3ef9b3360</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d23bcd6c8eaa6324fe109d8cac01b41fe9a54b8c498af9ce464c1aeeb99903d6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">18d5b4da8cf3e41895b34e8c37d13c9ed294954907929aacd95153508d5d89d7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1b8d1eae0f65441963d805f766c7e9cd092f91e0c600c820c764a4ff71a0764c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1fd9a5205139f3c6bb60d11f6072e0552f0a20b712c85f43d42342d162be1235</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a1e3014a625bcf107fbf38eece0e47fa0190e52e45dc6eee5a8265ddc6dc5ea7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9d09869f2c5a6f2d9df50ce3064b3391d3ecb6dced708ad64467b9e4f2c9bef3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">18722b50783b5e30a18a8a5db3006bab146d2b705c92eb9a94f78c72beb94094</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-none-win_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a3b9bec9579a15fb3ca2d9878deae789df72f2b0fdaf90ad49ee389cad5edab6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4ea10a29aa5de67de02256a28d1bf53d21322295cb00bd2d57fcd19b850ebd99</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">40bca549fdc929b470dd1dbfcb47b3295cb46a6d2c90e50588b0a1b3bd98f429</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9b37a7ba223b2f26122c148bb8d09a9ff312afca998c48c725ff5a0a632145f7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ec8c8900dc5c83650a63dd48c4d1d245343f904c4b64b48798c67a3767d7e165</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8ad3fe0a3567c2f0f629d800409cd528cb6251da12e81a1f765e5c5345fd0137</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9d353c4cfda586db2a176ce42c88f2fc31ec25e50212650c89fdd0f560ee507b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">83a696da8922314ff2aec02987eefb03784f473281d740bf9170181829133765</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5a03651352fc20975ee2a707cd2d74a386cd303cc688f407296064ad1e6d1562</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3ad692bc7792be8c32918c699638b660c0de078a6cbe464c46e1340dadb94c19</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">06247538e8253975bdb328e7683f8515ff5ff041f43be6c40bff62d989b7d0b0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9a0aa47f94ea9a0b39dd30850b0adf2e1cd32a8b4f9c7aa443d852aacf9ca214</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8d5f400326840934e3507701f9f7269247f7c026d1b6cfd49477d2be0933cfca</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7f762a1a85a12cc3484f77eee7be87b10f8c50b0b787bb02f4e357403cad0c0e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6e9be3ef84e2bb9710f3f777accce25556f4a71e15d2b73223788d528fcc2052</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4c48a10d17571d1275701e14a601e36959ffada3add8cdbc9e5061a6e3579a5d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6c889025f59884423428c261f212e04d438de865beda0b1e1babab85ef4c0f01</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">66fac0c238ab9a2e72d026b5fb91cb902c146202bbd29a9a1a44e8db7b710b6f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b4a21f71885aa2744719459951819e7bf5a906a6448a6b2bbce8e9cc9f2c8128</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1c9198c989f47898b2c22201756f73249de3748e0fc9de44adaf54a8b259cc0c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d8f57c4461cd24fda22493109c45b3980863c58a25b8bec885ca8bea6b8d4b28</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">853853cbf7bf9408b404754b92512ebe3e3a83587503d766d23e6bf83d092ee6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d5b1dc0e708fad9f92c296ab2f948af403bf201db8fb2eb4c8179db143732e49</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">59137c0c6826bd56c710d1d2bda81553b5e6b7c84d5a676747d80caf0409ad94</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6cb8fdc044909e2078c248986f2fc76f911f72b51ea4a4fbbf472e01d14faa58</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ab03a90b305d2588e8352168e8c5a1520b721d2d367f31e9332c4235b30b8994</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">927c589500f9f41e370b0125c12ac9e7d3a2fd166b89e9ee2828b3dda20bfe6f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1bd467213195e76f838caf2c28cd65e58302d0254e636e7c0fca81efa4a2e62c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">02b73130687bc3f6bb79d8a170959042eb56eb3a42df3671c79b428cd73f17cc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08dca260e85ffae975448e344834d765983237ad6dc308231aa16e7933db763e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3ccceb50c611c433145502735e0370877cced72a6c70fd2410238bcbc7fe51d8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">57d430f5fb63fea141ab71ca9c064e80de3a20b427ca2febcbfcef70ff0ce895</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0dd5fad9b9c0dd89904bbdea978ce89a2b692a7ee8a0ce19b940e538c88a809c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">be6dd5d52b73018b21adc1c5d28ac0c68184a64769052dfeb0c5d9998e7f56a2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3cab0e06143768499384a8a5efb9c4dc53e19382952859e4802f294214f36ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8c6ed10c2497e5fedadf61e465b3ca12a19f96004c15dcffe4bd442ebadc2d85</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">43babacef21c519bc6631c5fce2a61eccdfc011b4bcb9047255e9620732c8097</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c76c635fabf542bb78524905718c39f736a98e5ab25b23ec6d4abede1a85a6a3</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="wrapt@1.16.0">
+      <name>wrapt</name>
+      <version>1.16.0</version>
+      <description>Module for decorators, wrappers and monkey patching.</description>
+      <purl>pkg:pypi/wrapt@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ffa565331890b90056c01db69c0fe634a776f8019c143a5ae265f9c6bc4bd6d4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e4fdb9275308292e880dcbeb12546df7f3e0f96c6b41197e0cf37d2826359020</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bb2dee3874a500de01c93d5c71415fcaef1d858370d405824783e7a8ef5db440</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2a88e6010048489cda82b1326889ec075a8c856c2e6a256072b28eaee3ccf487</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac83a914ebaf589b69f7d0a1277602ff494e21f4c2f743313414378f8f50a4cf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">73aa7d98215d39b8455f103de64391cb79dfcad601701a3aa0dddacf74911d72</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">807cc8543a477ab7422f1120a217054f958a66ef7314f76dd9e77d3f02cdccd0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bf5703fdeb350e36885f2875d853ce13172ae281c56e509f4e6eca049bdfb136</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f6b2d0c6703c988d334f297aa5df18c45e97b0af3679bb75059e0e0bd8b1069d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">decbfa2f618fa8ed81c95ee18a387ff973143c656ef800c9f24fb7e9c16054e2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1a5db485fe2de4403f13fafdc231b0dbae5eca4359232d2efc79025527375b09</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">75ea7d0ee2a15733684badb16de6794894ed9c55aa5e9903260922f0482e687d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a452f9ca3e3267cd4d0fcf2edd0d035b1934ac2bd7e0e57ac91ad6b95c0c6389</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">43aa59eadec7890d9958748db829df269f0368521ba6dc68cc172d5d03ed8060</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">72554a23c78a8e7aa02abbd699d129eead8b147a23c56e08d08dfc29cfdddca1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d2efee35b4b0a347e0d99d28e884dfd82797852d62fcd7ebdeee26f3ceb72cf3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6dcfcffe73710be01d90cae08c3e548d90932d37b39ef83969ae135d36ef3956</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eb6e651000a19c96f452c85132811d25e9264d836951022d6e81df2fff38337d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">66027d667efe95cc4fa945af59f92c5a02c6f5bb6012bff9e60542c74c75c362</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5eb404d89131ec9b4f748fa5cfb5346802e5ee8836f57d516576e61f304f3b7b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9090c9e676d5236a6948330e83cb89969f433b1943a558968f659ead07cb3b36</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">94265b00870aa407bd0cbcfd536f17ecde43b94fb8d228560a1e9d3041462d73</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f2058f813d4f2b5e3a9eb2eb3faf8f1d99b81c3e51aeda4b168406443e8ba809</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">98b5e1f498a8ca1858a1cdbffb023bfd954da4e3fa2c0cb5853d40014557248b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">14d7dc606219cdd7405133c713f2c218d4252f2a469003f8c46bb92d5d095d81</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">49aac49dc4782cb04f58986e81ea0b4768e4ff197b57324dcbd7699c5dfb40b9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">418abb18146475c310d7a6dc71143d6f7adec5b004ac9ce08dc7a34e2babdc5c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">685f568fa5e627e93f3b52fda002c7ed2fa1800b50ce51f6ed1d572d8ab3e7fc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dcdba5c86e368442528f7060039eda390cc4091bfd1dca41e8046af7c910dda8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d462f28826f4657968ae51d2181a074dfe03c200d6131690b7d65d55b0f360f8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a33a747400b94b6d6b8a165e4480264a64a78c8a4c734b62136062e9a248dd39</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3646eefa23daeba62643a58aac816945cadc0afaf21800a1421eeba5f6cfb9c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3ebf019be5c09d400cf7b024aa52b1f3aeebeff51550d007e92c3c1c4afc2a40</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0d2691979e93d06a95a26257adb7bfd0c93818e89b1406f5a28f36e0d8c1e1fc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1acd723ee2a8826f3d53910255643e33673e1d11db84ce5880675954183ec47e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bc57efac2da352a51cc4658878a68d2b1b67dbe9d33c36cb826ca449d80a8465</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">da4813f751142436b075ed7aa012a8778aa43a99f7b36afe9b742d3ed8bdc95e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6f6eac2360f2d543cc875a0e5efd413b6cbd483cb3ad7ebf888884a6e0d2e966</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a0ea261ce52b5952bf669684a251a66df239ec6d441ccb59ec7afa882265d593</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7bd2d7ff69a2cac767fbf7a2b206add2e9a210e57947dd7ce03e25d03d2de292</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9159485323798c8dc530a224bd3ffcf76659319ccc7bbd52e01e73bd0241a0c5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a86373cf37cd7764f2201b76496aba58a52e76dedfaa698ef9e9688bfd9e41cf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">73870c364c11f03ed072dda68ff7aea6d2a3a5c3fe250d917a429c7432e15228</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b935ae30c6e7400022b50f8d359c03ed233d45b725cfdd299462f41ee5ffba6f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">db98ad84a55eb09b3c32a96c576476777e87c520a34e2519d3e59c44710c002c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9153ed35fc5e4fa3b2fe97bddaa7cbec0ed22412b85bcdaf54aeba92ea37428c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">66dfbaa7cfa3eb707bbfcd46dab2bc6207b005cbc9caa2199bcbc81d95071a00</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1dd50a2696ff89f57bd8847647a1c363b687d3d796dc30d4dd4a9d1689a706f0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">44a2754372e32ab315734c6c73b24351d06e77ffff6ae27d2ecf14cf3d229202</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8e9723528b9f787dc59168369e42ae1c3b0d3fadb2f1a71de14531d321ee05b0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dbed418ba5c3dce92619656802cc5355cb679e58d0d89b50f116e4a9d5a9603e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">941988b89b4fd6b41c3f0bfb20e92bd23746579736b7343283297c4c8cbae68f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6a42cd0cfa8ffc1915aef79cb4284f6383d8a3e9dcca70c445dcfdd639d51267</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1ca9b6085e4f866bd584fb135a041bfc32cab916e69f714a7d1d397f8c4891ca</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d5e49454f19ef621089e204f862388d29e6e8d8b162efce05208913dde5b9ad6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c31f72b1b6624c9d863fc095da460802f43a7c6868c5dda140f51da24fd47d7b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">490b0ee15c1a55be9c1bd8609b8cecd60e325f0575fc98f50058eae366e01f41</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9b201ae332c3637a42f02d1045e1d0cccfdc41f1f2f801dafbaa7e9b4797bfc2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2076fad65c6736184e77d7d4729b63a6d1ae0b70da4868adeec40989858eb3fb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c5cd603b575ebceca7da5a3a251e69561bec509e0b46e4993e1cac402b7247b8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b47cfad9e9bbbed2339081f4e346c93ecd7ab504299403320bf85f7f85c7d46c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5f15814a33e42b04e3de432e573aa557f9f0f56458745c2074952f564c50e664</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">db2e408d983b0e61e238cf579c09ef7020560441906ca990fe8412153e3b291f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">edfad1d29c73f9b863ebe7082ae9321374ccb10879eeabc84ba3b69f2579d537</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ed867c42c268f876097248e05b6117a65bcd1e63b779e916fe2e33cd6fd0d3c3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="yarl@1.9.4">
+      <name>yarl</name>
+      <version>1.9.4</version>
+      <description>Yet another URL library</description>
+      <purl>pkg:pypi/yarl@1.9.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a8c1df72eb746f4136fe9a2e72b0c9dc1da1cbd23b5372f94b5820ff8ae30e0e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a3a6ed1d525bfb91b3fc9b690c5a21bb52de28c018530ad85093cc488bee2dd2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c38c9ddb6103ceae4e4498f9c08fac9b590c5c71b0370f98714768e22ac6fa66</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d9e09c9d74f4566e905a0b8fa668c58109f7624db96a2171f21747abc7524234</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b8477c1ee4bd47c57d49621a062121c3023609f7a13b8a46953eb6c9716ca392</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d5ff2c858f5f6a42c2a8e751100f237c5e869cbde669a724f2062d4c4ef93551</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">357495293086c5b6d34ca9616a43d329317feab7917518bc97a08f9e55648455</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">54525ae423d7b7a8ee81ba189f131054defdb122cde31ff17477951464c1691c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">801e9264d19643548651b9db361ce3287176671fb0117f96b5ac0ee1c3530d53</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e516dc8baf7b380e6c1c26792610230f37147bb754d6426462ab115a02944385</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7d5aaac37d19b2904bb9dfe12cdb08c8443e7ba7d2852894ad448d4b8f442863</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">54beabb809ffcacbd9d28ac57b0db46e42a6e341a030293fb3185c409e626b8b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bac8d525a8dbc2a1507ec731d2867025d11ceadcb4dd421423a5d42c56818541</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7855426dfbddac81896b6e533ebefc0af2f132d4a47340cee6d22cac7190022d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">848cd2a1df56ddbffeb375535fb62c9d1645dde33ca4d51341378b3f5954429b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">35a2b9396879ce32754bd457d31a51ff0a9d426fd9e0e3c33394bf4b9036b099</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4c7d56b293cc071e82532f70adcbd8b61909eec973ae9d2d1f9b233f3d943f2c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d8a1c6c0be645c745a081c192e747c5de06e944a0d21245f4cf7c05e457c36e0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4b3c1ffe10069f655ea2d731808e76e0f452fc6c749bea04781daf18e6039525</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">549d19c84c55d11687ddbd47eeb348a89df9cb30e1993f1b128f4685cd0ebbf8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a7409f968456111140c1c95301cadf071bd30a81cbd7ab829169fb9e3d72eae9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e23a6d84d9d1738dbc6e38167776107e63307dfc8ad108e580548d1f2c587f42</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d8b889777de69897406c9fb0b76cdf2fd0f31267861ae7501d93003d55f54fbe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">03caa9507d3d3c83bca08650678e25364e1843b484f19986a527630ca376ecce</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4e9035df8d0880b2f1c7f5031f33f69e071dfe72ee9310cfc76f7b605958ceb9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c0ec0ed476f77db9fb29bca17f0a8fcc7bc97ad4c6c1d8959c507decb22e8572</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ee04010f26d5102399bd17f8df8bc38dc7ccd7701dc77f4a68c5b8d733406958</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">49a180c2e0743d5d6e0b4d1a9e5f633c62eca3f8a86ba5dd3c471060e352ca98</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">81eb57278deb6098a5b62e88ad8281b2ba09f2f1147c4767522353eaa6260b31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d1d2532b340b692880261c15aee4dc94dd22ca5d61b9db9a8a361953d36410b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0d2454f0aef65ea81037759be5ca9947539667eecebca092733b2eb43c965a81</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">44d8ffbb9c06e5a7f529f38f53eda23e50d1ed33c6c869e01481d3fafa6b8142</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aaaea1e536f98754a6e5c56091baa1b6ce2f2700cc4a00b0d49eca8dea471074</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3777ce5536d17989c91696db1d459574e9a9bd37660ea7ee4d3344579bb6f129</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9fc5fc1eeb029757349ad26bbc5880557389a03fa6ada41703db5e068881e5f2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ea65804b5dc88dacd4a40279af0cdadcfe74b3e5b4c897aa0d81cf86927fee78</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aa102d6d280a5455ad6a0f9e6d769989638718e938a6a0a2ff3f4a7ff8c62cc4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">09efe4615ada057ba2d30df871d2f668af661e971dfeedf0c159927d48bbeff0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">008d3e808d03ef28542372d01057fd09168419cdc8f848efe2804f894ae03e51</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6f5cb257bc2ec58f437da2b37a8cd48f666db96d47b8a3115c29f316313654ff</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">992f18e0ea248ee03b5a6e8b3b4738850ae7dbb172cc41c966462801cbf62cf7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e9d124c191d5b881060a9e5060627694c3bdd1fe24c5eecc8d5d7d0eb6faabc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3986b6f41ad22988e53d5778f91855dc0399b043fc8946d4f2e68af22ee9ff10</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4b21516d181cd77ebd06ce160ef8cc2a5e9ad35fb1c5930882baff5ac865eee7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a9bd00dc3bc395a662900f33f74feb3e757429e545d831eef5bb280252631984</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">63b20738b5aac74e239622d2fe30df4fca4942a86e31bf47a81a0e94c14df94f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d7d7f7de27b8944f1fee2c26a88b4dabc2409d2fea7a9ed3df79b67277644e17</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c74018551e31269d56fab81a728f683667e7c28c04e807ba08f8c9e3bba32f14</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ca06675212f94e7a610e85ca36948bb8fc023e458dd6c63ef71abfd482481aa5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5aef935237d60a51a62b86249839b51345f47564208c6ee615ed2a40878dccdd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2b134fd795e2322b7684155b7855cc99409d10b2e408056db2b93b51a52accc7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d25039a474c4c72a5ad4b52495056f843a7ff07b632c1b92ea9043a3d9950f6e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f7d6b36dd2e029b6bcb8a13cf19664c7b8e19ab3a58e0fefbb5b8461447ed5ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">957b4774373cf6f709359e5c8c4a0af9f6d7875db657adb0feaf8d6cb3c3964c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d7eeb6d22331e2fd42fce928a81c697c9ee2d51400bd1a28803965883e13cead</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6a962e04b8f91f8c4e5917e518d17958e3bdee71fd1d8b88cdce74dd0ebbf434</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f3bc6af6e2b8f92eced34ef6a96ffb248e863af20ef4fde9448cc8c9b858b749</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ad4d7a90a92e528aadf4965d685c17dacff3df282db1121136c382dc0b6014d2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ec61d826d80fc293ed46c9dd26995921e3a82146feacd952ef0757236fc137be</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8be9e837ea9113676e5754b43b940b50cce76d9ed7d2461df1af39a8ee674d9f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bef596fdaa8f26e3d66af846bbe77057237cb6e8efff8cd7cc8dff9a62278bbf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2d47552b6e52c3319fede1b60b3de120fe83bde9b7bddad11a69fb0af7db32f1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">84fc30f71689d7fc9168b92788abc977dc8cefa806909565fc2951d02f6b7d57</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4aa9741085f635934f3a2583e16fcf62ba835719a8b2b28fb2917bb0537c1dfa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">206a55215e6d05dbc6c98ce598a59e6fbd0c493e2de4ea6cc2f4934d5a18d130</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">07574b007ee20e5c375a8fe4a0789fad26db905f9813be0f9fef5a68080de559</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5a2e2433eb9344a163aced6a5f6c9222c0786e5a9e9cac2c89f0b28433f56e23</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6ad6d10ed9b67a382b45f29ea028f92d25bc0bc1daf6c5b801b90b5aa70fb9ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6fe79f998a4052d79e1c30eeb7d6c1c1056ad33300f682465e1b4e9b5a188b78</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a825ec844298c791fd28ed14ed1bffc56a98d15b8c58a20e0e08c1f5f2bea1be</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8619d6915b3b0b34420cf9b2bb6d81ef59d984cb0fde7544e9ece32b4b3043c3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">686a0c2f85f83463272ddffd4deb5e591c98aac1897d65e92319f729c320eece</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a00862fb23195b6b8322f7d781b0dc1d82cb3bcac346d1e38689370cc1cc398b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">604f31d97fa493083ea21bd9b92c419012531c4e17ea6da0f65cacdcf5d0bd27</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8a854227cf581330ffa2c4824d96e52ee621dd571078a252c25e3a3b3d94a1b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ba6f52cbc7809cd8d74604cce9c14868306ae4aa0282016b641c661f981a6e91</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a6327976c7c2f4ee6816eff196e25385ccc02cb81427952414a64811037bbc8b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8397a3817d7dcdd14bb266283cd1d6fc7264a48c186b986f32e86d86d35fbac5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e0381b4ce23ff92f8170080c97678040fc5b08da85e9e292292aba67fdac6c34</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">23d32a2594cb5d565d358a92e151315d1b2268bc10f4610d098f96b147370136</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ddb2a5c08a4eaaba605340fdee8fc08e406c56617566d9643ad8bf6852778fc7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">26a1dc6285e03f3cc9e839a2da83bcbf31dcb0d004c72d0730e755b33466c30e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">18580f672e44ce1238b82f7fb87d727c4a131f3a9d33a5e0e82b793362bf18b4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">29e0f83f37610f173eb7e7b5562dd71467993495e568e708d99e9d1944f561ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f23e4fe1e8794f74b6027d7cf19dc25f8b63af1483d91d595d4a07eca1fb26c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">db8e58b9d79200c76956cefd14d5c90af54416ff5353c5bfd7cbe58818e26ef0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c7224cab95645c7ab53791022ae77a4509472613e839dab722a72abe5a684575</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">824d6c50492add5da9374875ce72db7a0733b29c2394890aef23d533106e2b15</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">928cecb0ef9d5a7946eb6ff58417ad2fe9375762382f1bf5c55e61645f2c43ad</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">566db86717cf8080b99b58b083b773a908ae40f06681e87e589a976faf8246bf</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="aiohttp-cors@0.7.0">
+      <dependency ref="aiohttp@3.9.3"/>
+    </dependency>
+    <dependency ref="aiohttp@3.9.3">
+      <dependency ref="aiosignal@1.3.1"/>
+      <dependency ref="async-timeout@4.0.3"/>
+      <dependency ref="attrs@23.2.0"/>
+      <dependency ref="frozenlist@1.4.1"/>
+      <dependency ref="multidict@6.0.5"/>
+      <dependency ref="yarl@1.9.4"/>
+    </dependency>
+    <dependency ref="aiosignal@1.3.1">
+      <dependency ref="frozenlist@1.4.1"/>
+    </dependency>
+    <dependency ref="annotated-types@0.6.0"/>
+    <dependency ref="anyio@4.3.0">
+      <dependency ref="exceptiongroup@1.2.0"/>
+      <dependency ref="idna@3.6"/>
+      <dependency ref="sniffio@1.3.1"/>
+      <dependency ref="typing-extensions@4.10.0"/>
+    </dependency>
+    <dependency ref="async-timeout@4.0.3"/>
+    <dependency ref="attrs@23.2.0"/>
+    <dependency ref="cachetools@5.3.3"/>
+    <dependency ref="certifi@2024.2.2"/>
+    <dependency ref="charset-normalizer@3.3.2"/>
+    <dependency ref="click@8.1.7">
+      <dependency ref="colorama@0.4.6"/>
+    </dependency>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="colorful@0.5.6">
+      <dependency ref="colorama@0.4.6"/>
+    </dependency>
+    <dependency ref="distlib@0.3.8"/>
+    <dependency ref="exceptiongroup@1.2.0"/>
+    <dependency ref="fastapi@0.1.17">
+      <dependency ref="pydantic@2.6.4"/>
+      <dependency ref="starlette@0.37.2"/>
+    </dependency>
+    <dependency ref="filelock@3.13.3"/>
+    <dependency ref="frozenlist@1.4.1"/>
+    <dependency ref="google-api-core@2.8.0">
+      <dependency ref="google-auth@2.29.0"/>
+      <dependency ref="googleapis-common-protos@1.56.1"/>
+      <dependency ref="protobuf@5.26.1"/>
+      <dependency ref="requests@2.31.0"/>
+    </dependency>
+    <dependency ref="google-auth@2.29.0">
+      <dependency ref="cachetools@5.3.3"/>
+      <dependency ref="pyasn1-modules@0.4.0"/>
+      <dependency ref="rsa@4.9"/>
+    </dependency>
+    <dependency ref="googleapis-common-protos@1.56.1">
+      <dependency ref="protobuf@5.26.1"/>
+    </dependency>
+    <dependency ref="grpcio@1.62.1"/>
+    <dependency ref="h11@0.14.0"/>
+    <dependency ref="idna@3.6"/>
+    <dependency ref="jsonschema-specifications@2023.12.1">
+      <dependency ref="referencing@0.34.0"/>
+    </dependency>
+    <dependency ref="jsonschema@4.21.1">
+      <dependency ref="attrs@23.2.0"/>
+      <dependency ref="jsonschema-specifications@2023.12.1"/>
+      <dependency ref="referencing@0.34.0"/>
+      <dependency ref="rpds-py@0.18.0"/>
+    </dependency>
+    <dependency ref="msgpack@1.0.8"/>
+    <dependency ref="multidict@6.0.5"/>
+    <dependency ref="opencensus-context@0.1.3"/>
+    <dependency ref="opencensus@0.11.4">
+      <dependency ref="google-api-core@2.8.0"/>
+      <dependency ref="opencensus-context@0.1.3"/>
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="packaging@24.0"/>
+    <dependency ref="platformdirs@4.2.0"/>
+    <dependency ref="prometheus-client@0.20.0"/>
+    <dependency ref="protobuf@5.26.1"/>
+    <dependency ref="py-spy@0.3.14"/>
+    <dependency ref="pyasn1-modules@0.4.0">
+      <dependency ref="pyasn1@0.6.0"/>
+    </dependency>
+    <dependency ref="pyasn1@0.6.0"/>
+    <dependency ref="pydantic-core@2.16.3">
+      <dependency ref="typing-extensions@4.10.0"/>
+    </dependency>
+    <dependency ref="pydantic@2.6.4">
+      <dependency ref="annotated-types@0.6.0"/>
+      <dependency ref="pydantic-core@2.16.3"/>
+      <dependency ref="typing-extensions@4.10.0"/>
+    </dependency>
+    <dependency ref="pyyaml@6.0.1"/>
+    <dependency ref="ray@2.10.0">
+      <dependency ref="aiohttp-cors@0.7.0"/>
+      <dependency ref="aiohttp@3.9.3"/>
+      <dependency ref="aiosignal@1.3.1"/>
+      <dependency ref="click@8.1.7"/>
+      <dependency ref="colorful@0.5.6"/>
+      <dependency ref="fastapi@0.1.17"/>
+      <dependency ref="filelock@3.13.3"/>
+      <dependency ref="frozenlist@1.4.1"/>
+      <dependency ref="grpcio@1.62.1"/>
+      <dependency ref="jsonschema@4.21.1"/>
+      <dependency ref="msgpack@1.0.8"/>
+      <dependency ref="opencensus@0.11.4"/>
+      <dependency ref="packaging@24.0"/>
+      <dependency ref="prometheus-client@0.20.0"/>
+      <dependency ref="protobuf@5.26.1"/>
+      <dependency ref="py-spy@0.3.14"/>
+      <dependency ref="pydantic@2.6.4"/>
+      <dependency ref="pyyaml@6.0.1"/>
+      <dependency ref="requests@2.31.0"/>
+      <dependency ref="smart-open@7.0.4"/>
+      <dependency ref="starlette@0.37.2"/>
+      <dependency ref="uvicorn@0.29.0"/>
+      <dependency ref="virtualenv@20.25.1"/>
+      <dependency ref="watchfiles@0.21.0"/>
+    </dependency>
+    <dependency ref="referencing@0.34.0">
+      <dependency ref="attrs@23.2.0"/>
+      <dependency ref="rpds-py@0.18.0"/>
+    </dependency>
+    <dependency ref="regression-issue702">
+      <dependency ref="ray@2.10.0"/>
+    </dependency>
+    <dependency ref="requests@2.31.0">
+      <dependency ref="certifi@2024.2.2"/>
+      <dependency ref="charset-normalizer@3.3.2"/>
+      <dependency ref="idna@3.6"/>
+      <dependency ref="urllib3@2.2.1"/>
+    </dependency>
+    <dependency ref="rpds-py@0.18.0"/>
+    <dependency ref="rsa@4.9">
+      <dependency ref="pyasn1@0.6.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="smart-open@7.0.4">
+      <dependency ref="wrapt@1.16.0"/>
+    </dependency>
+    <dependency ref="sniffio@1.3.1"/>
+    <dependency ref="starlette@0.37.2">
+      <dependency ref="anyio@4.3.0"/>
+    </dependency>
+    <dependency ref="typing-extensions@4.10.0"/>
+    <dependency ref="urllib3@2.2.1"/>
+    <dependency ref="uvicorn@0.29.0">
+      <dependency ref="click@8.1.7"/>
+      <dependency ref="h11@0.14.0"/>
+      <dependency ref="typing-extensions@4.10.0"/>
+    </dependency>
+    <dependency ref="virtualenv@20.25.1">
+      <dependency ref="distlib@0.3.8"/>
+      <dependency ref="filelock@3.13.3"/>
+      <dependency ref="platformdirs@4.2.0"/>
+    </dependency>
+    <dependency ref="watchfiles@0.21.0">
+      <dependency ref="anyio@4.3.0"/>
+    </dependency>
+    <dependency ref="wrapt@1.16.0"/>
+    <dependency ref="yarl@1.9.4">
+      <dependency ref="idna@3.6"/>
+      <dependency ref="multidict@6.0.5"/>
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_regression-issue702_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_regression-issue702_lock20_1.6.json.bin
@@ -1,0 +1,13822 @@
+{
+  "components": [
+    {
+      "bom-ref": "aiohttp@3.9.3",
+      "description": "Async http client/server framework (asyncio)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "939677b61f9d72a4fa2a042a5eee2a99a24001a67c13da113b2e30396567db54"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f5cd333fcf7590a18334c90f8c9147c837a6ec8a178e88d90a9b96ea03194cc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "82e6aa28dd46374f72093eda8bcd142f7771ee1eb9d1e223ff0fa7177a96b4a5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f56455b0c2c7cc3b0c584815264461d07b177f903a04481dfc33e08a89f0c26b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bca77a198bb6e69795ef2f09a5f4c12758487f83f33d63acde5f0d4919815768"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e083c285857b78ee21a96ba1eb1b5339733c3563f72980728ca2b08b53826ca5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ab40e6251c3873d86ea9b30a1ac6d7478c09277b32e14745d0d3c6e76e3c7e29"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "df822ee7feaaeffb99c1a9e5e608800bd8eda6e5f18f5cfb0dc7eeb2eaa6bbec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "acef0899fea7492145d2bbaaaec7b345c87753168589cc7faf0afec9afe9b747"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd73265a9e5ea618014802ab01babf1940cecb90c9762d8b9e7d2cc1e1969ec6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a78ed8a53a1221393d9637c01870248a6f4ea5b214a59a92a36f18151739452c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b0e029353361f1746bac2e4cc19b32f972ec03f0f943b390c4ab3371840aabf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7cf5c9458e1e90e3c390c2639f1017a0379a99a94fdfad3a1fd966a2874bba52"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e59c23c52765951b69ec45ddbbc9403a8761ee6f57253250c6e1536cacc758b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "055ce4f74b82551678291473f66dc9fb9048a50d8324278751926ff0ae7715e5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b88f9386ff1ad91ace19d2a1c0225896e28815ee09fc6a8932fded8cda97c3d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c46956ed82961e31557b6857a5ca153c67e5476972e5f7190015018760938da2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "07b837ef0d2f252f96009e9b8435ec1fef68ef8b1461933253d318748ec1acdc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dad46e6f620574b3b4801c68255492e0159d1712271cc99d8bdf35f2043ec266"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5ed3e046ea7b14938112ccd53d91c1539af3e6679b222f9469981e3dac7ba1ce"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "039df344b45ae0b34ac885ab5b53940b174530d4dd8a14ed8b0e2155b9dddccb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7943c414d3a8d9235f5f15c22ace69787c140c80b718dcd57caaade95f7cd93b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84871a243359bb42c12728f04d181a389718710129b36b6aad0fc4655a7647d4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5eafe2c065df5401ba06821b9a054d9cb2848867f3c59801b5d07a0be3a380ae"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9d3c9b50f19704552f23b4eaea1fc082fdd82c63429a6506446cbd8737823da3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f033d80bc6283092613882dfe40419c6a6a1527e04fc69350e87a9df02bbc283"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2c895a656dd7e061b2fd6bb77d971cc38f2afc277229ce7dd3552de8313a483e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f5a71d25cd8106eab05f8704cd9167b6e5187bcdf8f090a66c6d88b634802b4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "50fca156d718f8ced687a373f9e140c1bb765ca16e3d6f4fe116e3df7c05b2c5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5fe9ce6c09668063b8447f85d43b8d1c4e5d3d7e92c63173e6180b2ac5d46dd8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "38a19bc3b686ad55804ae931012f78f7a534cce165d089a2059f658f6c91fa60"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "770d015888c2a598b377bd2f663adfd947d78c0124cfe7b959e1ef39f5b13869"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ee43080e75fc92bf36219926c8e6de497f9b247301bbf88c5c7593d931426679"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "52df73f14ed99cee84865b95a3d9e044f226320a87af208f068ecc33e0c35b96"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dc9b311743a78043b26ffaeeb9715dc360335e5517832f5a8e339f8a43581e4d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b955ed993491f1a5da7f92e98d5dad3c1e14dc175f74517c4e610b1f2456fb11"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "504b6981675ace64c28bf4a05a508af5cde526e36492c98916127f5a02354d53"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a6fe5571784af92b6bc2fda8d1925cccdf24642d49546d3144948a6a1ed58ca5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ba39e9c8627edc56544c8628cc180d88605df3892beeb2b94c9bc857774848ca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e5e46b578c0e9db71d04c4b506a2121c0cb371dd89af17a0586ff6769d4c58c1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "938a9653e1e0c592053f815f7028e41a3062e902095e5a7dc84617c87267ebd5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c3452ea726c76e92f3b9fae4b34a151981a9ec0a4847a627c43d71a15ac32aa6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ff30218887e62209942f91ac1be902cc80cddb86bf00fbc6783b7a43b2bea26f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "38f307b41e0bea3294a9a2a87833191e4bcf89bb0365e83a8be3a58b31fb7f38"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b791a3143681a520c0a17e26ae7465f1b6f99461a28019d1a2f425236e6eedb5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0ed621426d961df79aa3b963ac7af0d40392956ffa9be022024cd16297b30c8c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7f46acd6a194287b7e41e87957bfe2ad1ad88318d447caf5b090012f2c5bb528"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "feeb18a801aacb098220e2c3eea59a512362eb408d4afd0c242044c33ad6d542"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f734e38fd8666f53da904c52a23ce517f1b07722118d750405af7e4123933511"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b40670ec7e2156d8e57f70aec34a7216407848dfe6c693ef131ddf6e76feb672"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fdd215b7b7fd4a53994f238d0f46b7ba4ac4c0adb12452beee724ddd0743ae5d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "017a21b0df49039c8f46ca0971b3a7fdc1f56741ab1240cb90ca408049766168"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e99abf0bba688259a496f966211c49a514e65afa9b3073a1fcee08856e04425b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "648056db9a9fa565d3fa851880f99f45e3f9a771dd3ff3bb0c048ea83fb28194"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8aacb477dc26797ee089721536a292a664846489c49d3ef9725f992449eda5a8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "522a11c934ea660ff8953eda090dcd2154d367dec1ae3c540aff9f8a5c109ab4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5bce0dc147ca85caa5d33debc4f4d65e8e8b5c97c7f9f660f215fa74fc49a321"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b4af9f25b49a7be47c0972139e59ec0e8285c371049df1a63b6ca81fdd216a2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "298abd678033b8571995650ccee753d9458dfa0377be4dba91e4491da3f2be63"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "69361bfdca5468c0488d7017b9b1e5ce769d40b46a9f4a2eed26b78619e9396c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0fa43c32d1643f518491d9d3a730f85f5bbaedcbd7fbcae27435bb8b7a061b29"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "835a55b7ca49468aaaac0b217092dfdff370e6c215c9224c52f30daaa735c1c1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "06a9b2c8837d9a94fae16c6223acc14b4dfdff216ab9b7202e07a9a09541168f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "abf151955990d23f84205286938796c55ff11bbfb4ccfada8c9c83ae6b3c89a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "59c26c95975f26e662ca78fdf543d4eeaef70e533a672b4113dd888bd2423caa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f95511dd5d0e05fd9728bac4096319f80615aaef4acbecb35a990afebe953b0e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "595f105710293e76b9dc09f52e0dd896bd064a79346234b521f6b968ffdd8e58"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c7c8b816c2b5af5c8a436df44ca08258fc1a13b449393a91484225fcb7545533"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f1088fa100bf46e7b398ffd9904f4808a0612e1d966b4aa43baa535d1b6341eb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f59dfe57bb1ec82ac0698ebfcdb7bcd0e99c255bd637ff613760d5f33e7c81b3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "361a1026c9dd4aba0109e4040e2aecf9884f5cfe1b1b1bd3d09419c205e2e53d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "363afe77cfcbe3a36353d8ea133e904b108feea505aa4792dad6585a8192c55a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8e2c45c208c62e955e8256949eb225bd8b66a4c9b6865729a786f2aa79b72e9d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f7217af2e14da0856e082e96ff637f14ae45c10a5714b63c77f26d8884cf1051"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27468897f628c627230dba07ec65dc8d0db566923c48f29e084ce382119802bc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "90842933e5d1ff760fae6caca4b2b3edba53ba8f4b71e95dacf2818a2aca06f7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp/#aiohttp-3.9.3.tar.gz"
+        }
+      ],
+      "name": "aiohttp",
+      "purl": "pkg:pypi/aiohttp@3.9.3",
+      "type": "library",
+      "version": "3.9.3"
+    },
+    {
+      "bom-ref": "aiohttp-cors@0.7.0",
+      "description": "CORS support for aiohttp",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d39c6d7100fd9764ed1caf8cebf0eb01bf5e3f24e2e073fda6234bc48b19f5d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp-cors/#aiohttp-cors-0.7.0.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0451ba59fdf6909d0e2cd21e4c0a43752bc0703d33fc78ae94d9d9321710193e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiohttp-cors/#aiohttp_cors-0.7.0-py3-none-any.whl"
+        }
+      ],
+      "name": "aiohttp-cors",
+      "purl": "pkg:pypi/aiohttp-cors@0.7.0",
+      "type": "library",
+      "version": "0.7.0"
+    },
+    {
+      "bom-ref": "aiosignal@1.3.1",
+      "description": "aiosignal: a list of registered asynchronous callbacks",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f8376fb07dd1e86a584e4fcdec80b36b7f81aac666ebc724e2c090300dd83b17"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiosignal/#aiosignal-1.3.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54cd96e15e1649b75d6c87526a6ff0b6c1b0dd3459f43d9ca11d48c339b68cfc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/aiosignal/#aiosignal-1.3.1.tar.gz"
+        }
+      ],
+      "name": "aiosignal",
+      "purl": "pkg:pypi/aiosignal@1.3.1",
+      "type": "library",
+      "version": "1.3.1"
+    },
+    {
+      "bom-ref": "annotated-types@0.6.0",
+      "description": "Reusable constraint types to use with typing.Annotated",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0641064de18ba7a25dee8f96403ebc39113d0cb953a01429249d5c7564666a43"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/annotated-types/#annotated_types-0.6.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "563339e807e53ffd9c267e99fc6d9ea23eb8443c08f112651963e24e22f84a5d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/annotated-types/#annotated_types-0.6.0.tar.gz"
+        }
+      ],
+      "name": "annotated-types",
+      "purl": "pkg:pypi/annotated-types@0.6.0",
+      "type": "library",
+      "version": "0.6.0"
+    },
+    {
+      "bom-ref": "anyio@4.3.0",
+      "description": "High level compatibility layer for multiple asynchronous event loop implementations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/anyio/#anyio-4.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/anyio/#anyio-4.3.0.tar.gz"
+        }
+      ],
+      "name": "anyio",
+      "purl": "pkg:pypi/anyio@4.3.0",
+      "type": "library",
+      "version": "4.3.0"
+    },
+    {
+      "bom-ref": "async-timeout@4.0.3",
+      "description": "Timeout context manager for asyncio programs",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/async-timeout/#async-timeout-4.0.3.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/async-timeout/#async_timeout-4.0.3-py3-none-any.whl"
+        }
+      ],
+      "name": "async-timeout",
+      "purl": "pkg:pypi/async-timeout@4.0.3",
+      "type": "library",
+      "version": "4.0.3"
+    },
+    {
+      "bom-ref": "attrs@23.2.0",
+      "description": "Classes Without Boilerplate",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/#attrs-23.2.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/#attrs-23.2.0.tar.gz"
+        }
+      ],
+      "name": "attrs",
+      "purl": "pkg:pypi/attrs@23.2.0",
+      "type": "library",
+      "version": "23.2.0"
+    },
+    {
+      "bom-ref": "cachetools@5.3.3",
+      "description": "Extensible memoizing collections and decorators",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0abad1021d3f8325b2fc1d2e9c8b9c9d57b04c3932657a72465447332c24d945"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/cachetools/#cachetools-5.3.3-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ba29e2dfa0b8b556606f097407ed1aa62080ee108ab0dc5ec9d6a723a007d105"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/cachetools/#cachetools-5.3.3.tar.gz"
+        }
+      ],
+      "name": "cachetools",
+      "purl": "pkg:pypi/cachetools@5.3.3",
+      "type": "library",
+      "version": "5.3.3"
+    },
+    {
+      "bom-ref": "certifi@2024.2.2",
+      "description": "Python package for providing Mozilla's CA Bundle.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/#certifi-2024.2.2-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/#certifi-2024.2.2.tar.gz"
+        }
+      ],
+      "name": "certifi",
+      "purl": "pkg:pypi/certifi@2024.2.2",
+      "type": "library",
+      "version": "2024.2.2"
+    },
+    {
+      "bom-ref": "charset-normalizer@3.3.2",
+      "description": "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset-normalizer-3.3.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2127566c664442652f024c837091890cb1942c30937add288223dc895793f898"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-py3-none-any.whl"
+        }
+      ],
+      "name": "charset-normalizer",
+      "purl": "pkg:pypi/charset-normalizer@3.3.2",
+      "type": "library",
+      "version": "3.3.2"
+    },
+    {
+      "bom-ref": "click@8.1.7",
+      "description": "Composable command line interface toolkit",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/click/#click-8.1.7-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/click/#click-8.1.7.tar.gz"
+        }
+      ],
+      "name": "click",
+      "purl": "pkg:pypi/click@8.1.7",
+      "type": "library",
+      "version": "8.1.7"
+    },
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "colorful@0.5.6",
+      "description": "Terminal string styling done right, in Python.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eab8c1c809f5025ad2b5238a50bd691e26850da8cac8f90d660ede6ea1af9f1e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorful/#colorful-0.5.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b56d5c01db1dac4898308ea889edcb113fbee3e6ec5df4bacffd61d5241b5b8d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorful/#colorful-0.5.6.tar.gz"
+        }
+      ],
+      "name": "colorful",
+      "purl": "pkg:pypi/colorful@0.5.6",
+      "type": "library",
+      "version": "0.5.6"
+    },
+    {
+      "bom-ref": "distlib@0.3.8",
+      "description": "Distribution utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/distlib/#distlib-0.3.8-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/distlib/#distlib-0.3.8.tar.gz"
+        }
+      ],
+      "name": "distlib",
+      "purl": "pkg:pypi/distlib@0.3.8",
+      "type": "library",
+      "version": "0.3.8"
+    },
+    {
+      "bom-ref": "exceptiongroup@1.2.0",
+      "description": "Backport of PEP 654 (exception groups)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/exceptiongroup/#exceptiongroup-1.2.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/exceptiongroup/#exceptiongroup-1.2.0.tar.gz"
+        }
+      ],
+      "name": "exceptiongroup",
+      "purl": "pkg:pypi/exceptiongroup@1.2.0",
+      "type": "library",
+      "version": "1.2.0"
+    },
+    {
+      "bom-ref": "fastapi@0.110.0",
+      "description": "FastAPI framework, high performance, easy to learn, fast to code, ready for production",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "87a1f6fb632a218222c5984be540055346a8f5d8a68e8f6fb647b1dc9934de4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fastapi/#fastapi-0.110.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "266775f0dcc95af9d3ef39bad55cff525329a931d5fd51930aadd4f428bf7ff3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fastapi/#fastapi-0.110.0.tar.gz"
+        }
+      ],
+      "name": "fastapi",
+      "purl": "pkg:pypi/fastapi@0.110.0",
+      "type": "library",
+      "version": "0.110.0"
+    },
+    {
+      "bom-ref": "filelock@3.13.3",
+      "description": "A platform independent file lock.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5ffa845303983e7a0b7ae17636509bc97997d58afeafa72fb141a17b152284cb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/filelock/#filelock-3.13.3-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a79895a25bbefdf55d1a2a0a80968f7dbb28edcd6d4234a0afb3f37ecde4b546"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/filelock/#filelock-3.13.3.tar.gz"
+        }
+      ],
+      "name": "filelock",
+      "purl": "pkg:pypi/filelock@3.13.3",
+      "type": "library",
+      "version": "3.13.3"
+    },
+    {
+      "bom-ref": "frozenlist@1.4.1",
+      "description": "A list-like structure which implements collections.abc.MutableSequence",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f9aa1878d1083b276b0196f2dfbe00c9b7e752475ed3b682025ff20c1c1f51ac"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "29acab3f66f0f24674b7dc4736477bcd4bc3ad4b896f5f45379a67bce8b96868"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "74fb4bee6880b529a0c6560885fce4dc95936920f9f20f53d99a213f7bf66776"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "590344787a90ae57d62511dd7c736ed56b428f04cd8c161fcc5e7232c130c69a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "068b63f23b17df8569b7fdca5517edef76171cf3897eb68beb01341131fbd2ad"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c849d495bf5154cd8da18a9eb15db127d4dba2968d88831aff6f0331ea9bd4c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9750cc7fe1ae3b1611bb8cfc3f9ec11d532244235d75901fb6b8e42ce9229dfe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a9b2de4cf0cdd5bd2dee4c4f63a653c61d2408055ab77b151c1957f221cabf2a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0633c8d5337cb5c77acbccc6357ac49a1770b8c487e5b3505c57b949b4b82e98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27657df69e8801be6c3638054e202a135c7f299267f1a55ed3a598934f6c0d75"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f9a3ea26252bd92f570600098783d1371354d89d5f6b7dfd87359d669f2109b5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f57dab5fe3407b6c0c1cc907ac98e8a189f9e418f3b6e54d65a718aaafe3950"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e02a0e11cf6597299b9f3bbd3f93d79217cb90cfd1411aec33848b13f5c656cc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a828c57f00f729620a442881cc60e57cfcec6842ba38e1b19fd3e47ac0ff8dc1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f56e2333dda1fe0f909e7cc59f021eba0d2307bc6f012a1ccf2beca6ba362439"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a0cb6f11204443f27a1628b0e460f37fb30f624be6051d490fa7d7e26d4af3d0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b46c8ae3a8f1f41a0d2ef350c0b6e65822d80772fe46b653ab6b6274f61d4a49"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fde5bd59ab5357e3853313127f4d3565fc7dad314a74d7b5d43c22c6a5ed2ced"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "722e1124aec435320ae01ee3ac7bec11a5d47f25d0ed6328f2273d287bc3abb0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2471c201b70d58a0f0c1f91261542a03d9a5e088ed3dc6c160d614c01649c106"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c757a9dd70d72b076d6f68efdbb9bc943665ae954dad2801b874c8c69e185068"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f146e0911cb2f1da549fc58fc7bcd2b836a44b79ef871980d605ec392ff6b0d2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f9c515e7914626b2a2e1e311794b4c35720a0be87af52b79ff8e1429fc25f19"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c302220494f5c1ebeb0912ea782bcd5e2f8308037b3c7553fad0e48ebad6ad82"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "442acde1e068288a4ba7acfe05f5f343e19fac87bfc96d89eb886b0363e977ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b280e6507ea8a4fa0c0a7150b4e526a8d113989e28eaaef946cc77ffd7efc0a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fe1a06da377e3a1062ae5fe0926e12b84eceb8a50b350ddca72dc85015873f74"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "db9e724bebd621d9beca794f2a4ff1d26eed5965b004a97f1f1685a173b869c2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e774d53b1a477a67838a904131c4b0eef6b3d8a651f8b138b04f748fccfefe17"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fb3c2db03683b5767dedb5769b8a40ebb47d6f7f45b1b3e3b4b51ec8ad9d9825"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1979bc0aeb89b33b588c51c54ab0161791149f2461ea7c7c946d95d5f93b56ae"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cc7b01b3754ea68a62bd77ce6020afaffb44a590c2289089289363472d13aedb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c9c92be9fd329ac801cc420e08452b70e7aeab94ea4233a4804f0915c14eba9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c3894db91f5a489fc8fa6a9991820f368f0b3cbdb9cd8849547ccfab3392d86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ba60bb19387e13597fb059f32cd4d59445d7b18b69a745b8f8e5db0346f33480"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8aefbba5f69d42246543407ed2461db31006b0f76c4e32dfd6f42215a2c41d09"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "780d3a35680ced9ce682fbcf4cb9c2bad3136eeff760ab33707b71db84664e3a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9acbb16f06fe7f52f441bb6f413ebae6c37baa6ef9edd49cdd567216da8600cd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "23b701e65c7b36e4bf15546a89279bd4d8675faabc287d06bbcfac7d3c33e1e6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e0153a805a98f5ada7e09826255ba99fb4f7524bb81bf6b47fb702666484ae1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dd9b1baec094d91bf36ec729445f7769d0d0cf6b64d04d86e45baf89e2b9059b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1a4471094e146b6790f61b98616ab8e44f72661879cc63fa1049d13ef711e71e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5667ed53d68d91920defdf4035d1cdaa3c3121dc0b113255124bcfada1cfa1b8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "beee944ae828747fd7cb216a70f120767fc9f4f00bacae8543c14a6831673f89"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "64536573d0a2cb6e625cf309984e2d873979709f2cf22839bf2d61790b448ad5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "20b51fa3f588ff2fe658663db52a41a4f7aa6c04f6201449c6c7c476bd255c0d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "410478a0c562d1a5bcc2f7ea448359fcb050ed48b3c6f6f4f18c313a9bdb1826"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c6321c9efe29975232da3bd0af0ad216800a47e93d763ce64f291917a381b8eb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48f6a4533887e189dae092f1cf981f2e3885175f7a0f33c91fb5b7b682b6bab6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6eb73fa5426ea69ee0e012fb59cdc76a15b1283d6e32e4f8dc4482ec67d1194d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fbeb989b5cc29e8daf7f976b421c220f1b8c731cbf22b9130d8815418ea45887"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "32453c1de775c889eb4e22f1197fe3bdfe457d16476ea407472b9442e6295f7a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "693945278a31f2086d9bf3df0fe8254bbeaef1fe71e1351c3bd730aa7d31c41b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1d0ce09d36d53bbbe566fe296965b23b961764c0bcf3ce2fa45f463745c04701"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a670dc61eb0d0eb7080890c13de3066790f9049b47b0de04007090807c776b0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dca69045298ce5c11fd539682cff879cc1e664c245d1c64da929813e54241d11"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a06339f38e9ed3a64e4c4e43aec7f59084033647f908e4259d279a52d3757d09"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b7f2f9f912dca3934c1baec2e4585a674ef16fe00218d833856408c48d5beee7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7004be74cbb7d9f34553a5ce5fb08be14fb33bc86f332fb71cbe5216362a497"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5a7d70357e7cee13f470c7883a063aae5fe209a493c57d86eb7f5a6f910fae09"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bfa4a17e17ce9abf47a74ae02f32d014c5e9404b6d9ac7f729e01562bbee601e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b7e3ed87d4138356775346e6845cccbe66cd9e207f3cd11d2f0b9fd13681359d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c99169d4ff810155ca50b4da3b075cbde79752443117d89429595c2e8e37fed8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "edb678da49d9f72c9f6c609fbe41a5dfb9a9282f9e6a2253d5a91e0fc382d7c0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6db4667b187a6742b33afbbaf05a7bc551ffcf1ced0000a571aedbb4aa42fc7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "55fdc093b5a3cb41d420884cdaf37a1e74c3c37a31f46e66286d9145d2063bd0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "82e8211d69a4f4bc360ea22cd6555f8e61a1bd211d1d5d39d3d228b48c83a897"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "89aa2c2eeb20957be2d950b85974b30a01a762f3308cd02bb15e1ad632e22dc7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9d3e0c25a2350080e9319724dede4f31f43a6c9779be48021a7f4ebde8b2d742"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7268252af60904bf52c26173cbadc3a071cece75f873705419c8681f24d3edea"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0c250a29735d4f15321007fb02865f0e6b6a41a6b88f1f523ca1596ab5f50bd5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "96ec70beabbd3b10e8bfe52616a13561e58fe84c0101dd031dc78f250d5128b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "23b2d7679b73fe0e5a4560b672a39f98dfc6f60df63823b0a9970525325b95f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a7496bfe1da7fb1a4e1cc23bb67c58fab69311cc7d32b5a99c2007b4b2a0e932"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e6a20a581f9ce92d389a8c7d7c3dd47c81fd5d6e655c8dddf341e14aa48659d0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "04ced3e6a46b4cfffe20f9ae482818e34eba9b5fb0ce4056e4cc9b6e212d09b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c037a86e8513059a2613aaba4d817bb90b9d9b6b69aace3ce9c877e8c8ed402b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/frozenlist/#frozenlist-1.4.1.tar.gz"
+        }
+      ],
+      "name": "frozenlist",
+      "purl": "pkg:pypi/frozenlist@1.4.1",
+      "type": "library",
+      "version": "1.4.1"
+    },
+    {
+      "bom-ref": "google-api-core@2.8.0",
+      "description": "Google API client core library",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "065bb8e11c605fd232707ae50963dc1c8af5b3c95b4568887515985e6c1156b3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/google-api-core/#google-api-core-2.8.0.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b9f59236ce1bae9a687c1d4f22957e79a2669e53d032893f6bf0fca54f6931d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/google-api-core/#google_api_core-2.8.0-py3-none-any.whl"
+        }
+      ],
+      "name": "google-api-core",
+      "purl": "pkg:pypi/google-api-core@2.8.0",
+      "type": "library",
+      "version": "2.8.0"
+    },
+    {
+      "bom-ref": "google-auth@2.29.0",
+      "description": "Google Authentication Library",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "672dff332d073227550ffc7457868ac4218d6c500b155fe6cc17d2b13602c360"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/google-auth/#google-auth-2.29.0.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d452ad095688cd52bae0ad6fafe027f6a6d6f560e810fec20914e17a09526415"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/google-auth/#google_auth-2.29.0-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "google-auth",
+      "purl": "pkg:pypi/google-auth@2.29.0",
+      "type": "library",
+      "version": "2.29.0"
+    },
+    {
+      "bom-ref": "googleapis-common-protos@1.56.1",
+      "description": "Common protobufs used in Google APIs",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b5ee59dc646eb61a8eb65ee1db186d3df6687c8804830024f32573298bca19b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/googleapis-common-protos/#googleapis-common-protos-1.56.1.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ddcd955b5bb6589368f659fa475373faa1ed7d09cde5ba25e88513d87007e174"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/googleapis-common-protos/#googleapis_common_protos-1.56.1-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "googleapis-common-protos",
+      "purl": "pkg:pypi/googleapis-common-protos@1.56.1",
+      "type": "library",
+      "version": "1.56.1"
+    },
+    {
+      "bom-ref": "grpcio@1.62.1",
+      "description": "HTTP/2-based RPC framework",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "179bee6f5ed7b5f618844f760b6acf7e910988de77a4f75b95bbfaa8106f3c1e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-linux_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48611e4fa010e823ba2de8fd3f77c1322dd60cb0d180dc6630a7e157b205f7ea"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-macosx_12_0_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2a0e71b0a2158aa4bce48be9f8f9eb45cbd17c78c7443616d00abbe2a509f6d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-manylinux_2_17_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fbe80577c7880911d3ad65e5ecc997416c98f354efeba2f8d0f9112a67ed65a5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "58f6c693d446964e3292425e1d16e21a97a48ba9172f2d0df9d7b640acb99243"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "77c339403db5a20ef4fed02e4d1a9a3d9866bf9c0afc77a42234677313ea22f3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b5a4ea906db7dec694098435d84bf2854fe158eb3cd51e1107e571246d4d1d70"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4187201a53f8561c015bc745b81a1b2d278967b8de35f3399b84b0695e281d5f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "844d1f3fb11bd1ed362d3fdc495d0770cfab75761836193af166fee113421d66"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "833379943d1728a005e44103f17ecd73d058d37d95783eb8f0b28ddc1f54d7b2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-linux_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c7fcc6a32e7b7b58f5a7d27530669337a5d587d4066060bcb9dee7a8c833dfb7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-macosx_10_10_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fa7d28eb4d50b7cbe75bb8b45ed0da9a1dc5b219a0af59449676a29c2eed9698"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-manylinux_2_17_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48f7135c3de2f298b833be8b4ae20cafe37091634e91f61f5a7eb3d61ec6f660"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "71f11fd63365ade276c9d4a7b7df5c136f9030e3457107e1791b3737a9b9ed6a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b49fd8fe9f9ac23b78437da94c54aa7e9996fbb220bac024a67469ce5d0825f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "482ae2ae78679ba9ed5752099b32e5fe580443b4f798e1b71df412abf43375db"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1faa02530b6c7426404372515fe5ddf66e199c2ee613f88f025c6f3bd816450c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5bd90b8c395f39bc82a5fb32a0173e220e3f401ff697840f4003e15b96d1befc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b134d5d71b4e0837fff574c00e49176051a1c532d26c052a1e43231f252d813b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-linux_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d1f6c96573dc09d50dbcbd91dbf71d5cf97640c9427c32584010fbbd4c0e0037"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-macosx_10_10_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "359f821d4578f80f41909b9ee9b76fb249a21035a061a327f91c953493782c31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-manylinux_2_17_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a485f0c2010c696be269184bdb5ae72781344cb4e60db976c59d84dd6354fac9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b50b09b4dc01767163d67e1532f948264167cd27f49e9377e3556c3cba1268e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3227c667dccbe38f2c4d943238b887bac588d97c104815aecc62d2fd976e014b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3952b581eb121324853ce2b191dae08badb75cd493cb4e0243368aa9e61cfd41"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "83a17b303425104d6329c10eb34bba186ffa67161e63fa6cdae7776ff76df73f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6696ffe440333a19d8d128e88d440f91fb92c75a80ce4b44d55800e656a3ef1d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e3393b0823f938253370ebef033c9fd23d27f3eae8eb9a8f6264900c7ea3fb5a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-linux_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "83e7ccb85a74beaeae2634f10eb858a0ed1a63081172649ff4261f929bacfd22"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-macosx_10_10_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "882020c87999d54667a284c7ddf065b359bd00251fcd70279ac486776dbf84ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-manylinux_2_17_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a10383035e864f386fe096fed5c47d27a2bf7173c56a6e26cffaaa5a361addb1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "960edebedc6b9ada1ef58e1c71156f28689978188cd8cff3b646b57288a927d9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "23e2e04b83f347d0aadde0c9b616f4726c3d76db04b438fd3904b289a725267f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "978121758711916d34fe57c1f75b79cdfc73952f1481bb9583399331682d36f7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9084086190cc6d628f282e5615f987288b95457292e969b9205e45b442276407"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "22bccdd7b23c420a27fd28540fb5dcbc97dc6be105f7698cb0e7d7a420d0e362"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-linux_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8999bf1b57172dbc7c3e4bb3c732658e918f5c333b2942243f10d0d653953ba9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-macosx_10_10_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d9e52558b8b8c2f4ac05ac86344a7417ccdd2b460a59616de49eb6933b07a0bd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-manylinux_2_17_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1714e7bc935780bc3de1b3fcbc7674209adf5208ff825799d579ffd6cd0bd505"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c8842ccbd8c0e253c1f189088228f9b433f7a93b7196b9e5b6f87dba393f5d5d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f1e7b36bdff50103af95a80923bf1853f6823dd62f2d2a2524b66ed74103e49"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bba97b8e8883a8038606480d6b6772289f4c907f6ba780fa1f7b7da7dfd76f06"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a7f615270fe534548112a74e790cd9d4f5509d744dd718cd442bf016626c22e4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e6c8c8693df718c5ecbc7babb12c69a4e3677fd11de8886f05ab22d4e6b1c43b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "73db2dc1b201d20ab7083e7041946910bb991e7e9761a0394bbc3c2632326483"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-linux_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "407b26b7f7bbd4f4751dbc9767a1f0716f9fe72d3d7e96bb3ccfc4aace07c8de"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-macosx_10_10_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f8de7c8cef9261a2d0a62edf2ccea3d741a523c6b8a6477a340a1f2e417658de"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-manylinux_2_17_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9bd5c8a1af40ec305d001c60236308a67e25419003e9bb3ebfab5695a8d0b369"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "be0477cb31da67846a33b1a75c611f88bfbcd427fe17701b6317aefceee1b96f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "60dcd824df166ba266ee0cfaf35a31406cd16ef602b49f5d4dfb21f014b0dedd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "973c49086cabab773525f6077f95e5a993bfc03ba8fc32e32f2c279497780585"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "12859468e8918d3bd243d213cd6fd6ab07208195dc140763c00dfe901ce1e1b4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b7209117bbeebdfa5d898205cc55153a51285757902dd73c47de498ad4d11332"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6c455e008fa86d9e9a9d85bb76da4277c0d7d9668a3bfa70dbe86e9f3c759947"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/grpcio/#grpcio-1.62.1.tar.gz"
+        }
+      ],
+      "name": "grpcio",
+      "purl": "pkg:pypi/grpcio@1.62.1",
+      "type": "library",
+      "version": "1.62.1"
+    },
+    {
+      "bom-ref": "h11@0.14.0",
+      "description": "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/h11/#h11-0.14.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/h11/#h11-0.14.0.tar.gz"
+        }
+      ],
+      "name": "h11",
+      "purl": "pkg:pypi/h11@0.14.0",
+      "type": "library",
+      "version": "0.14.0"
+    },
+    {
+      "bom-ref": "httptools@0.6.1",
+      "description": "A collection of framework independent HTTP protocol utils.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d2f6c3c4cb1948d912538217838f6e9960bc4a521d7f9b323b3da579cd14532f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "00d5d4b68a717765b1fabfd9ca755bd12bf44105eeb806c03d1962acd9b8e563"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "639dc4f381a870c9ec860ce5c45921db50205a37cc3334e756269736ff0aac58"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e57997ac7fb7ee43140cc03664de5f268813a481dff6245e0075925adc6aa185"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0ac5a0ae3d9f4fe004318d64b8a854edd85ab76cffbf7ef5e32920faef62f142"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3f30d3ce413088a98b9db71c60a6ada2001a08945cb42dd65a9a9fe228627658"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1ed99a373e327f0107cb513b61820102ee4f3675656a37a50083eda05dc9541b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7a7ea483c1a4485c71cb5f38be9db078f8b0e8b4c4dc0210f531cdd2ddac1ef1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "85ed077c995e942b6f1b07583e4eb0a8d324d418954fc6af913d36db7c05a5a0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8b0bb634338334385351a1600a73e558ce619af390c2b38386206ac6a27fecfc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7d9ceb2c957320def533671fc9c715a80c47025139c8d1f3797477decbc6edd2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f0f8271c0a4db459f9dc807acd0eadd4839934a4b9b892f6f160e94da309837"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6a4f5ccead6d18ec072ac0b84420e95d27c1cdf5c9f1bc8fbd8daf86bd94f43d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5cceac09f164bcba55c0500a18fe3c47df29b62353198e4f37bbcc5d591172c3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "75c8022dca7935cba14741a42744eee13ba05db00b27a4b940f0d646bd4d56d0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48ed8129cd9a0d62cf4d1575fcf90fb37e3ff7d5654d3a5814eb3d55f36478c2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6f58e335a1402fb5a650e271e8c2d03cfa7cea46ae124649346d17bd30d59c90"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "93ad80d7176aa5788902f207a4e79885f0576134695dfb0fefc15b7a4648d503"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9bb68d3a085c2174c2477eb3ffe84ae9fb4fde8792edb7bcd09a1d8467e30a84"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b512aa728bc02354e5ac086ce76c3ce635b62f5fbc32ab7082b5e582d27867bb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "97662ce7fb196c785344d00d638fc9ad69e18ee4bfb4000b35a52efe5adcc949"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8e216a038d2d52ea13fdd9b9c9c7459fb80d78302b257828285eca1c773b99b3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp38-cp38-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e802e0b2378ade99cd666b5bffb8b2a7cc8f3d28988685dc300469ea8dd86cb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4bd3e488b447046e386a30f07af05f9b38d3d368d1f7b4d8f7e10af85393db97"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fe467eb086d80217b7584e61313ebadc8d187a4d95bb62031b7bab4b205c3ba3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3c3b214ce057c54675b00108ac42bacf2ab8f85c58e3f324a4e963bbc46424f4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8ae5b97f690badd2ca27cbf668494ee1b6d34cf1c464271ef7bfa9ca6b83ffaf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "405784577ba6540fa7d6ff49e37daf104e04f4b4ff2d1ac0469eaa6a20fde084"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "95fb92dd3649f9cb139e9c56604cc2d7c7bf0fc2e7c8d7fbd58f96e35eddd2a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dcbab042cc3ef272adc11220517278519adf8f53fd3056d0e68f0a6f891ba94e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0cf2372e98406efb42e93bfe10f2948e467edfd792b015f1b4ecd897903d3e8d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "678fcbae74477a17d103b7cae78b74800d795d702083867ce160fc202104d0da"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e0b281cf5a125c35f7f6722b65d8542d2e57331be573e9e88bc8b0115c4a7a81"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "95658c342529bba4e1d3d2b1a874db16c7cca435e8827422154c9da76ac4e13a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7ebaec1bf683e4bf5e9fbb49b8cc36da482033596a415b3e4ebab5a4c0d7ec5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c6e26c30455600b95d94b1b836085138e82f177351454ee841c148f93a9bad5a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/httptools/#httptools-0.6.1.tar.gz"
+        }
+      ],
+      "name": "httptools",
+      "purl": "pkg:pypi/httptools@0.6.1",
+      "type": "library",
+      "version": "0.6.1"
+    },
+    {
+      "bom-ref": "idna@3.6",
+      "description": "Internationalized Domain Names in Applications (IDNA)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/#idna-3.6-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/#idna-3.6.tar.gz"
+        }
+      ],
+      "name": "idna",
+      "purl": "pkg:pypi/idna@3.6",
+      "type": "library",
+      "version": "3.6"
+    },
+    {
+      "bom-ref": "jsonschema@4.21.1",
+      "description": "An implementation of JSON Schema validation for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7996507afae316306f9e2290407761157c6f78002dcf7419acb99822143d1c6f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema/#jsonschema-4.21.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "85727c00279f5fa6bedbe6238d2aa6403bedd8b4864ab11207d07df3cc1b2ee5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema/#jsonschema-4.21.1.tar.gz"
+        }
+      ],
+      "name": "jsonschema",
+      "purl": "pkg:pypi/jsonschema@4.21.1",
+      "type": "library",
+      "version": "4.21.1"
+    },
+    {
+      "bom-ref": "jsonschema-specifications@2023.12.1",
+      "description": "The JSON Schema meta-schemas and vocabularies, exposed as a Registry",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "87e4fdf3a94858b8a2ba2778d9ba57d8a9cafca7c7489c46ba0d30a8bc6a9c3c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.12.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48a76787b3e70f5ed53f1160d2b81f586e4ca6d1548c5de7085d1682674764cc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.12.1.tar.gz"
+        }
+      ],
+      "name": "jsonschema-specifications",
+      "purl": "pkg:pypi/jsonschema-specifications@2023.12.1",
+      "type": "library",
+      "version": "2023.12.1"
+    },
+    {
+      "bom-ref": "msgpack@1.0.8",
+      "description": "MessagePack serializer",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "505fe3d03856ac7d215dbe005414bc28505d26f0c128906037e66d98c4e95868"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e6b7842518a63a9f17107eb176320960ec095a8ee3b4420b5f688e24bf50c53c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "376081f471a2ef24828b83a641a02c575d6103a3ad7fd7dade5486cad10ea659"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5e390971d082dba073c05dbd56322427d3280b7cc8b53484c9377adfbae67dc2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "00e073efcba9ea99db5acef3959efa45b52bc67b61b00823d2a1a6944bf45982"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "82d92c773fbc6942a7a8b520d22c11cfc8fd83bba86116bfcf962c2f5c2ecdaa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9ee32dcb8e531adae1f1ca568822e9b3a738369b3b686d1477cbc643c4a9c128"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e3aa7e51d738e0ec0afbed661261513b38b3014754c9459508399baf14ae0c9d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "69284049d07fce531c17404fcba2bb1df472bc2dcdac642ae71a2d079d950653"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "13577ec9e247f8741c84d06b9ece5f654920d8365a4b636ce0e44f15e07ec693"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e532dbd6ddfe13946de050d7474e3f5fb6ec774fbb1a188aaf469b08cf04189a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9517004e21664f2b5a5fd6333b0731b9cf0817403a941b393d89a2f1dc2bd836"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d16a786905034e7e34098634b184a7d81f91d4c3d246edc6bd7aefb2fd8ea6ad"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e2872993e209f7ed04d963e4b4fbae72d034844ec66bc4ca403329db2074377b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c330eace3dd100bdb54b5653b966de7f51c26ec4a7d4e87132d9b4f738220ba"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "83b5c044f3eff2a6534768ccfd50425939e7a8b5cf9a7261c385de1e20dcfc85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1876b0b653a808fcd50123b953af170c535027bf1d053b59790eebb0aeb38950"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dfe1f0f0ed5785c187144c46a292b8c34c1295c01da12e10ccddfc16def4448a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3528807cbbb7f315bb81959d5961855e7ba52aa60a3097151cb21956fbc7502b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e2f879ab92ce502a1e65fce390eab619774dda6a6ff719718069ac94084098ce"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "26ee97a8261e6e35885c2ecd2fd4a6d38252246f94a2aec23665a4e66d066305"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eadb9f826c138e6cf3c49d6f8de88225a3c0ab181a9b4ba792e006e5292d150e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "114be227f5213ef8b215c22dde19532f5da9652e56e8ce969bf0a26d7c419fee"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d661dc4785affa9d0edfdd1e59ec056a58b3dbb9f196fa43587f3ddac654ac7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d56fd9f1f1cdc8227d7b7918f55091349741904d9520c65f0139a9755952c9e8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0726c282d188e204281ebd8de31724b7d749adebc086873a59efb8cf7ae27df3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8db8e423192303ed77cff4dce3a4b88dbfaf43979d280181558af5e2c3c71afc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "99881222f4a8c2f641f25703963a5cefb076adffd959e0558dc9f803a52d6a58"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b5505774ea2a73a86ea176e8a9a4a7c8bf5d521050f0f6f8426afe798689243f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ef254a06bcea461e65ff0373d8a0dd1ed3aa004af48839f002a0c994a6f72d04"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e1dd7839443592d00e96db831eddb4111a2a81a46b028f0facd60a09ebbdd543"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "64d0fcd436c5683fdd7c907eeae5e2cbb5eb872fafbc03a43609d7941840995c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "74398a4cf19de42e1498368c36eed45d9528f5fd0155241e82c4082b7e16cffd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0ceea77719d45c839fd73abcb190b8390412a890df2f83fb8cf49b2a4b5c2f40"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1ab0bbcd4d1f7b6991ee7c753655b481c50084294218de69365f8f1970d4c151"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1cce488457370ffd1f953846f82323cb6b2ad2190987cd4d70b2713e17268d24"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3923a1778f7e5ef31865893fdca12a8d7dc03a44b33e2a5f3295416314c09f5d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a22e47578b30a3e199ab067a4d43d790249b3c0587d9a771921f86250c8435db"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bd739c9251d01e0279ce729e37b39d49a08c0420d3fee7f2a4968c0576678f77"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d3420522057ebab1728b21ad473aa950026d07cb09da41103f8e597dfbfaeb13"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5845fdf5e5d5b78a49b826fcdc0eb2e2aa7191980e3d2cfd2a30303a74f212e2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6a0e76621f6e1f908ae52860bdcb58e1ca85231a9b0545e64509c931dd34275a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "374a8e88ddab84b9ada695d255679fb99c53513c0a51778796fcf0944d6c789c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f3709997b228685fe53e8c433e2df9f0cdb5f4542bd5114ed17ac3c0129b0480"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f51bab98d52739c50c56658cc303f190785f9a2cd97b823357e7aeae54c8f68a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "73ee792784d48aa338bba28063e19a27e8d989344f34aad14ea6e1b9bd83f596"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f9904e24646570539a8950400602d66d2b2c492b9010ea7e965025cb71d0c86d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e75753aeda0ddc4c28dce4c32ba2f6ec30b1b02f6c0b14e547841ba5b24f753f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5dbf059fb4b7c240c873c1245ee112505be27497e90f7c6591261c7d3c3a8228"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4916727e31c28be8beaf11cf117d6f6f188dcc36daae4e851fee88646f5b6b18"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7938111ed1358f536daf311be244f34df7bf3cdedb3ed883787aca97778b28d8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "493c5c5e44b06d6c9268ce21b302c9ca055c1fd3484c25ba41d34476c76ee746"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/msgpack/#msgpack-1.0.8.tar.gz"
+        }
+      ],
+      "name": "msgpack",
+      "purl": "pkg:pypi/msgpack@1.0.8",
+      "type": "library",
+      "version": "1.0.8"
+    },
+    {
+      "bom-ref": "multidict@6.0.5",
+      "description": "multidict implementation",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "228b644ae063c10e7f324ab1ab6b548bdf6f8b47f3ec234fef1093bc2735e5f9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "896ebdcf62683551312c30e20614305f53125750803b614e9e6ce74a96232604"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "411bf8515f3be9813d06004cac41ccf7d1cd46dfe233705933dd163b60e37600"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1d147090048129ce3c453f0292e7697d333db95e52616b3793922945804a433c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "215ed703caf15f578dca76ee6f6b21b7603791ae090fbf1ef9d865571039ade5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7c6390cf87ff6234643428991b7359b5f59cc15155695deb4eda5c777d2b880f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "21fd81c4ebdb4f214161be351eb5bcf385426bf023041da2fd9e60681f3cebae"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3cc2ad10255f903656017363cd59436f2111443a76f996584d1077e43ee51182"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6939c95381e003f54cd4c5516740faba40cf5ad3eeff460c3ad1d3e0ea2549bf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "220dd781e3f7af2c2c1053da9fa96d9cf3072ca58f057f4c5adaaa1cab8fc442"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "766c8f7511df26d9f11cd3a8be623e59cca73d44643abab3f8c8c07620524e4a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fe5d7785250541f7f5019ab9cba2c71169dc7d74d0f45253f8313f436458a4ef"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c1c1496e73051918fcd4f58ff2e0f2f3066d1c76a0c6aeffd9b45d53243702cc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7afcdd1fc07befad18ec4523a782cde4e93e0a2bf71239894b8d61ee578c1319"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "99f60d34c048c5c2fabc766108c103612344c46e35d4ed9ae0673d33c8fb26e8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f285e862d2f153a70586579c15c44656f888806ed0e5b56b64489afe4a2dbfba"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "53689bb4e102200a4fafa9de9c7c3c212ab40a7ab2c8e474491914d2305f187e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "612d1156111ae11d14afaf3a0669ebf6c170dbb735e510a7438ffe2369a847fd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7be7047bd08accdb7487737631d25735c9a04327911de89ff1b26b81745bd4e3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "de170c7b4fe6859beb8926e84f7d7d6c693dfe8e27372ce3b76f01c46e489fcf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "04bde7a7b3de05732a4eb39c94574db1ec99abb56162d6c520ad26f83267de29"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "85f67aed7bb647f93e7520633d8f51d3cbc6ab96957c71272b286b2f30dc70ed"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "425bf820055005bfc8aa9a0b99ccb52cc2f4070153e34b701acc98d201693733"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d3eb1ceec286eba8220c26f3b0096cf189aea7057b6e7b7a2e60ed36b373b77f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7901c05ead4b3fb75113fb1dd33eb1253c6d3ee37ce93305acd9d38e0b5f21a4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e0e79d91e71b9867c73323a3444724d496c037e578a0e1755ae159ba14f4f3d1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "29bfeb0dff5cb5fdab2023a7a9947b3b4af63e9c47cae2a10ad58394b517fddc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e030047e85cbcedbfc073f71836d62dd5dadfbe7531cae27789ff66bc551bd5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2f4848aa3baa109e6ab81fe2006c77ed4d3cd1e0ac2c1fbddb7b1277c168788c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2faa5ae9376faba05f630d7e5e6be05be22913782b927b19d12b8145968a85ea"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "51d035609b86722963404f711db441cf7134f1889107fb171a970c9701f92e1e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cbebcd5bcaf1eaf302617c114aa67569dd3f090dd0ce8ba9e35e9985b41ac35b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2ffc42c922dbfddb4a4c3b438eb056828719f07608af27d163191cb3e3aa6cc5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ceb3b7e6a0135e092de86110c5a74e46bda4bd4fbfeeb3a3bcec79c0f861e450"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "79660376075cfd4b2c80f295528aa6beb2058fd289f4c9252f986751a4cd0496"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e4428b29611e989719874670fd152b6625500ad6c686d464e99f5aaeeaca175a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d84a5c3a5f7ce6db1f999fb9438f686bc2e09d38143f2d93d8406ed2dd6b9226"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "76c0de87358b192de7ea9649beb392f107dcad9ad27276324c24c91774ca5271"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "79a6d2ba910adb2cbafc95dad936f8b9386e77c84c35bc0add315b856d7c3abb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "92d16a3e275e38293623ebf639c471d3e03bb20b8ebb845237e0d3664914caef"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fb616be3538599e797a2017cccca78e354c767165e8858ab5116813146041a24"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "14c2976aa9038c2629efa2c148022ed5eb4cb939e15ec7aace7ca932f48f9ba6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "435a0984199d81ca178b9ae2c26ec3d49692d20ee29bc4c11a2a8d4514c67eda"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9fe7b0653ba3d9d65cbe7698cca585bf0f8c83dbbcc710db9c90f478e175f2d5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "01265f5e40f5a17f8241d52656ed27192be03bfa8764d88e8220141d1e4b3556"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "19fe01cea168585ba0f678cad6f58133db2aa14eccaf22f88e4a6dccadfad8b3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6bf7a982604375a8d49b6cc1b781c1747f243d91b81035a9b43a2126c04766f5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "107c0cdefe028703fb5dafe640a409cb146d44a6ae201e55b35a4af8e95457dd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "403c0911cd5d5791605808b942c88a8155c2592e05332d2bf78f18697a5fa15e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aeaf541ddbad8311a87dd695ed9642401131ea39ad7bc8cf3ef3967fd093b626"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e4972624066095e52b569e02b5ca97dbd7a7ddd4294bf4e7247d52635630dd83"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d946b0a9eb8aaa590df1fe082cee553ceab173e6cb5b03239716338629c50c7a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b55358304d7a73d7bdf5de62494aaf70bd33015831ffd98bc498b433dfe5b10c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a3145cb08d8625b2d3fee1b2d596a8766352979c9bffe5d7833e0503d0f0b5e5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d65f25da8e248202bd47445cec78e0025c0fe7582b23ec69c3b27a640dd7a8e3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c9bf56195c6bbd293340ea82eafd0071cb3d450c703d2c93afb89f93b8386ccc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "69db76c09796b313331bb7048229e3bee7928eb62bab5e071e9f7fcc4879caee"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fce28b3c8a81b6b36dfac9feb1de115bab619b3c13905b419ec71d03a3fc1423"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "76f067f5121dcecf0d63a67f29080b26c43c71a98b10c701b0677e4a065fbd54"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b82cc8ace10ab5bd93235dfaab2021c70637005e1ac787031f4d1da63d493c1d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5cb241881eefd96b46f89b1a056187ea8e9ba14ab88ba632e68d7a2ecb7aadf7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e8e94e6912639a02ce173341ff62cc1201232ab86b8a8fcc05572741a5dc7d93"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "09a892e4a9fb47331da06948690ae38eaa2426de97b4ccbfafbdcbe5c8f37ff8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "55205d03e8a598cfc688c71ca8ea5f66447164efff8869517f175ea632c7cb7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "37b15024f864916b4951adb95d3a80c9431299080341ab9544ed148091b53f50"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f2a1dee728b52b33eebff5072817176c172050d44d67befd681609b4746e1c2e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "edd08e6f2f1a390bf137080507e44ccc086353c8e98c657e666c017718561b89"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "60d698e8179a42ec85172d12f50b1668254628425a6bd611aba022257cac1386"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3d25f19500588cbc47dc19081d78131c32637c25804df8414463ec908631e453"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4cc0ef8b962ac7a5e62b9e826bd0cd5040e7d401bc45a6835910ed699037a461"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eca2e9d0cc5a889850e9bbd68e98314ada174ff6ccd1129500103df7a94a7a44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4a6a4f196f08c58c59e0b8ef8ec441d12aee4125a7d4f4fef000ccb22f8d7241"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0275e35209c27a3f7951e1ce7aaf93ce0d163b28948444bec61dd7badc6d3f8c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7be68734bd8c9a513f2b0cfd508802d6609da068f40dc57d4e3494cefc92929"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1d9ea7a7e779d7a3561aade7d596649fbecfa5c08a7674b11b423783217933f9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ea1456df2a27c73ce51120fa2f519f1bea2f4a03a917f4a43c8707cf4cbbae1a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf590b134eb70629e350691ecca88eac3e3b8b3c86992042fb82e3cb1830d5e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c0631926c4f58e9a5ccce555ad7747d9a9f8b10619621f22f9635f069f6233e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dce1c6912ab9ff5f179eaf6efe7365c1f425ed690b03341911bf4939ef2f3046"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c0868d64af83169e4d4152ec612637a543f7a336e4a307b119e98042e852ad9c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "141b43360bfd3bdd75f15ed811850763555a251e38b2405967f8e25fb43f7d40"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7df704ca8cf4a073334e0427ae2345323613e4df18cc224f647f251e5e75a527"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6214c5a5571802c33f80e6c84713b2c79e024995b9c5897f794b43e714daeec9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd6c8fca38178e12c00418de737aef1261576bd1b6e8c6134d3e729a4e858b38"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e02021f87a5b6932fa6ce916ca004c4d441509d33bbdbeca70d05dff5e9d2479"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ebd8d160f91a764652d3e51ce0d2956b38efe37c9231cd82cfc0bed2e40b581c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "04da1bb8c8dbadf2a18a452639771951c662c5ad03aefe4884775454be322c9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d6f6d4f185481c9669b9447bf9d9cf3b95a0e9df9d169bbc17e363b7d5487755"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0d63c74e3d7ab26de115c49bffc92cc77ed23395303d496eae515d4204a625e7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f7e301075edaf50500f0b341543c41194d8df3ae5caf4702f2095f3ca73dd8da"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/multidict/#multidict-6.0.5.tar.gz"
+        }
+      ],
+      "name": "multidict",
+      "purl": "pkg:pypi/multidict@6.0.5",
+      "type": "library",
+      "version": "6.0.5"
+    },
+    {
+      "bom-ref": "opencensus@0.11.4",
+      "description": "A stats collection and distributed tracing framework",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a18487ce68bc19900336e0ff4655c5a116daf10c1b3685ece8d971bddad6a864"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/opencensus/#opencensus-0.11.4-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/opencensus/#opencensus-0.11.4.tar.gz"
+        }
+      ],
+      "name": "opencensus",
+      "purl": "pkg:pypi/opencensus@0.11.4",
+      "type": "library",
+      "version": "0.11.4"
+    },
+    {
+      "bom-ref": "opencensus-context@0.1.3",
+      "description": "OpenCensus Runtime Context",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a03108c3c10d8c80bb5ddf5c8a1f033161fa61972a9917f9b9b3a18517f0088c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/opencensus-context/#opencensus-context-0.1.3.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "073bb0590007af276853009fac7e4bab1d523c3f03baf4cb4511ca38967c6039"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/opencensus-context/#opencensus_context-0.1.3-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "opencensus-context",
+      "purl": "pkg:pypi/opencensus-context@0.1.3",
+      "type": "library",
+      "version": "0.1.3"
+    },
+    {
+      "bom-ref": "packaging@24.0",
+      "description": "Core utilities for Python packages",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/packaging/#packaging-24.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/packaging/#packaging-24.0.tar.gz"
+        }
+      ],
+      "name": "packaging",
+      "purl": "pkg:pypi/packaging@24.0",
+      "type": "library",
+      "version": "24.0"
+    },
+    {
+      "bom-ref": "platformdirs@4.2.0",
+      "description": "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\".",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/platformdirs/#platformdirs-4.2.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/platformdirs/#platformdirs-4.2.0.tar.gz"
+        }
+      ],
+      "name": "platformdirs",
+      "purl": "pkg:pypi/platformdirs@4.2.0",
+      "type": "library",
+      "version": "4.2.0"
+    },
+    {
+      "bom-ref": "prometheus-client@0.20.0",
+      "description": "Python client for the Prometheus monitoring system.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cde524a85bce83ca359cc837f28b8c0db5cac7aa653a588fd7e84ba061c329e7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/prometheus-client/#prometheus_client-0.20.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "287629d00b147a32dcb2be0b9df905da599b2d82f80377083ec8463309a4bb89"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/prometheus-client/#prometheus_client-0.20.0.tar.gz"
+        }
+      ],
+      "name": "prometheus-client",
+      "purl": "pkg:pypi/prometheus-client@0.20.0",
+      "type": "library",
+      "version": "0.20.0"
+    },
+    {
+      "bom-ref": "protobuf@5.26.1",
+      "description": "",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3c388ea6ddfe735f8cf69e3f7dc7611e73107b60bdfcf5d0f024c3ccd3794e23"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp310-abi3-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e6039957449cb918f331d32ffafa8eb9255769c96aa0560d9a5bf0b4e00a2a33"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp310-abi3-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "38aa5f535721d5bb99861166c445c4105c4e285c765fbb2ac10f116e32dcd46d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp37-abi3-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fbfe61e7ee8c1860855696e3ac6cfd1b01af5498facc6834fcc345c9684fb2ca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp37-abi3-manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f7417703f841167e5a27d48be13389d52ad705ec09eade63dfc3180a959215d7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp37-abi3-manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d693d2504ca96750d92d9de8a103102dd648fda04540495535f0fec7577ed8fc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9b557c317ebe6836835ec4ef74ec3e994ad0894ea424314ad3552bc6e8835b4e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b9ba3ca83c2e31219ffbeb9d76b63aad35a3eb1544170c55336993d7a18ae72c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7ee014c2c87582e101d6b54260af03b6596728505c79f17c8586e7523aaa8f8c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "da612f2720c0183417194eeaa2523215c4fcc1a1949772dc65f05047e08d5932"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8ca2a1d97c290ec7b16e4e5dff2e5ae150cc1582f55b5ab300d45cb0dfa90e51"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/protobuf/#protobuf-5.26.1.tar.gz"
+        }
+      ],
+      "name": "protobuf",
+      "purl": "pkg:pypi/protobuf@5.26.1",
+      "type": "library",
+      "version": "5.26.1"
+    },
+    {
+      "bom-ref": "py-spy@0.3.14",
+      "description": "Sampling profiler for Python programs",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5b342cc5feb8d160d57a7ff308de153f6be68dcf506ad02b4d67065f2bae7f45"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fe7efe6c91f723442259d428bf1f9ddb9c1679828866b353d539345ca40d9dd2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "590905447241d789d9de36cff9f52067b6f18d8b5e9fb399242041568d414461"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fd6211fe7f587b3532ba9d300784326d9a6f2b890af7bf6fff21a029ebbc812b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e8e48032e71c94c3dd51694c39e762e4bbfec250df5bf514adcdd64e79371e0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f59b0b52e56ba9566305236375e6fc68888261d0d36b5addbe3cf85affbefc0e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8f5b311d09f3a8e33dbd0d44fc6e37b715e8e0c7efefafcda8bfd63b31ab5a31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-win_amd64.whl"
+        }
+      ],
+      "name": "py-spy",
+      "purl": "pkg:pypi/py-spy@0.3.14",
+      "type": "library",
+      "version": "0.3.14"
+    },
+    {
+      "bom-ref": "pyasn1@0.6.0",
+      "description": "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cca4bb0f2df5504f02f6f8a775b6e416ff9b0b3b16f7ee80b5a3153d9b804473"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyasn1/#pyasn1-0.6.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a35ab2c4b5ef98e17dfdec8ab074046fbda76e281c5a706ccd82328cfc8f64c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyasn1/#pyasn1-0.6.0.tar.gz"
+        }
+      ],
+      "name": "pyasn1",
+      "purl": "pkg:pypi/pyasn1@0.6.0",
+      "type": "library",
+      "version": "0.6.0"
+    },
+    {
+      "bom-ref": "pyasn1-modules@0.4.0",
+      "description": "A collection of ASN.1-based protocols modules",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "be04f15b66c206eed667e0bb5ab27e2b1855ea54a842e5037738099e8ca4ae0b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyasn1-modules/#pyasn1_modules-0.4.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "831dbcea1b177b28c9baddf4c6d1013c24c3accd14a1873fffaa6a2e905f17b6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyasn1-modules/#pyasn1_modules-0.4.0.tar.gz"
+        }
+      ],
+      "name": "pyasn1-modules",
+      "purl": "pkg:pypi/pyasn1-modules@0.4.0",
+      "type": "library",
+      "version": "0.4.0"
+    },
+    {
+      "bom-ref": "pydantic@2.6.4",
+      "description": "Data validation using Python type hints",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cc46fce86607580867bdc3361ad462bab9c222ef042d3da86f2fb333e1d916c5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic/#pydantic-2.6.4-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b1704e0847db01817624a6b86766967f552dd9dbf3afba4004409f908dcc84e6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic/#pydantic-2.6.4.tar.gz"
+        }
+      ],
+      "name": "pydantic",
+      "purl": "pkg:pypi/pydantic@2.6.4",
+      "type": "library",
+      "version": "2.6.4"
+    },
+    {
+      "bom-ref": "pydantic-core@2.16.3",
+      "description": "",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "75b81e678d1c1ede0785c7f46690621e4c6e63ccd9192af1f0bd9d504bbb6bf4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9c865a7ee6f93783bd5d781af5a4c43dadc37053a5b42f7d18dc019f8c9d2bd1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "162e498303d2b1c036b957a1278fa0899d02b2842f1ff901b6395104c5554a45"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2f583bd01bbfbff4eaee0868e6fc607efdfcc2b03c1c766b06a707abbc856187"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b926dd38db1519ed3043a4de50214e0d600d404099c3392f098a7f9d75029ff8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "716b542728d4c742353448765aa7cdaa519a7b82f9564130e2b3f6766018c9ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fc4ad7f7ee1a13d9cb49d8198cd7d7e3aa93e425f371a68235f784e99741561f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bd87f48924f360e5d1c5f770d6155ce0e7d83f7b4e10c2f9ec001c73cf475c99"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0df446663464884297c793874573549229f9eca73b59360878f382a0fc085979"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4df8a199d9f6afc5ae9a65f8f95ee52cae389a8c6b20163762bde0426275b7db"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "456855f57b413f077dff513a5a28ed838dbbb15082ba00f80750377eed23d132"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "732da3243e1b8d3eab8c6ae23ae6a58548849d2e4a4e03a1924c8ddf71a387cb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "519ae0312616026bf4cedc0fe459e982734f3ca82ee8c7246c19b650b60a5ee4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3992a322a5617ded0a9f23fd06dbc1e4bd7cf39bc4ccf344b10f80af58beacd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d62da299c6ecb04df729e4b5c52dc0d53f4f8430b4492b93aa8de1f541c4aac"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2acca2be4bb2f2147ada8cac612f8a98fc09f41c89f87add7256ad27332c2fda"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b662180108c55dfbf1280d865b2d116633d436cfc0bba82323554873967b340"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7c6ed0dc9d8e65f24f5824291550139fe6f37fac03788d4580da0d33bc00c97"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a6b1bb0827f56654b4437955555dc3aeeebeddc47c2d7ed575477f082622c49e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e56f8186d6210ac7ece503193ec84104da7ceb98f68ce18c07282fcc2452e76f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "936e5db01dd49476fa8f4383c259b8b1303d5dd5fb34c97de194560698cc2c5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "33809aebac276089b78db106ee692bdc9044710e26f24a9a2eaa35a0f9fa70ba"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ded1c35f15c9dea16ead9bffcde9bb5c7c031bff076355dc58dcb1cb436c4721"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d89ca19cdd0dd5f31606a9329e309d4fcbb3df860960acec32630297d61820df"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6162f8d2dc27ba21027f261e4fa26f8bcb3cf9784b7f9499466a311ac284b5b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-none-win_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0f56ae86b60ea987ae8bcd6654a887238fd53d1384f9b222ac457070b7ac4cff"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c9bd22a2a639e26171068f8ebb5400ce2c1bc7d17959f60a3b753ae13c632975"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4204e773b4b408062960e65468d5346bdfe139247ee5f1ca2a378983e11388a2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f651dd19363c632f4abe3480a7c87a9773be27cfe1341aef06e8759599454120"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aaf09e615a0bf98d406657e0008e4a8701b11481840be7d31755dc9f97c44053"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8e47755d8152c1ab5b55928ab422a76e2e7b22b5ed8e90a7d584268dd49e9c6b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "500960cb3a0543a724a81ba859da816e8cf01b0e6aaeedf2c3775d12ee49cade"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf6204fe865da605285c34cf1172879d0314ff267b1c35ff59de7154f35fdc2e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d33dd21f572545649f90c38c227cc8631268ba25c460b5569abebdd0ec5974ca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "49d5d58abd4b83fb8ce763be7794d09b2f50f10aa65c0f0c1696c677edeb7cbf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f53aace168a2a10582e570b7736cc5bef12cae9cf21775e3eafac597e8551fbe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0d32576b1de5a30d9a97f300cc6a3f4694c428d956adbc7e6e2f9cad279e45ed"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ec08be75bb268473677edb83ba71e7e74b43c008e4a7b1907c6d57e940bf34b6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-none-win_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b1f6f5938d63c6139860f044e2538baeee6f0b251a1816e7adb6cbce106a1f01"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2a1ef6a36fdbf71538142ed604ad19b82f67b05749512e47f247a6ddd06afdc7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "704d35ecc7e9c31d48926150afada60401c55efa3b46cd1ded5a01bdffaf1d48"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d937653a696465677ed583124b94a4b2d79f5e30b2c46115a68e482c6a591c8a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c9803edf8e29bd825f43481f19c37f50d2b01899448273b3a7758441b512acf8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "72282ad4892a9fb2da25defeac8c2e84352c108705c972db82ab121d15f14e6d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7f752826b5b8361193df55afcdf8ca6a57d0232653494ba473630a83ba50d8c9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4384a8f68ddb31a0b0c3deae88765f5868a1b9148939c3f4121233314ad5532c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a4b2bf78342c40b3dc830880106f54328928ff03e357935ad26c7128bbd66ce8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "13dcc4802961b5f843a9385fc821a0b0135e8c07fc3d9949fd49627c1a5e6ae5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e3e70c94a0c3841e6aa831edab1619ad5c511199be94d0c11ba75fe06efe107a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ecdf6bf5f578615f2e985a5e1f6572e23aa632c4bd1dc67f8f406d445ac115ed"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bda1ee3e08252b8d41fa5537413ffdddd58fa73107171a126d3b9ff001b9b820"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "21b888c973e4f26b7a96491c0965a8a312e13be108022ee510248fe379a5fa23"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "be0ec334369316fa73448cc8c982c01e5d2a81c95969d58b8f6e272884df0074"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b5b6079cc452a7c53dd378c6f881ac528246b3ac9aae0f8eef98498a75657805"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7ee8d5f878dccb6d499ba4d30d757111847b6849ae07acdd1205fffa1fc1253c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7233d65d9d651242a68801159763d09e9ec96e8a158dbf118dc090cd77a104c9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c6119dc90483a5cb50a1306adb8d52c66e447da88ea44f323e0ae1a5fcb14256"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "578114bc803a4c1ff9946d977c221e4376620a46cf78da267d946397dc9514a8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d8f99b147ff3fcf6b3cc60cb0c39ea443884d5559a30b1481e92495f2310ff2b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4ac6b4ce1e7283d715c4b729d8f9dab9627586dafce81d9eaa009dd7f25dd972"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7774b570e61cb998490c5235740d475413a1f6de823169b4cf94e2fe9e9f6b2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9091632a25b8b87b9a605ec0e61f241c456e9248bfdcf7abdf344fdb169c81cf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "36fa178aacbc277bc6b62a2c3da95226520da4f4e9e206fdf076484363895d2c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dcca5d2bf65c6fb591fff92da03f94cd4f315972f97c21975398bd4bd046854a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2a72fb9963cba4cd5793854fd12f4cfee731e86df140f59ff52a49b3552db241"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b60cc1a081f80a2105a59385b92d82278b15d80ebb3adb200542ae165cd7d183"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cbcc558401de90a746d02ef330c528f2e668c83350f045833543cd57ecead1ad"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fee427241c2d9fb7192b658190f9f5fd6dfe41e02f3c1489d2ec1e6a5ab1e04a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f4cb85f693044e0f71f394ff76c98ddc1bc0953e48c061725e540396d5c8a2e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b29eeb887aa931c2fcef5aa515d9d176d25006794610c264ddc114c053bf96fe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a425479ee40ff021f8216c9d07a6a3b54b31c8267c6e17aa88b70d7ebd0e5e5b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c5cbc703168d1b7a838668998308018a2718c2130595e8e190220238addc96f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "99b6add4c0b39a513d323d3b93bc173dac663c27b99860dd5bf491b240d26137"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "75f76ee558751746d6a38f89d60b6228fa174e5172d143886af0f85aa306fd89"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "00ee1c97b5364b84cb0bd82e9bbf645d5e2871fb8c58059d158412fee2d33d8a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "287073c66748f624be4cef893ef9174e3eb88fe0b8a78dc22e88eca4bc357ca6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ed25e1835c00a332cb10c683cd39da96a719ab1dfc08427d476bce41b92531fc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "86b3d0033580bd6bbe07590152007275bd7af95f98eaa5bd36f3da219dcd93da"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1cac689f80a3abab2d3c0048b29eea5751114054f032a941a32de4c852c59cad"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3.tar.gz"
+        }
+      ],
+      "name": "pydantic-core",
+      "purl": "pkg:pypi/pydantic-core@2.16.3",
+      "type": "library",
+      "version": "2.16.3"
+    },
+    {
+      "bom-ref": "python-dotenv@1.0.1",
+      "description": "Read key-value pairs from a .env file and set them as environment variables",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dotenv/#python-dotenv-1.0.1.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dotenv/#python_dotenv-1.0.1-py3-none-any.whl"
+        }
+      ],
+      "name": "python-dotenv",
+      "purl": "pkg:pypi/python-dotenv@1.0.1",
+      "type": "library",
+      "version": "1.0.1"
+    },
+    {
+      "bom-ref": "pyyaml@6.0.1",
+      "description": "YAML parser and emitter for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pyyaml/#PyYAML-6.0.1.tar.gz"
+        }
+      ],
+      "name": "pyyaml",
+      "purl": "pkg:pypi/pyyaml@6.0.1",
+      "type": "library",
+      "version": "6.0.1"
+    },
+    {
+      "bom-ref": "ray@2.10.0",
+      "description": "Ray provides a simple, universal API for building distributed applications.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8a174268c7b6ca9826e4884b837395b695a45c17049927965d1b4cc370184ba2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-macosx_10_15_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c193deed7e3f604cdb37047f5646cab14f4337693dd32add8bc902dfadb89f75"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a3db89d22afc7a0a976249715dd90ffe69f7692d32cb599cd1afbc38482060f7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cb74f7d2aa5a21e5f9dcb315a4f9bde822328e76ba95cd0ba370cfda098a67f4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "44ab600fe0b5a12675d0d42d564994ac4e53286217c4de1c4eb00d74ae79ef24"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8eb606b7d247213b377ccca0f8d425f9c61a48b23e9b2e4566bc75f66d797bb5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-macosx_10_15_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8eb11aec8a65946f7546d0e703158c03a85a8be27332dbbf86d9411802700e7e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5b4ec4b5707e18382685d0703ed04afd1602359a3056f6ae4b37588a0551eef3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c7d1438cba8726ec9a59c96964e007b60a0728436647f48c383228692c2f2ee0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eceecea4133e63f5d607cc9f2a4278de51eeeeef552f694895e381aae9ff8522"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fb92f2d6d4eca602dfb0d3d459a09be59668e1560ce4bd89b692892f25b1933b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-macosx_10_15_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "31aa60373fc7291752ee89a5f5ad8effec682b1f165911f38ae95fc43bc668a9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5b7d41eb04f6b67c38170edc0406dc71537eabfd6e5d4e3399a36385ff8b0194"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8a44535e6266fa09e3eb4fc9035906decfc9f3aeda86fe66b1e738a01a51939a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "77ba4120d694e7c3dc7d93a9d3cb33925827d04ad11af2d21fa0db66f227d27a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b49a8c2b40f02a56a2af2b6026c1eedd485747c6e4c2cf9ac433af6e572bdbb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-macosx_10_15_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5fe8fb8847304dd3a6e435b95af9e5436309f2b3612c63c56bf4ac8dea73f9f4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f215eb704f2cb72e984d5a85fe435b4d74808c906950176789ba2101ce739082"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "32d97e5343578a3d37ab5f30148fa193dec46a21fa21f15b6f23fe48a420831a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "917d081fc98500f244ebc0e8da836025e1e4fa52f21030b8336cb0a2c79e84e2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-win_amd64.whl"
+        }
+      ],
+      "name": "ray",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "serve"
+        }
+      ],
+      "purl": "pkg:pypi/ray@2.10.0",
+      "type": "library",
+      "version": "2.10.0"
+    },
+    {
+      "bom-ref": "referencing@0.34.0",
+      "description": "JSON Referencing + Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d53ae300ceddd3169f1ffa9caf2cb7b769e92657e4fafb23d34b93679116dfd4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/#referencing-0.34.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5773bd84ef41799a5a8ca72dc34590c041eb01bf9aa02632b4a973fb0181a844"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/#referencing-0.34.0.tar.gz"
+        }
+      ],
+      "name": "referencing",
+      "purl": "pkg:pypi/referencing@0.34.0",
+      "type": "library",
+      "version": "0.34.0"
+    },
+    {
+      "bom-ref": "requests@2.31.0",
+      "description": "Python HTTP for Humans.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/requests/#requests-2.31.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/requests/#requests-2.31.0.tar.gz"
+        }
+      ],
+      "name": "requests",
+      "purl": "pkg:pypi/requests@2.31.0",
+      "type": "library",
+      "version": "2.31.0"
+    },
+    {
+      "bom-ref": "rpds-py@0.18.0",
+      "description": "Python bindings to Rust's persistent data structures (rpds)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5b4e7d8d6c9b2e8ee2d55c90b59c707ca59bc30058269b3db7b1f8df5763557e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c463ed05f9dfb9baebef68048aed8dcdc94411e4bf3d33a39ba97e271624f8f7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "01e36a39af54a30f28b73096dd39b6802eddd04c90dbe161c1b8dbe22353189f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d62dec4976954a23d7f91f2f4530852b0c7608116c257833922a896101336c51"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dd18772815d5f008fa03d2b9a681ae38d5ae9f0e599f7dda233c439fcaa00d40"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "923d39efa3cfb7279a0327e337a7958bff00cc447fd07a25cddb0a1cc9a6d2da"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "39514da80f971362f9267c600b6d459bfbbc549cffc2cef8e47474fddc9b45b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a34d557a42aa28bd5c48a023c570219ba2593bcbbb8dc1b98d8cf5d529ab1434"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "93df1de2f7f7239dc9cc5a4a12408ee1598725036bd2dedadc14d94525192fc3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "34b18ba135c687f4dac449aa5157d36e2cbb7c03cbea4ddbd88604e076aa836e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c0b5dcf9193625afd8ecc92312d6ed78781c46ecbf39af9ad4681fc9f464af88"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c4325ff0442a12113a6379af66978c3fe562f846763287ef66bdc1d57925d337"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7223a2a5fe0d217e60a60cdae28d6949140dde9c3bcc714063c5b463065e3d66"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a96e0c6a41dcdba3a0a581bbf6c44bb863f27c541547fb4b9711fd8cf0ffad4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "30f43887bbae0d49113cbaab729a112251a940e9b274536613097ab8b4899cf6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fcb25daa9219b4cf3a0ab24b0eb9a5cc8949ed4dc72acb8fa16b7e1681aa3c58"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d68c93e381010662ab873fea609bf6c0f428b6d0bb00f2c6939782e0818d37bf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b34b7aa8b261c1dbf7720b5d6f01f38243e9b9daf7e6b8bc1fd4657000062f2c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2e6d75ab12b0bbab7215e5d40f1e5b738aa539598db27ef83b2ec46747df90e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0b8612cd233543a3781bc659c731b9d607de65890085098986dfd573fc2befe5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aec493917dd45e3c69d00a8874e7cbed844efd935595ef78a0f25f14312e33c6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "661d25cbffaf8cc42e971dd570d87cb29a665f49f4abe1f9e76be9a5182c4688"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1df3659d26f539ac74fb3b0c481cdf9d725386e3552c6fa2974f4d33d78e544b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a1ce3ba137ed54f83e56fb983a5859a27d43a40188ba798993812fed73c70836"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "69e64831e22a6b377772e7fb337533c365085b31619005802a79242fee620bc1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "998e33ad22dc7ec7e030b3df701c43630b5bc0d8fbc2267653577e3fec279afa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7f2facbd386dd60cbbf1a794181e6aa0bd429bd78bfdf775436020172e2a23f0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1d9a5be316c15ffb2b3c405c4ff14448c36b4435be062a7f578ccd8b01f0c4d8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd5bf1af8efe569654bbef5a3e0a56eca45f87cfcffab31dd8dde70da5982475"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5417558f6887e9b6b65b4527232553c139b57ec42c64570569b155262ac0754f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "56a737287efecafc16f6d067c2ea0117abadcd078d58721f967952db329a3e5c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8f03bccbd8586e9dd37219bce4d4e0d3ab492e6b3b533e973fa08a112cb2ffc9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4457a94da0d5c53dc4b3e4de1158bdab077db23c53232f37a3cb7afdb053a4e3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0ab39c1ba9023914297dd88ec3b3b3c3f33671baeb6acf82ad7ce883f6e8e157"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9d54553c1136b50fd12cc17e5b11ad07374c316df307e4cfd6441bea5fb68496"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0af039631b6de0397ab2ba16eaf2872e9f8fca391b44d3d8cac317860a700a3f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84ffab12db93b5f6bad84c712c92060a2d321b35c3c9960b43d08d0f639d60d7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "685537e07897f173abcf67258bee3c05c374fa6fff89d4c7e42fb391b0605e98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e003b002ec72c8d5a3e3da2989c7d6065b47d9eaa70cd8808b5384fbb970f4ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08f9ad53c3f31dfb4baa00da22f1e862900f45908383c062c27628754af2e88e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c0013fe6b46aa496a6749c77e00a3eb07952832ad6166bd481c74bda0dcb6d58"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e32a92116d4f2a80b629778280103d2a510a5b3f6314ceccd6e38006b5e92dcb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e541ec6f2ec456934fd279a3120f856cd0aedd209fc3852eca563f81738f6861"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bed88b9a458e354014d662d47e7a5baafd7ff81c780fd91584a10d6ec842cb73"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2644e47de560eb7bd55c20fc59f6daa04682655c58d08185a9b95c1970fa1e07"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8e8916ae4c720529e18afa0b879473049e95949bf97042e938530e072fde061d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "465a3eb5659338cf2a9243e50ad9b2296fa15061736d6e26240e713522b6235c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ea7d4a99f3b38c37eac212dbd6ec42b7a5ec51e2c74b5d3223e43c811609e65f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "67071a6171e92b6da534b8ae326505f7c18022c6f19072a81dcf40db2638767c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "41ef53e7c58aa4ef281da975f62c258950f54b76ec8e45941e93a3d1d8580594"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fdea4952db2793c4ad0bdccd27c1d8fdd1423a92f04598bc39425bcc2b8ee46e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7cd863afe7336c62ec78d7d1349a2f34c007a3cc6c2369d667c65aeec412a5b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5307def11a35f5ae4581a0b658b0af8178c65c530e94893345bebf41cc139d33"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "77f195baa60a54ef9d2de16fbbfd3ff8b04edc0c0140a761b56c267ac11aa467"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "39f5441553f1c2aed4de4377178ad8ff8f9d733723d6c66d983d75341de265ab"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9a00312dea9310d4cb7dbd7787e722d2e86a95c2db92fbd7d0155f97127bcb40"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8f2fc11e8fe034ee3c34d316d0ad8808f45bc3b9ce5857ff29d513f3ff2923a1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "586f8204935b9ec884500498ccc91aa869fc652c40c093bd9e1471fbcc25c022"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ddc2f4dfd396c7bfa18e6ce371cba60e4cf9d2e5cdb71376aa2da264605b60b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5ddcba87675b6d509139d1b521e0c8250e967e63b5909a7e8f8944d0f90ff36f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7bd339195d84439cbe5771546fe8a4e8a7a045417d8f9de9a368c434e42a721e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d7c36232a90d4755b720fbd76739d8891732b18cf240a9c645d75f00639a9024"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b0817e34942b2ca527b0e9298373e7cc75f429e8da2055607f4931fded23e20"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "99f70b740dc04d09e6b2699b675874367885217a2e9f782bdf5395632ac663b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6ef687afab047554a2d366e112dd187b62d261d49eb79b77e386f94644363294"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ad36cfb355e24f1bd37cac88c112cd7730873f20fb0bdaf8ba59eedf8216079f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "36b3ee798c58ace201289024b52788161e1ea133e4ac93fba7d49da5fec0ef9e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f8a2f084546cc59ea99fda8e070be2fd140c3092dc11524a71aa8f0f3d5a55ca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e4461d0f003a0aa9be2bdd1b798a041f177189c1a0f7619fe8c95ad08d9a45d7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8db715ebe3bb7d86d77ac1826f7d67ec11a70dbd2376b7cc214199360517b641"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "793968759cd0d96cac1e367afd70c235867831983f876a53389ad869b043c948"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "66e6a3af5a75363d2c9a48b07cb27c4ea542938b1a2e93b15a503cdfa8490795"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6ef0befbb5d79cf32d0266f5cff01545602344eda89480e1dd88aca964260b18"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1d4acf42190d449d5e89654d5c1ed3a4f17925eec71f05e2a41414689cda02d1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a5f446dd5055667aabaee78487f2b5ab72e244f9bc0b2ffebfeec79051679984"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9dbbeb27f4e70bfd9eec1be5477517365afe05a9b2c441a0b21929ee61048124"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "22806714311a69fd0af9b35b7be97c18a0fc2826e6827dbb3a8c94eac6cf7eeb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b34ae4636dfc4e76a438ab826a0d1eed2589ca7d9a1b2d5bb546978ac6485461"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8c8370641f1a7f0e0669ddccca22f1da893cef7628396431eb445d46d893e5cd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c8362467a0fdeccd47935f22c256bec5e6abe543bf0d66e3d3d57a8fb5731863"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "11a8c85ef4a07a7638180bf04fe189d12757c696eb41f310d2426895356dcf05"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b316144e85316da2723f9d8dc75bada12fa58489a527091fa1d5a612643d1a0e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf1ea2e34868f6fbf070e1af291c8180480310173de0b0c43fc38a02929fc0e3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e546e768d08ad55b20b11dbb78a745151acbd938f8f00d0cfbabe8b0199b9880"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4901165d170a5fde6f589acb90a6b33629ad1ec976d4529e769c6f3d885e3e80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "618a3d6cae6ef8ec88bb76dd80b83cfe415ad4f1d942ca2a903bf6b6ff97a2da"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ed4eb745efbff0a8e9587d22a84be94a5eb7d2d99c02dacf7bd0911713ed14dd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6c81e5f372cd0dc5dc4809553d34f832f60a46034a5f187756d9b90586c2c307"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "43fbac5f22e25bee1d482c97474f930a353542855f05c1161fd804c9dc74a09d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6d7faa6f14017c0b1e69f5e2c357b998731ea75a442ab3841c0dbbbfe902d2c4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08231ac30a842bd04daabc4d71fddd7e6d26189406d5a69535638e4dcb88fe76"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "044a3e61a7c2dafacae99d1e722cc2d4c05280790ec5a05031b3876809d89a5c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3f26b5bd1079acdb0c7a5645e350fe54d16b17bfc5e71f371c449383d3342e17"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "482103aed1dfe2f3b71a58eff35ba105289b8d862551ea576bd15479aba01f66"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1374f4129f9bcca53a1bba0bb86bf78325a0374577cf7e9e4cd046b1e6f20e24"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "635dc434ff724b178cb192c70016cc0ad25a275228f749ee0daf0eddbc8183b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bc362ee4e314870a70f4ae88772d72d877246537d9f8cb8f7eacf10884862432"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4832d7d380477521a8c1644bbab6588dfedea5e30a7d967b5fb75977c45fd77f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "42821446ee7a76f5d9f71f9e33a4fb2ffd724bb3e7f93386150b61a43115788d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.18.0.tar.gz"
+        }
+      ],
+      "name": "rpds-py",
+      "purl": "pkg:pypi/rpds-py@0.18.0",
+      "type": "library",
+      "version": "0.18.0"
+    },
+    {
+      "bom-ref": "rsa@4.9",
+      "description": "Pure-Python RSA implementation",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rsa/#rsa-4.9-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rsa/#rsa-4.9.tar.gz"
+        }
+      ],
+      "name": "rsa",
+      "purl": "pkg:pypi/rsa@4.9",
+      "type": "library",
+      "version": "4.9"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "smart-open@7.0.4",
+      "description": "Utils for streaming large files (S3, HDFS, GCS, Azure Blob Storage, gzip, bz2...)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4e98489932b3372595cddc075e6033194775165702887216b65eba760dfd8d47"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/smart-open/#smart_open-7.0.4-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "62b65852bdd1d1d516839fcb1f6bc50cd0f16e05b4ec44b52f43d38bcb838524"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/smart-open/#smart_open-7.0.4.tar.gz"
+        }
+      ],
+      "name": "smart-open",
+      "purl": "pkg:pypi/smart-open@7.0.4",
+      "type": "library",
+      "version": "7.0.4"
+    },
+    {
+      "bom-ref": "sniffio@1.3.1",
+      "description": "Sniff out which async library your code is running under",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/sniffio/#sniffio-1.3.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/sniffio/#sniffio-1.3.1.tar.gz"
+        }
+      ],
+      "name": "sniffio",
+      "purl": "pkg:pypi/sniffio@1.3.1",
+      "type": "library",
+      "version": "1.3.1"
+    },
+    {
+      "bom-ref": "starlette@0.36.3",
+      "description": "The little ASGI library that shines.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "13d429aa93a61dc40bf503e8c801db1f1bca3dc706b10ef2434a36123568f044"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/starlette/#starlette-0.36.3-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "90a671733cfb35771d8cc605e0b679d23b992f8dcfad48cc60b38cb29aeb7080"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/starlette/#starlette-0.36.3.tar.gz"
+        }
+      ],
+      "name": "starlette",
+      "purl": "pkg:pypi/starlette@0.36.3",
+      "type": "library",
+      "version": "0.36.3"
+    },
+    {
+      "bom-ref": "typing-extensions@4.10.0",
+      "description": "Backported and Experimental Type Hints for Python 3.8+",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/typing-extensions/#typing_extensions-4.10.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/typing-extensions/#typing_extensions-4.10.0.tar.gz"
+        }
+      ],
+      "name": "typing-extensions",
+      "purl": "pkg:pypi/typing-extensions@4.10.0",
+      "type": "library",
+      "version": "4.10.0"
+    },
+    {
+      "bom-ref": "urllib3@2.2.1",
+      "description": "HTTP library with thread-safe connection pooling, file post, and more.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/urllib3/#urllib3-2.2.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/urllib3/#urllib3-2.2.1.tar.gz"
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3@2.2.1",
+      "type": "library",
+      "version": "2.2.1"
+    },
+    {
+      "bom-ref": "uvicorn@0.29.0",
+      "description": "The lightning-fast ASGI server.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2c2aac7ff4f4365c206fd773a39bf4ebd1047c238f8b8268ad996829323473de"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvicorn/#uvicorn-0.29.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6a69214c0b6a087462412670b3ef21224fa48cae0e452b5883e8e8bdfdd11dd0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvicorn/#uvicorn-0.29.0.tar.gz"
+        }
+      ],
+      "name": "uvicorn",
+      "properties": [
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "standard"
+        }
+      ],
+      "purl": "pkg:pypi/uvicorn@0.29.0",
+      "type": "library",
+      "version": "0.29.0"
+    },
+    {
+      "bom-ref": "uvloop@0.19.0",
+      "description": "Fast implementation of asyncio event loop on top of libuv",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "de4313d7f575474c8f5a12e163f6d89c0a878bc49219641d49e6f1444369a90e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5588bd21cf1fcf06bded085f37e43ce0e00424197e7c10e77afd4bbefffef428"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7b1fd71c3843327f3bbc3237bedcdb6504fd50368ab3e04d0410e52ec293f5b8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5a05128d315e2912791de6088c34136bfcdd0c7cbc1cf85fd6fd1bb321b7c849"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd81bdc2b8219cb4b2556eea39d2e36bfa375a2dd021404f90a62e44efaaf957"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5f17766fb6da94135526273080f3455a112f82570b2ee5daa64d682387fe0dcd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4ce6b0af8f2729a02a5d1575feacb2a94fc7b2e983868b009d51c9a9d2149bef"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "31e672bb38b45abc4f26e273be83b72a0d28d074d5b370fc4dcf4c4eb15417d2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "570fc0ed613883d8d30ee40397b79207eedd2624891692471808a95069a007c1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5138821e40b0c3e6c9478643b4660bd44372ae1e16a322b8fc07478f92684e24"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "91ab01c6cd00e39cde50173ba4ec68a1e578fee9279ba64f5221810a9e786533"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "47bf3e9312f63684efe283f7342afb414eea4d3011542155c7e625cd799c3b12"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "da8435a3bd498419ee8c13c34b89b5005130a476bda1d6ca8cfdde3de35cd650"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "02506dc23a5d90e04d4f65c7791e65cf44bd91b37f24cfc3ef6cf2aff05dc7ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2693049be9d36fef81741fddb3f441673ba12a34a704e7b4361efb75cf30befc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7010271303961c6f0fe37731004335401eb9075a12680738731e9c92ddd96ad6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5daa304d2161d2918fa9a17d5635099a2f78ae5b5960e742b2fcfbb7aefaa593"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7207272c9520203fea9b93843bb775d03e1cf88a80a936ce760f60bb5add92f3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "78ab247f0b5671cc887c31d33f9b3abfb88d2614b84e4303f1a63b46c046c8bd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp38-cp38-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "472d61143059c84947aa8bb74eabbace30d577a03a1805b77933d6bd13ddebbd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "45bf4c24c19fb8a50902ae37c5de50da81de4922af65baf760f7c0c42e1088be"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "271718e26b3e17906b28b67314c45d19106112067205119dddbd834c2b7ce797"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "34175c9fd2a4bc3adc1380e1261f60306344e3407c20a4d684fd5f3be010fa3d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e27f100e1ff17f6feeb1f33968bc185bf8ce41ca557deee9d9bbbffeb72030b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "13dfdf492af0aa0a0edf66807d2b465607d11c4fa48f4a1fd41cbea5b18e8e8b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6e3d4e85ac060e2342ff85e90d0c04157acb210b9ce508e784a944f852a40e67"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8ca4956c9ab567d87d59d49fa3704cf29e37109ad348f2d5223c9bf761a332e7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f467a5fd23b4fc43ed86342641f3936a68ded707f4627622fa3f82a120e18256"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "492e2c32c2af3f971473bc22f086513cedfc66a130756145a931a90c3958cb17"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2df95fca285a9f5bfe730e51945ffe2fa71ccbfdde3b0da5772b4ee4f2e770d5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0246f4fd1bf2bf702e06b0d45ee91677ee5c31242f39aab4ea6fe0c51aedd0fd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uvloop/#uvloop-0.19.0.tar.gz"
+        }
+      ],
+      "name": "uvloop",
+      "purl": "pkg:pypi/uvloop@0.19.0",
+      "type": "library",
+      "version": "0.19.0"
+    },
+    {
+      "bom-ref": "virtualenv@20.25.1",
+      "description": "Virtual Python Environment builder",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961c026ac520bac5f69acb8ea063e8a4f071bcc9457b9c1f28f6b085c511583a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/virtualenv/#virtualenv-20.25.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e08e13ecdca7a0bd53798f356d5831434afa5b07b93f0abdf0797b7a06ffe197"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/virtualenv/#virtualenv-20.25.1.tar.gz"
+        }
+      ],
+      "name": "virtualenv",
+      "purl": "pkg:pypi/virtualenv@20.25.1",
+      "type": "library",
+      "version": "20.25.1"
+    },
+    {
+      "bom-ref": "watchfiles@0.21.0",
+      "description": "Simple, modern and high performance file watching and code reload in python.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27b4035013f1ea49c6c0b42d983133b136637a527e48c132d368eb19bf1ac6aa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c81818595eff6e92535ff32825f31c116f867f64ff8cdf6562cd1d6b2e1e8f3e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6c107ea3cf2bd07199d66f156e3ea756d1b84dfd43b542b2d870b77868c98c03"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0d9ac347653ebd95839a7c607608703b20bc07e577e870d824fa4801bc1cb124"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5eb86c6acb498208e7663ca22dbe68ca2cf42ab5bf1c776670a50919a56e64ab"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f564bf68404144ea6b87a78a3f910cc8de216c6b12a4cf0b27718bf4ec38d303"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3d0f32ebfaa9c6011f8454994f86108c2eb9c79b8b7de00b36d558cadcedaa3d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b6d45d9b699ecbac6c7bd8e0a2609767491540403610962968d258fd6405c17c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aff06b2cac3ef4616e26ba17a9c250c1fe9dd8a5d907d0193f84c499b1b6e6a9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d9792dff410f266051025ecfaa927078b94cc7478954b06796a9756ccc7e14a9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "214cee7f9e09150d4fb42e24919a1e74d8c9b8a9306ed1474ecaddcd5479c293"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1ad7247d79f9f55bb25ab1778fd47f32d70cf36053941f07de0b7c4e96b5d235"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "668c265d90de8ae914f860d3eeb164534ba2e836811f91fecc7050416ee70aa7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a23092a992e61c3a6a70f350a56db7197242f3490da9c87b500f389b2d01eef"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7941bbcfdded9c26b0bf720cb7e6fd803d95a55d2c14b4bd1f6a2772230c586"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "11cd0c3100e2233e9c53106265da31d574355c288e15259c0d40a4405cbae317"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d78f30cbe8b2ce770160d3c08cff01b2ae9306fe66ce899b73f0409dc1846c1b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6674b00b9756b0af620aa2a3346b01f8e2a3dc729d25617e1b89cf6af4a54eb1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fd7ac678b92b29ba630d8c842d8ad6c555abda1b9ef044d6cc092dacbfc9719d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9c873345680c1b87f1e09e0eaf8cf6c891b9851d8b4d3645e7efe2ec20a20cc7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "49f56e6ecc2503e7dbe233fa328b2be1a7797d31548e7a193237dcdf1ad0eee0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "02d91cbac553a3ad141db016e3350b03184deaafeba09b9d6439826ee594b365"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ebe684d7d26239e23d102a2bad2a358dedf18e462e8808778703427d1f584400"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4566006aa44cb0d21b8ab53baf4b9c667a0ed23efe4aaad8c227bfba0bf15cbe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c550a56bf209a3d987d5a975cdf2063b3389a5d16caf29db4bdddeae49f22078"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-none-win_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "51ddac60b96a42c15d24fbdc7a4bfcd02b5a29c047b7f8bf63d3f6f5a860949a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "511f0b034120cd1989932bf1e9081aa9fb00f1f949fbd2d9cab6264916ae89b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cfb92d49dbb95ec7a07511bc9efb0faff8fe24ef3805662b8d6808ba8409a71a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3f92944efc564867bbf841c823c8b71bb0be75e06b8ce45c084b46411475a915"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "642d66b75eda909fd1112d35c53816d59789a4b38c141a96d62f50a3ef9b3360"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d23bcd6c8eaa6324fe109d8cac01b41fe9a54b8c498af9ce464c1aeeb99903d6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "18d5b4da8cf3e41895b34e8c37d13c9ed294954907929aacd95153508d5d89d7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b8d1eae0f65441963d805f766c7e9cd092f91e0c600c820c764a4ff71a0764c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1fd9a5205139f3c6bb60d11f6072e0552f0a20b712c85f43d42342d162be1235"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a1e3014a625bcf107fbf38eece0e47fa0190e52e45dc6eee5a8265ddc6dc5ea7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9d09869f2c5a6f2d9df50ce3064b3391d3ecb6dced708ad64467b9e4f2c9bef3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "18722b50783b5e30a18a8a5db3006bab146d2b705c92eb9a94f78c72beb94094"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a3b9bec9579a15fb3ca2d9878deae789df72f2b0fdaf90ad49ee389cad5edab6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-none-win_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4ea10a29aa5de67de02256a28d1bf53d21322295cb00bd2d57fcd19b850ebd99"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "40bca549fdc929b470dd1dbfcb47b3295cb46a6d2c90e50588b0a1b3bd98f429"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9b37a7ba223b2f26122c148bb8d09a9ff312afca998c48c725ff5a0a632145f7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ec8c8900dc5c83650a63dd48c4d1d245343f904c4b64b48798c67a3767d7e165"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8ad3fe0a3567c2f0f629d800409cd528cb6251da12e81a1f765e5c5345fd0137"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9d353c4cfda586db2a176ce42c88f2fc31ec25e50212650c89fdd0f560ee507b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "83a696da8922314ff2aec02987eefb03784f473281d740bf9170181829133765"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5a03651352fc20975ee2a707cd2d74a386cd303cc688f407296064ad1e6d1562"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3ad692bc7792be8c32918c699638b660c0de078a6cbe464c46e1340dadb94c19"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "06247538e8253975bdb328e7683f8515ff5ff041f43be6c40bff62d989b7d0b0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9a0aa47f94ea9a0b39dd30850b0adf2e1cd32a8b4f9c7aa443d852aacf9ca214"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d5f400326840934e3507701f9f7269247f7c026d1b6cfd49477d2be0933cfca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7f762a1a85a12cc3484f77eee7be87b10f8c50b0b787bb02f4e357403cad0c0e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6e9be3ef84e2bb9710f3f777accce25556f4a71e15d2b73223788d528fcc2052"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4c48a10d17571d1275701e14a601e36959ffada3add8cdbc9e5061a6e3579a5d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6c889025f59884423428c261f212e04d438de865beda0b1e1babab85ef4c0f01"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "66fac0c238ab9a2e72d026b5fb91cb902c146202bbd29a9a1a44e8db7b710b6f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b4a21f71885aa2744719459951819e7bf5a906a6448a6b2bbce8e9cc9f2c8128"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1c9198c989f47898b2c22201756f73249de3748e0fc9de44adaf54a8b259cc0c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d8f57c4461cd24fda22493109c45b3980863c58a25b8bec885ca8bea6b8d4b28"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "853853cbf7bf9408b404754b92512ebe3e3a83587503d766d23e6bf83d092ee6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d5b1dc0e708fad9f92c296ab2f948af403bf201db8fb2eb4c8179db143732e49"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "59137c0c6826bd56c710d1d2bda81553b5e6b7c84d5a676747d80caf0409ad94"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6cb8fdc044909e2078c248986f2fc76f911f72b51ea4a4fbbf472e01d14faa58"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ab03a90b305d2588e8352168e8c5a1520b721d2d367f31e9332c4235b30b8994"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "927c589500f9f41e370b0125c12ac9e7d3a2fd166b89e9ee2828b3dda20bfe6f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1bd467213195e76f838caf2c28cd65e58302d0254e636e7c0fca81efa4a2e62c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "02b73130687bc3f6bb79d8a170959042eb56eb3a42df3671c79b428cd73f17cc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08dca260e85ffae975448e344834d765983237ad6dc308231aa16e7933db763e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3ccceb50c611c433145502735e0370877cced72a6c70fd2410238bcbc7fe51d8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "57d430f5fb63fea141ab71ca9c064e80de3a20b427ca2febcbfcef70ff0ce895"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0dd5fad9b9c0dd89904bbdea978ce89a2b692a7ee8a0ce19b940e538c88a809c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "be6dd5d52b73018b21adc1c5d28ac0c68184a64769052dfeb0c5d9998e7f56a2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3cab0e06143768499384a8a5efb9c4dc53e19382952859e4802f294214f36ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8c6ed10c2497e5fedadf61e465b3ca12a19f96004c15dcffe4bd442ebadc2d85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "43babacef21c519bc6631c5fce2a61eccdfc011b4bcb9047255e9620732c8097"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c76c635fabf542bb78524905718c39f736a98e5ab25b23ec6d4abede1a85a6a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/watchfiles/#watchfiles-0.21.0.tar.gz"
+        }
+      ],
+      "name": "watchfiles",
+      "purl": "pkg:pypi/watchfiles@0.21.0",
+      "type": "library",
+      "version": "0.21.0"
+    },
+    {
+      "bom-ref": "websockets@12.0",
+      "description": "An implementation of the WebSocket Protocol (RFC 6455 & 7692)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d554236b2a2006e0ce16315c16eaa0d628dab009c33b63ea03f41c6107958374"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2d225bb6886591b1746b17c0573e29804619c8f755b5598d875bb4235ea639be"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb809e816916a3b210bed3c82fb88eaf16e8afcf9c115ebb2bacede1797d2547"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c588f6abc13f78a67044c6b1273a99e1cf31038ad51815b3b016ce699f0d75c2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5aa9348186d79a5f232115ed3fa9020eab66d6c3437d72f9d2c8ac0c6858c558"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6350b14a40c95ddd53e775dbdbbbc59b124a5c8ecd6fbb09c2e52029f7a9f480"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "70ec754cc2a769bcd218ed8d7209055667b30860ffecb8633a834dde27d6307c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6e96f5ed1b83a8ddb07909b45bd94833b0710f738115751cdaa9da1fb0cb66e8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d87be612cbef86f994178d5186add3d94e9f31cc3cb499a0482b866ec477603"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "befe90632d66caaf72e8b2ed4d7f02b348913813c8b0a32fae1cc5fe3730902f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "363f57ca8bc8576195d0540c648aa58ac18cf85b76ad5202b9f976918f4219cf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5d873c7de42dea355d73f170be0f23788cf3fa9f7bed718fd2830eefedce01b4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3f61726cae9f65b872502ff3c1496abc93ffbe31b278455c418492016e2afc8f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ed2fcf7a07334c77fc8a230755c2209223a7cc44fc27597729b8ef5425aa61a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8e332c210b14b57904869ca9f9bf4ca32f5427a03eeb625da9b616c85a3a506c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5693ef74233122f8ebab026817b1b37fe25c411ecfca084b29bc7d6efc548f45"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6e9e7db18b4539a29cc5ad8c8b252738a30e2b13f033c2d6e9d0549b45841c04"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6e2df67b8014767d0f785baa98393725739287684b9f8d8a1001eb2839031447"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bea88d71630c5900690fcb03161ab18f8f244805c59e2e0dc4ffadae0a7ee0ca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dff6cdf35e31d1315790149fee351f9e52978130cef6c87c4b6c9b3baf78bc53"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e3aa8c468af01d70332a382350ee95f6986db479ce7af14d5e81ec52aa2b402"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25eb766c8ad27da0f79420b2af4b85d29914ba0edf69f547cc4f06ca6f1d403b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e6e2711d5a8e6e482cacb927a49a3d432345dfe7dea8ace7b5790df5932e4df"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dbcf72a37f0b3316e993e13ecf32f10c0e1259c28ffd0a85cee26e8549595fbc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "12743ab88ab2af1d17dd4acb4645677cb7063ef4db93abffbf164218a5d54c6b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7b645f491f3c48d3f8a00d1fce07445fab7347fec54a3e65f0725d730d5b99cb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9893d1aa45a7f8b3bc4510f6ccf8db8c3b62120917af15e3de247f0780294b92"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f38a7b376117ef7aff996e737583172bdf535932c9ca021746573bce40165ed"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f764ba54e33daf20e167915edc443b6f88956f37fb606449b4a5b10ba42235a5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e4b3f8ea6a9cfa8be8484c9221ec0257508e3a1ec43c36acdefb2a9c3b00aa2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9fdf06fd06c32205a07e47328ab49c40fc1407cdec801d698a7c41167ea45113"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "baa386875b70cbd81798fa9f71be689c1bf484f65fd6fb08d051a0ee4e79924d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ae0a5da8f35a5be197f328d4727dbcfafa53d1824fac3d96cdd3a642fe09394f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5f6ffe2c6598f7f7207eef9a1228b6f5c818f9f4d53ee920aacd35cec8110438"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9edf3fc590cc2ec20dc9d7a45108b5bbaf21c0d89f9fd3fd1685e223771dc0b2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8572132c7be52632201a35f5e08348137f658e5ffd21f51f94572ca6c05ea81d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "604428d1b87edbf02b233e2c207d7d528460fa978f9e391bd8aaf9c8311de137"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1a9d160fd080c6285e202327aba140fc9a0d910b09e423afff4ae5cbbf1c7205"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "87b4aafed34653e465eb77b7c93ef058516cb5acf3eb21e42f33928616172def"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2ee7288b85959797970114deae81ab41b731f19ebcd3bd499ae9ca0e3f1d2c8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7fa3d25e81bfe6a89718e9791128398a50dec6d57faf23770787ff441d851967"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a571f035a47212288e3b3519944f6bf4ac7bc7553243e41eac50dd48552b6df7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3c6cc1360c10c17463aadd29dd3af332d4a1adaa8796f6b0e9f9df1fdb0bad62"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1bf386089178ea69d720f8db6199a0504a406209a0fc23e603b27b300fdd6892"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ab3d732ad50a4fbd04a4490ef08acd0517b6ae6b77eb967251f4c263011a990d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a1d9697f3337a89691e3bd8dc56dea45a6f6d975f92e7d5f773bc715c15dde28"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1df2fbd2c8a98d38a66f5238484405b8d1d16f929bb7a33ed73e4801222a6f53"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "23509452b3bc38e3a057382c2e941d5ac2e01e251acce7adc74011d7d8de434c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2e5fc14ec6ea568200ea4ef46545073da81900a2b67b3e666f04adf53ad452ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "46e71dbbd12850224243f5d2aeec90f0aaa0f2dde5aeeb8fc8df21e04d99eff9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b81f90dcc6c85a9b7f29873beb56c94c85d6f0dac2ea8b60d995bd18bf3e2aae"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a02413bc474feda2849c59ed2dfb2cddb4cd3d2f03a2fedec51d6e959d9b608b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bbe6013f9f791944ed31ca08b077e26249309639313fff132bfbf3ba105673b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cbe83a6bbdf207ff0541de01e11904827540aa069293696dd528a6640bd6a5f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fc4e7fa5414512b481a2483775a8e8be7803a35b30ca805afa4998a84f9fd9e8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "248d8e2446e13c1d4326e0a6a4e9629cb13a11195051a73acf414812700badbd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f44069528d45a933997a6fef143030d8ca8042f0dfaad753e2906398290e2870"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c4e37d36f0d19f0a4413d3e18c0d03d0c268ada2061868c1e6f5ab1a6d575077"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3d829f975fc2e527a3ef2f9c8f25e553eb7bc779c6665e8e1d52aa22800bb38b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2c71bd45a777433dd9113847af751aae36e448bc6b8c361a566cb043eda6ec30"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-pp310-pypy310_pp73-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0bee75f400895aef54157b36ed6d3b308fcab62e5260703add87f44cee9c82a6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "423fc1ed29f7512fceb727e2d2aecb952c46aa34895e9ed96071821309951123"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27a5e9964ef509016759f2ef3f2c1e13f403725a5e6a1775555994966a66e931"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c3181df4583c4d3994d31fb235dc681d2aaad744fbdbf94c4802485ececdecf2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b067cb952ce8bf40115f6c19f478dc71c5e719b7fbaa511359795dfd9d1a6468"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-pp38-pypy38_pp73-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "00700340c6c7ab788f176d118775202aadea7602c5cc6be6ae127761c16d6b0b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e469d01137942849cff40517c97a30a93ae79917752b34029f0ec72df6b46399"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ffefa1374cd508d633646d51a8e9277763a9b78ae71324183693959cf94635a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ba0cab91b3956dfa9f512147860783a1829a8d905ee218a9837c18f683239611"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2cb388a5bfb56df4d9a406783b7f9dbefb888c09b71629351cc6b036e9259370"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-pp39-pypy39_pp73-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dc284bbc8d7c78a6c69e0c7325ab46ee5e40bb4d50e494d8131a07ef47500e9e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81df9cbcbb6c260de1e007e58c011bfebe2dafc8435107b0537f393dd38c8b1b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/websockets/#websockets-12.0.tar.gz"
+        }
+      ],
+      "name": "websockets",
+      "purl": "pkg:pypi/websockets@12.0",
+      "type": "library",
+      "version": "12.0"
+    },
+    {
+      "bom-ref": "wrapt@1.16.0",
+      "description": "Module for decorators, wrappers and monkey patching.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ffa565331890b90056c01db69c0fe634a776f8019c143a5ae265f9c6bc4bd6d4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e4fdb9275308292e880dcbeb12546df7f3e0f96c6b41197e0cf37d2826359020"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bb2dee3874a500de01c93d5c71415fcaef1d858370d405824783e7a8ef5db440"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2a88e6010048489cda82b1326889ec075a8c856c2e6a256072b28eaee3ccf487"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac83a914ebaf589b69f7d0a1277602ff494e21f4c2f743313414378f8f50a4cf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "73aa7d98215d39b8455f103de64391cb79dfcad601701a3aa0dddacf74911d72"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "807cc8543a477ab7422f1120a217054f958a66ef7314f76dd9e77d3f02cdccd0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bf5703fdeb350e36885f2875d853ce13172ae281c56e509f4e6eca049bdfb136"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f6b2d0c6703c988d334f297aa5df18c45e97b0af3679bb75059e0e0bd8b1069d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "decbfa2f618fa8ed81c95ee18a387ff973143c656ef800c9f24fb7e9c16054e2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1a5db485fe2de4403f13fafdc231b0dbae5eca4359232d2efc79025527375b09"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "75ea7d0ee2a15733684badb16de6794894ed9c55aa5e9903260922f0482e687d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a452f9ca3e3267cd4d0fcf2edd0d035b1934ac2bd7e0e57ac91ad6b95c0c6389"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "43aa59eadec7890d9958748db829df269f0368521ba6dc68cc172d5d03ed8060"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "72554a23c78a8e7aa02abbd699d129eead8b147a23c56e08d08dfc29cfdddca1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d2efee35b4b0a347e0d99d28e884dfd82797852d62fcd7ebdeee26f3ceb72cf3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6dcfcffe73710be01d90cae08c3e548d90932d37b39ef83969ae135d36ef3956"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb6e651000a19c96f452c85132811d25e9264d836951022d6e81df2fff38337d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "66027d667efe95cc4fa945af59f92c5a02c6f5bb6012bff9e60542c74c75c362"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5eb404d89131ec9b4f748fa5cfb5346802e5ee8836f57d516576e61f304f3b7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9090c9e676d5236a6948330e83cb89969f433b1943a558968f659ead07cb3b36"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "94265b00870aa407bd0cbcfd536f17ecde43b94fb8d228560a1e9d3041462d73"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f2058f813d4f2b5e3a9eb2eb3faf8f1d99b81c3e51aeda4b168406443e8ba809"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "98b5e1f498a8ca1858a1cdbffb023bfd954da4e3fa2c0cb5853d40014557248b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "14d7dc606219cdd7405133c713f2c218d4252f2a469003f8c46bb92d5d095d81"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "49aac49dc4782cb04f58986e81ea0b4768e4ff197b57324dcbd7699c5dfb40b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "418abb18146475c310d7a6dc71143d6f7adec5b004ac9ce08dc7a34e2babdc5c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "685f568fa5e627e93f3b52fda002c7ed2fa1800b50ce51f6ed1d572d8ab3e7fc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dcdba5c86e368442528f7060039eda390cc4091bfd1dca41e8046af7c910dda8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d462f28826f4657968ae51d2181a074dfe03c200d6131690b7d65d55b0f360f8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a33a747400b94b6d6b8a165e4480264a64a78c8a4c734b62136062e9a248dd39"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3646eefa23daeba62643a58aac816945cadc0afaf21800a1421eeba5f6cfb9c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3ebf019be5c09d400cf7b024aa52b1f3aeebeff51550d007e92c3c1c4afc2a40"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0d2691979e93d06a95a26257adb7bfd0c93818e89b1406f5a28f36e0d8c1e1fc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1acd723ee2a8826f3d53910255643e33673e1d11db84ce5880675954183ec47e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bc57efac2da352a51cc4658878a68d2b1b67dbe9d33c36cb826ca449d80a8465"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "da4813f751142436b075ed7aa012a8778aa43a99f7b36afe9b742d3ed8bdc95e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6f6eac2360f2d543cc875a0e5efd413b6cbd483cb3ad7ebf888884a6e0d2e966"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a0ea261ce52b5952bf669684a251a66df239ec6d441ccb59ec7afa882265d593"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7bd2d7ff69a2cac767fbf7a2b206add2e9a210e57947dd7ce03e25d03d2de292"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9159485323798c8dc530a224bd3ffcf76659319ccc7bbd52e01e73bd0241a0c5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a86373cf37cd7764f2201b76496aba58a52e76dedfaa698ef9e9688bfd9e41cf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "73870c364c11f03ed072dda68ff7aea6d2a3a5c3fe250d917a429c7432e15228"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b935ae30c6e7400022b50f8d359c03ed233d45b725cfdd299462f41ee5ffba6f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "db98ad84a55eb09b3c32a96c576476777e87c520a34e2519d3e59c44710c002c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9153ed35fc5e4fa3b2fe97bddaa7cbec0ed22412b85bcdaf54aeba92ea37428c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "66dfbaa7cfa3eb707bbfcd46dab2bc6207b005cbc9caa2199bcbc81d95071a00"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1dd50a2696ff89f57bd8847647a1c363b687d3d796dc30d4dd4a9d1689a706f0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "44a2754372e32ab315734c6c73b24351d06e77ffff6ae27d2ecf14cf3d229202"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8e9723528b9f787dc59168369e42ae1c3b0d3fadb2f1a71de14531d321ee05b0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dbed418ba5c3dce92619656802cc5355cb679e58d0d89b50f116e4a9d5a9603e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "941988b89b4fd6b41c3f0bfb20e92bd23746579736b7343283297c4c8cbae68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6a42cd0cfa8ffc1915aef79cb4284f6383d8a3e9dcca70c445dcfdd639d51267"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1ca9b6085e4f866bd584fb135a041bfc32cab916e69f714a7d1d397f8c4891ca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d5e49454f19ef621089e204f862388d29e6e8d8b162efce05208913dde5b9ad6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c31f72b1b6624c9d863fc095da460802f43a7c6868c5dda140f51da24fd47d7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "490b0ee15c1a55be9c1bd8609b8cecd60e325f0575fc98f50058eae366e01f41"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9b201ae332c3637a42f02d1045e1d0cccfdc41f1f2f801dafbaa7e9b4797bfc2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2076fad65c6736184e77d7d4729b63a6d1ae0b70da4868adeec40989858eb3fb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c5cd603b575ebceca7da5a3a251e69561bec509e0b46e4993e1cac402b7247b8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b47cfad9e9bbbed2339081f4e346c93ecd7ab504299403320bf85f7f85c7d46c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5f15814a33e42b04e3de432e573aa557f9f0f56458745c2074952f564c50e664"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "db2e408d983b0e61e238cf579c09ef7020560441906ca990fe8412153e3b291f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "edfad1d29c73f9b863ebe7082ae9321374ccb10879eeabc84ba3b69f2579d537"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ed867c42c268f876097248e05b6117a65bcd1e63b779e916fe2e33cd6fd0d3c3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/wrapt/#wrapt-1.16.0.tar.gz"
+        }
+      ],
+      "name": "wrapt",
+      "purl": "pkg:pypi/wrapt@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "yarl@1.9.4",
+      "description": "Yet another URL library",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a8c1df72eb746f4136fe9a2e72b0c9dc1da1cbd23b5372f94b5820ff8ae30e0e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a3a6ed1d525bfb91b3fc9b690c5a21bb52de28c018530ad85093cc488bee2dd2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c38c9ddb6103ceae4e4498f9c08fac9b590c5c71b0370f98714768e22ac6fa66"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d9e09c9d74f4566e905a0b8fa668c58109f7624db96a2171f21747abc7524234"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b8477c1ee4bd47c57d49621a062121c3023609f7a13b8a46953eb6c9716ca392"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d5ff2c858f5f6a42c2a8e751100f237c5e869cbde669a724f2062d4c4ef93551"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "357495293086c5b6d34ca9616a43d329317feab7917518bc97a08f9e55648455"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54525ae423d7b7a8ee81ba189f131054defdb122cde31ff17477951464c1691c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "801e9264d19643548651b9db361ce3287176671fb0117f96b5ac0ee1c3530d53"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e516dc8baf7b380e6c1c26792610230f37147bb754d6426462ab115a02944385"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7d5aaac37d19b2904bb9dfe12cdb08c8443e7ba7d2852894ad448d4b8f442863"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54beabb809ffcacbd9d28ac57b0db46e42a6e341a030293fb3185c409e626b8b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bac8d525a8dbc2a1507ec731d2867025d11ceadcb4dd421423a5d42c56818541"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7855426dfbddac81896b6e533ebefc0af2f132d4a47340cee6d22cac7190022d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "848cd2a1df56ddbffeb375535fb62c9d1645dde33ca4d51341378b3f5954429b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "35a2b9396879ce32754bd457d31a51ff0a9d426fd9e0e3c33394bf4b9036b099"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4c7d56b293cc071e82532f70adcbd8b61909eec973ae9d2d1f9b233f3d943f2c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d8a1c6c0be645c745a081c192e747c5de06e944a0d21245f4cf7c05e457c36e0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b3c1ffe10069f655ea2d731808e76e0f452fc6c749bea04781daf18e6039525"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "549d19c84c55d11687ddbd47eeb348a89df9cb30e1993f1b128f4685cd0ebbf8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a7409f968456111140c1c95301cadf071bd30a81cbd7ab829169fb9e3d72eae9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e23a6d84d9d1738dbc6e38167776107e63307dfc8ad108e580548d1f2c587f42"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d8b889777de69897406c9fb0b76cdf2fd0f31267861ae7501d93003d55f54fbe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "03caa9507d3d3c83bca08650678e25364e1843b484f19986a527630ca376ecce"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4e9035df8d0880b2f1c7f5031f33f69e071dfe72ee9310cfc76f7b605958ceb9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c0ec0ed476f77db9fb29bca17f0a8fcc7bc97ad4c6c1d8959c507decb22e8572"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ee04010f26d5102399bd17f8df8bc38dc7ccd7701dc77f4a68c5b8d733406958"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "49a180c2e0743d5d6e0b4d1a9e5f633c62eca3f8a86ba5dd3c471060e352ca98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81eb57278deb6098a5b62e88ad8281b2ba09f2f1147c4767522353eaa6260b31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d1d2532b340b692880261c15aee4dc94dd22ca5d61b9db9a8a361953d36410b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0d2454f0aef65ea81037759be5ca9947539667eecebca092733b2eb43c965a81"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "44d8ffbb9c06e5a7f529f38f53eda23e50d1ed33c6c869e01481d3fafa6b8142"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aaaea1e536f98754a6e5c56091baa1b6ce2f2700cc4a00b0d49eca8dea471074"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3777ce5536d17989c91696db1d459574e9a9bd37660ea7ee4d3344579bb6f129"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9fc5fc1eeb029757349ad26bbc5880557389a03fa6ada41703db5e068881e5f2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ea65804b5dc88dacd4a40279af0cdadcfe74b3e5b4c897aa0d81cf86927fee78"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aa102d6d280a5455ad6a0f9e6d769989638718e938a6a0a2ff3f4a7ff8c62cc4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "09efe4615ada057ba2d30df871d2f668af661e971dfeedf0c159927d48bbeff0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "008d3e808d03ef28542372d01057fd09168419cdc8f848efe2804f894ae03e51"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6f5cb257bc2ec58f437da2b37a8cd48f666db96d47b8a3115c29f316313654ff"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "992f18e0ea248ee03b5a6e8b3b4738850ae7dbb172cc41c966462801cbf62cf7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e9d124c191d5b881060a9e5060627694c3bdd1fe24c5eecc8d5d7d0eb6faabc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3986b6f41ad22988e53d5778f91855dc0399b043fc8946d4f2e68af22ee9ff10"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b21516d181cd77ebd06ce160ef8cc2a5e9ad35fb1c5930882baff5ac865eee7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a9bd00dc3bc395a662900f33f74feb3e757429e545d831eef5bb280252631984"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "63b20738b5aac74e239622d2fe30df4fca4942a86e31bf47a81a0e94c14df94f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d7d7f7de27b8944f1fee2c26a88b4dabc2409d2fea7a9ed3df79b67277644e17"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c74018551e31269d56fab81a728f683667e7c28c04e807ba08f8c9e3bba32f14"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ca06675212f94e7a610e85ca36948bb8fc023e458dd6c63ef71abfd482481aa5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5aef935237d60a51a62b86249839b51345f47564208c6ee615ed2a40878dccdd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2b134fd795e2322b7684155b7855cc99409d10b2e408056db2b93b51a52accc7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d25039a474c4c72a5ad4b52495056f843a7ff07b632c1b92ea9043a3d9950f6e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f7d6b36dd2e029b6bcb8a13cf19664c7b8e19ab3a58e0fefbb5b8461447ed5ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "957b4774373cf6f709359e5c8c4a0af9f6d7875db657adb0feaf8d6cb3c3964c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d7eeb6d22331e2fd42fce928a81c697c9ee2d51400bd1a28803965883e13cead"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6a962e04b8f91f8c4e5917e518d17958e3bdee71fd1d8b88cdce74dd0ebbf434"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f3bc6af6e2b8f92eced34ef6a96ffb248e863af20ef4fde9448cc8c9b858b749"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ad4d7a90a92e528aadf4965d685c17dacff3df282db1121136c382dc0b6014d2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ec61d826d80fc293ed46c9dd26995921e3a82146feacd952ef0757236fc137be"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8be9e837ea9113676e5754b43b940b50cce76d9ed7d2461df1af39a8ee674d9f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bef596fdaa8f26e3d66af846bbe77057237cb6e8efff8cd7cc8dff9a62278bbf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2d47552b6e52c3319fede1b60b3de120fe83bde9b7bddad11a69fb0af7db32f1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84fc30f71689d7fc9168b92788abc977dc8cefa806909565fc2951d02f6b7d57"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4aa9741085f635934f3a2583e16fcf62ba835719a8b2b28fb2917bb0537c1dfa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "206a55215e6d05dbc6c98ce598a59e6fbd0c493e2de4ea6cc2f4934d5a18d130"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "07574b007ee20e5c375a8fe4a0789fad26db905f9813be0f9fef5a68080de559"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5a2e2433eb9344a163aced6a5f6c9222c0786e5a9e9cac2c89f0b28433f56e23"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6ad6d10ed9b67a382b45f29ea028f92d25bc0bc1daf6c5b801b90b5aa70fb9ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6fe79f998a4052d79e1c30eeb7d6c1c1056ad33300f682465e1b4e9b5a188b78"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a825ec844298c791fd28ed14ed1bffc56a98d15b8c58a20e0e08c1f5f2bea1be"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8619d6915b3b0b34420cf9b2bb6d81ef59d984cb0fde7544e9ece32b4b3043c3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "686a0c2f85f83463272ddffd4deb5e591c98aac1897d65e92319f729c320eece"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a00862fb23195b6b8322f7d781b0dc1d82cb3bcac346d1e38689370cc1cc398b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "604f31d97fa493083ea21bd9b92c419012531c4e17ea6da0f65cacdcf5d0bd27"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8a854227cf581330ffa2c4824d96e52ee621dd571078a252c25e3a3b3d94a1b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ba6f52cbc7809cd8d74604cce9c14868306ae4aa0282016b641c661f981a6e91"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a6327976c7c2f4ee6816eff196e25385ccc02cb81427952414a64811037bbc8b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8397a3817d7dcdd14bb266283cd1d6fc7264a48c186b986f32e86d86d35fbac5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e0381b4ce23ff92f8170080c97678040fc5b08da85e9e292292aba67fdac6c34"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "23d32a2594cb5d565d358a92e151315d1b2268bc10f4610d098f96b147370136"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ddb2a5c08a4eaaba605340fdee8fc08e406c56617566d9643ad8bf6852778fc7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "26a1dc6285e03f3cc9e839a2da83bcbf31dcb0d004c72d0730e755b33466c30e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "18580f672e44ce1238b82f7fb87d727c4a131f3a9d33a5e0e82b793362bf18b4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "29e0f83f37610f173eb7e7b5562dd71467993495e568e708d99e9d1944f561ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f23e4fe1e8794f74b6027d7cf19dc25f8b63af1483d91d595d4a07eca1fb26c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "db8e58b9d79200c76956cefd14d5c90af54416ff5353c5bfd7cbe58818e26ef0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c7224cab95645c7ab53791022ae77a4509472613e839dab722a72abe5a684575"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "824d6c50492add5da9374875ce72db7a0733b29c2394890aef23d533106e2b15"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "928cecb0ef9d5a7946eb6ff58417ad2fe9375762382f1bf5c55e61645f2c43ad"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "566db86717cf8080b99b58b083b773a908ae40f06681e87e589a976faf8246bf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/yarl/#yarl-1.9.4.tar.gz"
+        }
+      ],
+      "name": "yarl",
+      "purl": "pkg:pypi/yarl@1.9.4",
+      "type": "library",
+      "version": "1.9.4"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "aiohttp@3.9.3"
+      ],
+      "ref": "aiohttp-cors@0.7.0"
+    },
+    {
+      "dependsOn": [
+        "aiosignal@1.3.1",
+        "async-timeout@4.0.3",
+        "attrs@23.2.0",
+        "frozenlist@1.4.1",
+        "multidict@6.0.5",
+        "yarl@1.9.4"
+      ],
+      "ref": "aiohttp@3.9.3"
+    },
+    {
+      "dependsOn": [
+        "frozenlist@1.4.1"
+      ],
+      "ref": "aiosignal@1.3.1"
+    },
+    {
+      "ref": "annotated-types@0.6.0"
+    },
+    {
+      "dependsOn": [
+        "exceptiongroup@1.2.0",
+        "idna@3.6",
+        "sniffio@1.3.1",
+        "typing-extensions@4.10.0"
+      ],
+      "ref": "anyio@4.3.0"
+    },
+    {
+      "ref": "async-timeout@4.0.3"
+    },
+    {
+      "ref": "attrs@23.2.0"
+    },
+    {
+      "ref": "cachetools@5.3.3"
+    },
+    {
+      "ref": "certifi@2024.2.2"
+    },
+    {
+      "ref": "charset-normalizer@3.3.2"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6"
+      ],
+      "ref": "click@8.1.7"
+    },
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6"
+      ],
+      "ref": "colorful@0.5.6"
+    },
+    {
+      "ref": "distlib@0.3.8"
+    },
+    {
+      "ref": "exceptiongroup@1.2.0"
+    },
+    {
+      "dependsOn": [
+        "pydantic@2.6.4",
+        "starlette@0.36.3",
+        "typing-extensions@4.10.0"
+      ],
+      "ref": "fastapi@0.110.0"
+    },
+    {
+      "ref": "filelock@3.13.3"
+    },
+    {
+      "ref": "frozenlist@1.4.1"
+    },
+    {
+      "dependsOn": [
+        "google-auth@2.29.0",
+        "googleapis-common-protos@1.56.1",
+        "protobuf@5.26.1",
+        "requests@2.31.0"
+      ],
+      "ref": "google-api-core@2.8.0"
+    },
+    {
+      "dependsOn": [
+        "cachetools@5.3.3",
+        "pyasn1-modules@0.4.0",
+        "rsa@4.9"
+      ],
+      "ref": "google-auth@2.29.0"
+    },
+    {
+      "dependsOn": [
+        "protobuf@5.26.1"
+      ],
+      "ref": "googleapis-common-protos@1.56.1"
+    },
+    {
+      "ref": "grpcio@1.62.1"
+    },
+    {
+      "ref": "h11@0.14.0"
+    },
+    {
+      "ref": "httptools@0.6.1"
+    },
+    {
+      "ref": "idna@3.6"
+    },
+    {
+      "dependsOn": [
+        "referencing@0.34.0"
+      ],
+      "ref": "jsonschema-specifications@2023.12.1"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.2.0",
+        "jsonschema-specifications@2023.12.1",
+        "referencing@0.34.0",
+        "rpds-py@0.18.0"
+      ],
+      "ref": "jsonschema@4.21.1"
+    },
+    {
+      "ref": "msgpack@1.0.8"
+    },
+    {
+      "ref": "multidict@6.0.5"
+    },
+    {
+      "ref": "opencensus-context@0.1.3"
+    },
+    {
+      "dependsOn": [
+        "google-api-core@2.8.0",
+        "opencensus-context@0.1.3",
+        "six@1.16.0"
+      ],
+      "ref": "opencensus@0.11.4"
+    },
+    {
+      "ref": "packaging@24.0"
+    },
+    {
+      "ref": "platformdirs@4.2.0"
+    },
+    {
+      "ref": "prometheus-client@0.20.0"
+    },
+    {
+      "ref": "protobuf@5.26.1"
+    },
+    {
+      "ref": "py-spy@0.3.14"
+    },
+    {
+      "dependsOn": [
+        "pyasn1@0.6.0"
+      ],
+      "ref": "pyasn1-modules@0.4.0"
+    },
+    {
+      "ref": "pyasn1@0.6.0"
+    },
+    {
+      "dependsOn": [
+        "typing-extensions@4.10.0"
+      ],
+      "ref": "pydantic-core@2.16.3"
+    },
+    {
+      "dependsOn": [
+        "annotated-types@0.6.0",
+        "pydantic-core@2.16.3",
+        "typing-extensions@4.10.0"
+      ],
+      "ref": "pydantic@2.6.4"
+    },
+    {
+      "ref": "python-dotenv@1.0.1"
+    },
+    {
+      "ref": "pyyaml@6.0.1"
+    },
+    {
+      "dependsOn": [
+        "aiohttp-cors@0.7.0",
+        "aiohttp@3.9.3",
+        "aiosignal@1.3.1",
+        "click@8.1.7",
+        "colorful@0.5.6",
+        "fastapi@0.110.0",
+        "filelock@3.13.3",
+        "frozenlist@1.4.1",
+        "grpcio@1.62.1",
+        "jsonschema@4.21.1",
+        "msgpack@1.0.8",
+        "opencensus@0.11.4",
+        "packaging@24.0",
+        "prometheus-client@0.20.0",
+        "protobuf@5.26.1",
+        "py-spy@0.3.14",
+        "pydantic@2.6.4",
+        "pyyaml@6.0.1",
+        "requests@2.31.0",
+        "smart-open@7.0.4",
+        "starlette@0.36.3",
+        "uvicorn@0.29.0",
+        "virtualenv@20.25.1",
+        "watchfiles@0.21.0"
+      ],
+      "ref": "ray@2.10.0"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.2.0",
+        "rpds-py@0.18.0"
+      ],
+      "ref": "referencing@0.34.0"
+    },
+    {
+      "dependsOn": [
+        "ray@2.10.0"
+      ],
+      "ref": "regression-issue702"
+    },
+    {
+      "dependsOn": [
+        "certifi@2024.2.2",
+        "charset-normalizer@3.3.2",
+        "idna@3.6",
+        "urllib3@2.2.1"
+      ],
+      "ref": "requests@2.31.0"
+    },
+    {
+      "ref": "rpds-py@0.18.0"
+    },
+    {
+      "dependsOn": [
+        "pyasn1@0.6.0"
+      ],
+      "ref": "rsa@4.9"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "dependsOn": [
+        "wrapt@1.16.0"
+      ],
+      "ref": "smart-open@7.0.4"
+    },
+    {
+      "ref": "sniffio@1.3.1"
+    },
+    {
+      "dependsOn": [
+        "anyio@4.3.0"
+      ],
+      "ref": "starlette@0.36.3"
+    },
+    {
+      "ref": "typing-extensions@4.10.0"
+    },
+    {
+      "ref": "urllib3@2.2.1"
+    },
+    {
+      "dependsOn": [
+        "click@8.1.7",
+        "colorama@0.4.6",
+        "h11@0.14.0",
+        "httptools@0.6.1",
+        "python-dotenv@1.0.1",
+        "pyyaml@6.0.1",
+        "typing-extensions@4.10.0",
+        "uvloop@0.19.0",
+        "watchfiles@0.21.0",
+        "websockets@12.0"
+      ],
+      "ref": "uvicorn@0.29.0"
+    },
+    {
+      "ref": "uvloop@0.19.0"
+    },
+    {
+      "dependsOn": [
+        "distlib@0.3.8",
+        "filelock@3.13.3",
+        "platformdirs@4.2.0"
+      ],
+      "ref": "virtualenv@20.25.1"
+    },
+    {
+      "dependsOn": [
+        "anyio@4.3.0"
+      ],
+      "ref": "watchfiles@0.21.0"
+    },
+    {
+      "ref": "websockets@12.0"
+    },
+    {
+      "ref": "wrapt@1.16.0"
+    },
+    {
+      "dependsOn": [
+        "idna@3.6",
+        "multidict@6.0.5"
+      ],
+      "ref": "yarl@1.9.4"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "regression-issue702",
+      "description": "regression for issue #702",
+      "name": "regression-issue702",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_regression-issue702_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_regression-issue702_lock20_1.6.xml.bin
@@ -1,0 +1,8895 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="regression-issue702">
+      <name>regression-issue702</name>
+      <version>0.1.0</version>
+      <description>regression for issue #702</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="aiohttp@3.9.3">
+      <name>aiohttp</name>
+      <version>3.9.3</version>
+      <description>Async http client/server framework (asyncio)</description>
+      <purl>pkg:pypi/aiohttp@3.9.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">939677b61f9d72a4fa2a042a5eee2a99a24001a67c13da113b2e30396567db54</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f5cd333fcf7590a18334c90f8c9147c837a6ec8a178e88d90a9b96ea03194cc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">82e6aa28dd46374f72093eda8bcd142f7771ee1eb9d1e223ff0fa7177a96b4a5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f56455b0c2c7cc3b0c584815264461d07b177f903a04481dfc33e08a89f0c26b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bca77a198bb6e69795ef2f09a5f4c12758487f83f33d63acde5f0d4919815768</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e083c285857b78ee21a96ba1eb1b5339733c3563f72980728ca2b08b53826ca5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ab40e6251c3873d86ea9b30a1ac6d7478c09277b32e14745d0d3c6e76e3c7e29</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">df822ee7feaaeffb99c1a9e5e608800bd8eda6e5f18f5cfb0dc7eeb2eaa6bbec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">acef0899fea7492145d2bbaaaec7b345c87753168589cc7faf0afec9afe9b747</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd73265a9e5ea618014802ab01babf1940cecb90c9762d8b9e7d2cc1e1969ec6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a78ed8a53a1221393d9637c01870248a6f4ea5b214a59a92a36f18151739452c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b0e029353361f1746bac2e4cc19b32f972ec03f0f943b390c4ab3371840aabf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7cf5c9458e1e90e3c390c2639f1017a0379a99a94fdfad3a1fd966a2874bba52</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3e59c23c52765951b69ec45ddbbc9403a8761ee6f57253250c6e1536cacc758b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">055ce4f74b82551678291473f66dc9fb9048a50d8324278751926ff0ae7715e5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b88f9386ff1ad91ace19d2a1c0225896e28815ee09fc6a8932fded8cda97c3d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c46956ed82961e31557b6857a5ca153c67e5476972e5f7190015018760938da2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">07b837ef0d2f252f96009e9b8435ec1fef68ef8b1461933253d318748ec1acdc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dad46e6f620574b3b4801c68255492e0159d1712271cc99d8bdf35f2043ec266</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5ed3e046ea7b14938112ccd53d91c1539af3e6679b222f9469981e3dac7ba1ce</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">039df344b45ae0b34ac885ab5b53940b174530d4dd8a14ed8b0e2155b9dddccb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7943c414d3a8d9235f5f15c22ace69787c140c80b718dcd57caaade95f7cd93b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">84871a243359bb42c12728f04d181a389718710129b36b6aad0fc4655a7647d4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5eafe2c065df5401ba06821b9a054d9cb2848867f3c59801b5d07a0be3a380ae</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9d3c9b50f19704552f23b4eaea1fc082fdd82c63429a6506446cbd8737823da3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f033d80bc6283092613882dfe40419c6a6a1527e04fc69350e87a9df02bbc283</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2c895a656dd7e061b2fd6bb77d971cc38f2afc277229ce7dd3552de8313a483e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f5a71d25cd8106eab05f8704cd9167b6e5187bcdf8f090a66c6d88b634802b4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">50fca156d718f8ced687a373f9e140c1bb765ca16e3d6f4fe116e3df7c05b2c5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5fe9ce6c09668063b8447f85d43b8d1c4e5d3d7e92c63173e6180b2ac5d46dd8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">38a19bc3b686ad55804ae931012f78f7a534cce165d089a2059f658f6c91fa60</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">770d015888c2a598b377bd2f663adfd947d78c0124cfe7b959e1ef39f5b13869</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ee43080e75fc92bf36219926c8e6de497f9b247301bbf88c5c7593d931426679</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">52df73f14ed99cee84865b95a3d9e044f226320a87af208f068ecc33e0c35b96</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dc9b311743a78043b26ffaeeb9715dc360335e5517832f5a8e339f8a43581e4d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b955ed993491f1a5da7f92e98d5dad3c1e14dc175f74517c4e610b1f2456fb11</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">504b6981675ace64c28bf4a05a508af5cde526e36492c98916127f5a02354d53</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a6fe5571784af92b6bc2fda8d1925cccdf24642d49546d3144948a6a1ed58ca5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ba39e9c8627edc56544c8628cc180d88605df3892beeb2b94c9bc857774848ca</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e5e46b578c0e9db71d04c4b506a2121c0cb371dd89af17a0586ff6769d4c58c1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">938a9653e1e0c592053f815f7028e41a3062e902095e5a7dc84617c87267ebd5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c3452ea726c76e92f3b9fae4b34a151981a9ec0a4847a627c43d71a15ac32aa6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ff30218887e62209942f91ac1be902cc80cddb86bf00fbc6783b7a43b2bea26f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">38f307b41e0bea3294a9a2a87833191e4bcf89bb0365e83a8be3a58b31fb7f38</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b791a3143681a520c0a17e26ae7465f1b6f99461a28019d1a2f425236e6eedb5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0ed621426d961df79aa3b963ac7af0d40392956ffa9be022024cd16297b30c8c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7f46acd6a194287b7e41e87957bfe2ad1ad88318d447caf5b090012f2c5bb528</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">feeb18a801aacb098220e2c3eea59a512362eb408d4afd0c242044c33ad6d542</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f734e38fd8666f53da904c52a23ce517f1b07722118d750405af7e4123933511</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b40670ec7e2156d8e57f70aec34a7216407848dfe6c693ef131ddf6e76feb672</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fdd215b7b7fd4a53994f238d0f46b7ba4ac4c0adb12452beee724ddd0743ae5d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">017a21b0df49039c8f46ca0971b3a7fdc1f56741ab1240cb90ca408049766168</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e99abf0bba688259a496f966211c49a514e65afa9b3073a1fcee08856e04425b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">648056db9a9fa565d3fa851880f99f45e3f9a771dd3ff3bb0c048ea83fb28194</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8aacb477dc26797ee089721536a292a664846489c49d3ef9725f992449eda5a8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">522a11c934ea660ff8953eda090dcd2154d367dec1ae3c540aff9f8a5c109ab4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5bce0dc147ca85caa5d33debc4f4d65e8e8b5c97c7f9f660f215fa74fc49a321</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4b4af9f25b49a7be47c0972139e59ec0e8285c371049df1a63b6ca81fdd216a2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">298abd678033b8571995650ccee753d9458dfa0377be4dba91e4491da3f2be63</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">69361bfdca5468c0488d7017b9b1e5ce769d40b46a9f4a2eed26b78619e9396c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0fa43c32d1643f518491d9d3a730f85f5bbaedcbd7fbcae27435bb8b7a061b29</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">835a55b7ca49468aaaac0b217092dfdff370e6c215c9224c52f30daaa735c1c1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">06a9b2c8837d9a94fae16c6223acc14b4dfdff216ab9b7202e07a9a09541168f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">abf151955990d23f84205286938796c55ff11bbfb4ccfada8c9c83ae6b3c89a3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">59c26c95975f26e662ca78fdf543d4eeaef70e533a672b4113dd888bd2423caa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f95511dd5d0e05fd9728bac4096319f80615aaef4acbecb35a990afebe953b0e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">595f105710293e76b9dc09f52e0dd896bd064a79346234b521f6b968ffdd8e58</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c7c8b816c2b5af5c8a436df44ca08258fc1a13b449393a91484225fcb7545533</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f1088fa100bf46e7b398ffd9904f4808a0612e1d966b4aa43baa535d1b6341eb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f59dfe57bb1ec82ac0698ebfcdb7bcd0e99c255bd637ff613760d5f33e7c81b3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">361a1026c9dd4aba0109e4040e2aecf9884f5cfe1b1b1bd3d09419c205e2e53d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">363afe77cfcbe3a36353d8ea133e904b108feea505aa4792dad6585a8192c55a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8e2c45c208c62e955e8256949eb225bd8b66a4c9b6865729a786f2aa79b72e9d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f7217af2e14da0856e082e96ff637f14ae45c10a5714b63c77f26d8884cf1051</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">27468897f628c627230dba07ec65dc8d0db566923c48f29e084ce382119802bc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp/#aiohttp-3.9.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">90842933e5d1ff760fae6caca4b2b3edba53ba8f4b71e95dacf2818a2aca06f7</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="aiohttp-cors@0.7.0">
+      <name>aiohttp-cors</name>
+      <version>0.7.0</version>
+      <description>CORS support for aiohttp</description>
+      <purl>pkg:pypi/aiohttp-cors@0.7.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp-cors/#aiohttp-cors-0.7.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d39c6d7100fd9764ed1caf8cebf0eb01bf5e3f24e2e073fda6234bc48b19f5d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiohttp-cors/#aiohttp_cors-0.7.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0451ba59fdf6909d0e2cd21e4c0a43752bc0703d33fc78ae94d9d9321710193e</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="aiosignal@1.3.1">
+      <name>aiosignal</name>
+      <version>1.3.1</version>
+      <description>aiosignal: a list of registered asynchronous callbacks</description>
+      <purl>pkg:pypi/aiosignal@1.3.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiosignal/#aiosignal-1.3.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f8376fb07dd1e86a584e4fcdec80b36b7f81aac666ebc724e2c090300dd83b17</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/aiosignal/#aiosignal-1.3.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">54cd96e15e1649b75d6c87526a6ff0b6c1b0dd3459f43d9ca11d48c339b68cfc</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="annotated-types@0.6.0">
+      <name>annotated-types</name>
+      <version>0.6.0</version>
+      <description>Reusable constraint types to use with typing.Annotated</description>
+      <purl>pkg:pypi/annotated-types@0.6.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/annotated-types/#annotated_types-0.6.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0641064de18ba7a25dee8f96403ebc39113d0cb953a01429249d5c7564666a43</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/annotated-types/#annotated_types-0.6.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">563339e807e53ffd9c267e99fc6d9ea23eb8443c08f112651963e24e22f84a5d</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="anyio@4.3.0">
+      <name>anyio</name>
+      <version>4.3.0</version>
+      <description>High level compatibility layer for multiple asynchronous event loop implementations</description>
+      <purl>pkg:pypi/anyio@4.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/anyio/#anyio-4.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/anyio/#anyio-4.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="async-timeout@4.0.3">
+      <name>async-timeout</name>
+      <version>4.0.3</version>
+      <description>Timeout context manager for asyncio programs</description>
+      <purl>pkg:pypi/async-timeout@4.0.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/async-timeout/#async-timeout-4.0.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/async-timeout/#async_timeout-4.0.3-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="attrs@23.2.0">
+      <name>attrs</name>
+      <version>23.2.0</version>
+      <description>Classes Without Boilerplate</description>
+      <purl>pkg:pypi/attrs@23.2.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/#attrs-23.2.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/#attrs-23.2.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="cachetools@5.3.3">
+      <name>cachetools</name>
+      <version>5.3.3</version>
+      <description>Extensible memoizing collections and decorators</description>
+      <purl>pkg:pypi/cachetools@5.3.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/cachetools/#cachetools-5.3.3-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0abad1021d3f8325b2fc1d2e9c8b9c9d57b04c3932657a72465447332c24d945</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/cachetools/#cachetools-5.3.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ba29e2dfa0b8b556606f097407ed1aa62080ee108ab0dc5ec9d6a723a007d105</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="certifi@2024.2.2">
+      <name>certifi</name>
+      <version>2024.2.2</version>
+      <description>Python package for providing Mozilla's CA Bundle.</description>
+      <purl>pkg:pypi/certifi@2024.2.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/#certifi-2024.2.2-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/#certifi-2024.2.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="charset-normalizer@3.3.2">
+      <name>charset-normalizer</name>
+      <version>3.3.2</version>
+      <description>The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet.</description>
+      <purl>pkg:pypi/charset-normalizer@3.3.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset-normalizer-3.3.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2127566c664442652f024c837091890cb1942c30937add288223dc895793f898</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/charset-normalizer/#charset_normalizer-3.3.2-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="click@8.1.7">
+      <name>click</name>
+      <version>8.1.7</version>
+      <description>Composable command line interface toolkit</description>
+      <purl>pkg:pypi/click@8.1.7</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/click/#click-8.1.7-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/click/#click-8.1.7.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="colorful@0.5.6">
+      <name>colorful</name>
+      <version>0.5.6</version>
+      <description>Terminal string styling done right, in Python.</description>
+      <purl>pkg:pypi/colorful@0.5.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorful/#colorful-0.5.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eab8c1c809f5025ad2b5238a50bd691e26850da8cac8f90d660ede6ea1af9f1e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorful/#colorful-0.5.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b56d5c01db1dac4898308ea889edcb113fbee3e6ec5df4bacffd61d5241b5b8d</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="distlib@0.3.8">
+      <name>distlib</name>
+      <version>0.3.8</version>
+      <description>Distribution utilities</description>
+      <purl>pkg:pypi/distlib@0.3.8</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/distlib/#distlib-0.3.8-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/distlib/#distlib-0.3.8.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="exceptiongroup@1.2.0">
+      <name>exceptiongroup</name>
+      <version>1.2.0</version>
+      <description>Backport of PEP 654 (exception groups)</description>
+      <purl>pkg:pypi/exceptiongroup@1.2.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/exceptiongroup/#exceptiongroup-1.2.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/exceptiongroup/#exceptiongroup-1.2.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="fastapi@0.110.0">
+      <name>fastapi</name>
+      <version>0.110.0</version>
+      <description>FastAPI framework, high performance, easy to learn, fast to code, ready for production</description>
+      <purl>pkg:pypi/fastapi@0.110.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fastapi/#fastapi-0.110.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">87a1f6fb632a218222c5984be540055346a8f5d8a68e8f6fb647b1dc9934de4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fastapi/#fastapi-0.110.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">266775f0dcc95af9d3ef39bad55cff525329a931d5fd51930aadd4f428bf7ff3</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="filelock@3.13.3">
+      <name>filelock</name>
+      <version>3.13.3</version>
+      <description>A platform independent file lock.</description>
+      <purl>pkg:pypi/filelock@3.13.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/filelock/#filelock-3.13.3-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5ffa845303983e7a0b7ae17636509bc97997d58afeafa72fb141a17b152284cb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/filelock/#filelock-3.13.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a79895a25bbefdf55d1a2a0a80968f7dbb28edcd6d4234a0afb3f37ecde4b546</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="frozenlist@1.4.1">
+      <name>frozenlist</name>
+      <version>1.4.1</version>
+      <description>A list-like structure which implements collections.abc.MutableSequence</description>
+      <purl>pkg:pypi/frozenlist@1.4.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f9aa1878d1083b276b0196f2dfbe00c9b7e752475ed3b682025ff20c1c1f51ac</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">29acab3f66f0f24674b7dc4736477bcd4bc3ad4b896f5f45379a67bce8b96868</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">74fb4bee6880b529a0c6560885fce4dc95936920f9f20f53d99a213f7bf66776</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">590344787a90ae57d62511dd7c736ed56b428f04cd8c161fcc5e7232c130c69a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">068b63f23b17df8569b7fdca5517edef76171cf3897eb68beb01341131fbd2ad</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5c849d495bf5154cd8da18a9eb15db127d4dba2968d88831aff6f0331ea9bd4c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9750cc7fe1ae3b1611bb8cfc3f9ec11d532244235d75901fb6b8e42ce9229dfe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a9b2de4cf0cdd5bd2dee4c4f63a653c61d2408055ab77b151c1957f221cabf2a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0633c8d5337cb5c77acbccc6357ac49a1770b8c487e5b3505c57b949b4b82e98</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">27657df69e8801be6c3638054e202a135c7f299267f1a55ed3a598934f6c0d75</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f9a3ea26252bd92f570600098783d1371354d89d5f6b7dfd87359d669f2109b5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f57dab5fe3407b6c0c1cc907ac98e8a189f9e418f3b6e54d65a718aaafe3950</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e02a0e11cf6597299b9f3bbd3f93d79217cb90cfd1411aec33848b13f5c656cc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a828c57f00f729620a442881cc60e57cfcec6842ba38e1b19fd3e47ac0ff8dc1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f56e2333dda1fe0f909e7cc59f021eba0d2307bc6f012a1ccf2beca6ba362439</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a0cb6f11204443f27a1628b0e460f37fb30f624be6051d490fa7d7e26d4af3d0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b46c8ae3a8f1f41a0d2ef350c0b6e65822d80772fe46b653ab6b6274f61d4a49</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fde5bd59ab5357e3853313127f4d3565fc7dad314a74d7b5d43c22c6a5ed2ced</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">722e1124aec435320ae01ee3ac7bec11a5d47f25d0ed6328f2273d287bc3abb0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2471c201b70d58a0f0c1f91261542a03d9a5e088ed3dc6c160d614c01649c106</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c757a9dd70d72b076d6f68efdbb9bc943665ae954dad2801b874c8c69e185068</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f146e0911cb2f1da549fc58fc7bcd2b836a44b79ef871980d605ec392ff6b0d2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f9c515e7914626b2a2e1e311794b4c35720a0be87af52b79ff8e1429fc25f19</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c302220494f5c1ebeb0912ea782bcd5e2f8308037b3c7553fad0e48ebad6ad82</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">442acde1e068288a4ba7acfe05f5f343e19fac87bfc96d89eb886b0363e977ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1b280e6507ea8a4fa0c0a7150b4e526a8d113989e28eaaef946cc77ffd7efc0a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fe1a06da377e3a1062ae5fe0926e12b84eceb8a50b350ddca72dc85015873f74</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">db9e724bebd621d9beca794f2a4ff1d26eed5965b004a97f1f1685a173b869c2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e774d53b1a477a67838a904131c4b0eef6b3d8a651f8b138b04f748fccfefe17</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fb3c2db03683b5767dedb5769b8a40ebb47d6f7f45b1b3e3b4b51ec8ad9d9825</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1979bc0aeb89b33b588c51c54ab0161791149f2461ea7c7c946d95d5f93b56ae</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cc7b01b3754ea68a62bd77ce6020afaffb44a590c2289089289363472d13aedb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c9c92be9fd329ac801cc420e08452b70e7aeab94ea4233a4804f0915c14eba9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5c3894db91f5a489fc8fa6a9991820f368f0b3cbdb9cd8849547ccfab3392d86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ba60bb19387e13597fb059f32cd4d59445d7b18b69a745b8f8e5db0346f33480</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8aefbba5f69d42246543407ed2461db31006b0f76c4e32dfd6f42215a2c41d09</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">780d3a35680ced9ce682fbcf4cb9c2bad3136eeff760ab33707b71db84664e3a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9acbb16f06fe7f52f441bb6f413ebae6c37baa6ef9edd49cdd567216da8600cd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">23b701e65c7b36e4bf15546a89279bd4d8675faabc287d06bbcfac7d3c33e1e6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3e0153a805a98f5ada7e09826255ba99fb4f7524bb81bf6b47fb702666484ae1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dd9b1baec094d91bf36ec729445f7769d0d0cf6b64d04d86e45baf89e2b9059b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1a4471094e146b6790f61b98616ab8e44f72661879cc63fa1049d13ef711e71e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5667ed53d68d91920defdf4035d1cdaa3c3121dc0b113255124bcfada1cfa1b8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">beee944ae828747fd7cb216a70f120767fc9f4f00bacae8543c14a6831673f89</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">64536573d0a2cb6e625cf309984e2d873979709f2cf22839bf2d61790b448ad5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">20b51fa3f588ff2fe658663db52a41a4f7aa6c04f6201449c6c7c476bd255c0d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">410478a0c562d1a5bcc2f7ea448359fcb050ed48b3c6f6f4f18c313a9bdb1826</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c6321c9efe29975232da3bd0af0ad216800a47e93d763ce64f291917a381b8eb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48f6a4533887e189dae092f1cf981f2e3885175f7a0f33c91fb5b7b682b6bab6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6eb73fa5426ea69ee0e012fb59cdc76a15b1283d6e32e4f8dc4482ec67d1194d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fbeb989b5cc29e8daf7f976b421c220f1b8c731cbf22b9130d8815418ea45887</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">32453c1de775c889eb4e22f1197fe3bdfe457d16476ea407472b9442e6295f7a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">693945278a31f2086d9bf3df0fe8254bbeaef1fe71e1351c3bd730aa7d31c41b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1d0ce09d36d53bbbe566fe296965b23b961764c0bcf3ce2fa45f463745c04701</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a670dc61eb0d0eb7080890c13de3066790f9049b47b0de04007090807c776b0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dca69045298ce5c11fd539682cff879cc1e664c245d1c64da929813e54241d11</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a06339f38e9ed3a64e4c4e43aec7f59084033647f908e4259d279a52d3757d09</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b7f2f9f912dca3934c1baec2e4585a674ef16fe00218d833856408c48d5beee7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e7004be74cbb7d9f34553a5ce5fb08be14fb33bc86f332fb71cbe5216362a497</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5a7d70357e7cee13f470c7883a063aae5fe209a493c57d86eb7f5a6f910fae09</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bfa4a17e17ce9abf47a74ae02f32d014c5e9404b6d9ac7f729e01562bbee601e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b7e3ed87d4138356775346e6845cccbe66cd9e207f3cd11d2f0b9fd13681359d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c99169d4ff810155ca50b4da3b075cbde79752443117d89429595c2e8e37fed8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">edb678da49d9f72c9f6c609fbe41a5dfb9a9282f9e6a2253d5a91e0fc382d7c0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6db4667b187a6742b33afbbaf05a7bc551ffcf1ced0000a571aedbb4aa42fc7b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">55fdc093b5a3cb41d420884cdaf37a1e74c3c37a31f46e66286d9145d2063bd0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">82e8211d69a4f4bc360ea22cd6555f8e61a1bd211d1d5d39d3d228b48c83a897</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">89aa2c2eeb20957be2d950b85974b30a01a762f3308cd02bb15e1ad632e22dc7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9d3e0c25a2350080e9319724dede4f31f43a6c9779be48021a7f4ebde8b2d742</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7268252af60904bf52c26173cbadc3a071cece75f873705419c8681f24d3edea</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0c250a29735d4f15321007fb02865f0e6b6a41a6b88f1f523ca1596ab5f50bd5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">96ec70beabbd3b10e8bfe52616a13561e58fe84c0101dd031dc78f250d5128b9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">23b2d7679b73fe0e5a4560b672a39f98dfc6f60df63823b0a9970525325b95f6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a7496bfe1da7fb1a4e1cc23bb67c58fab69311cc7d32b5a99c2007b4b2a0e932</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e6a20a581f9ce92d389a8c7d7c3dd47c81fd5d6e655c8dddf341e14aa48659d0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">04ced3e6a46b4cfffe20f9ae482818e34eba9b5fb0ce4056e4cc9b6e212d09b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/frozenlist/#frozenlist-1.4.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c037a86e8513059a2613aaba4d817bb90b9d9b6b69aace3ce9c877e8c8ed402b</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="google-api-core@2.8.0">
+      <name>google-api-core</name>
+      <version>2.8.0</version>
+      <description>Google API client core library</description>
+      <purl>pkg:pypi/google-api-core@2.8.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/google-api-core/#google-api-core-2.8.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">065bb8e11c605fd232707ae50963dc1c8af5b3c95b4568887515985e6c1156b3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/google-api-core/#google_api_core-2.8.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1b9f59236ce1bae9a687c1d4f22957e79a2669e53d032893f6bf0fca54f6931d</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="google-auth@2.29.0">
+      <name>google-auth</name>
+      <version>2.29.0</version>
+      <description>Google Authentication Library</description>
+      <purl>pkg:pypi/google-auth@2.29.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/google-auth/#google-auth-2.29.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">672dff332d073227550ffc7457868ac4218d6c500b155fe6cc17d2b13602c360</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/google-auth/#google_auth-2.29.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d452ad095688cd52bae0ad6fafe027f6a6d6f560e810fec20914e17a09526415</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="googleapis-common-protos@1.56.1">
+      <name>googleapis-common-protos</name>
+      <version>1.56.1</version>
+      <description>Common protobufs used in Google APIs</description>
+      <purl>pkg:pypi/googleapis-common-protos@1.56.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/googleapis-common-protos/#googleapis-common-protos-1.56.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b5ee59dc646eb61a8eb65ee1db186d3df6687c8804830024f32573298bca19b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/googleapis-common-protos/#googleapis_common_protos-1.56.1-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ddcd955b5bb6589368f659fa475373faa1ed7d09cde5ba25e88513d87007e174</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="grpcio@1.62.1">
+      <name>grpcio</name>
+      <version>1.62.1</version>
+      <description>HTTP/2-based RPC framework</description>
+      <purl>pkg:pypi/grpcio@1.62.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-linux_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">179bee6f5ed7b5f618844f760b6acf7e910988de77a4f75b95bbfaa8106f3c1e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-macosx_12_0_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48611e4fa010e823ba2de8fd3f77c1322dd60cb0d180dc6630a7e157b205f7ea</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-manylinux_2_17_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2a0e71b0a2158aa4bce48be9f8f9eb45cbd17c78c7443616d00abbe2a509f6d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fbe80577c7880911d3ad65e5ecc997416c98f354efeba2f8d0f9112a67ed65a5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">58f6c693d446964e3292425e1d16e21a97a48ba9172f2d0df9d7b640acb99243</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">77c339403db5a20ef4fed02e4d1a9a3d9866bf9c0afc77a42234677313ea22f3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b5a4ea906db7dec694098435d84bf2854fe158eb3cd51e1107e571246d4d1d70</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4187201a53f8561c015bc745b81a1b2d278967b8de35f3399b84b0695e281d5f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">844d1f3fb11bd1ed362d3fdc495d0770cfab75761836193af166fee113421d66</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-linux_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">833379943d1728a005e44103f17ecd73d058d37d95783eb8f0b28ddc1f54d7b2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-macosx_10_10_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c7fcc6a32e7b7b58f5a7d27530669337a5d587d4066060bcb9dee7a8c833dfb7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-manylinux_2_17_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fa7d28eb4d50b7cbe75bb8b45ed0da9a1dc5b219a0af59449676a29c2eed9698</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48f7135c3de2f298b833be8b4ae20cafe37091634e91f61f5a7eb3d61ec6f660</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">71f11fd63365ade276c9d4a7b7df5c136f9030e3457107e1791b3737a9b9ed6a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4b49fd8fe9f9ac23b78437da94c54aa7e9996fbb220bac024a67469ce5d0825f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">482ae2ae78679ba9ed5752099b32e5fe580443b4f798e1b71df412abf43375db</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1faa02530b6c7426404372515fe5ddf66e199c2ee613f88f025c6f3bd816450c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5bd90b8c395f39bc82a5fb32a0173e220e3f401ff697840f4003e15b96d1befc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-linux_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b134d5d71b4e0837fff574c00e49176051a1c532d26c052a1e43231f252d813b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-macosx_10_10_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d1f6c96573dc09d50dbcbd91dbf71d5cf97640c9427c32584010fbbd4c0e0037</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-manylinux_2_17_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">359f821d4578f80f41909b9ee9b76fb249a21035a061a327f91c953493782c31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a485f0c2010c696be269184bdb5ae72781344cb4e60db976c59d84dd6354fac9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b50b09b4dc01767163d67e1532f948264167cd27f49e9377e3556c3cba1268e1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3227c667dccbe38f2c4d943238b887bac588d97c104815aecc62d2fd976e014b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3952b581eb121324853ce2b191dae08badb75cd493cb4e0243368aa9e61cfd41</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">83a17b303425104d6329c10eb34bba186ffa67161e63fa6cdae7776ff76df73f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6696ffe440333a19d8d128e88d440f91fb92c75a80ce4b44d55800e656a3ef1d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-linux_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e3393b0823f938253370ebef033c9fd23d27f3eae8eb9a8f6264900c7ea3fb5a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-macosx_10_10_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">83e7ccb85a74beaeae2634f10eb858a0ed1a63081172649ff4261f929bacfd22</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-manylinux_2_17_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">882020c87999d54667a284c7ddf065b359bd00251fcd70279ac486776dbf84ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a10383035e864f386fe096fed5c47d27a2bf7173c56a6e26cffaaa5a361addb1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">960edebedc6b9ada1ef58e1c71156f28689978188cd8cff3b646b57288a927d9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">23e2e04b83f347d0aadde0c9b616f4726c3d76db04b438fd3904b289a725267f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">978121758711916d34fe57c1f75b79cdfc73952f1481bb9583399331682d36f7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9084086190cc6d628f282e5615f987288b95457292e969b9205e45b442276407</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-linux_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">22bccdd7b23c420a27fd28540fb5dcbc97dc6be105f7698cb0e7d7a420d0e362</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-macosx_10_10_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8999bf1b57172dbc7c3e4bb3c732658e918f5c333b2942243f10d0d653953ba9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-manylinux_2_17_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d9e52558b8b8c2f4ac05ac86344a7417ccdd2b460a59616de49eb6933b07a0bd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1714e7bc935780bc3de1b3fcbc7674209adf5208ff825799d579ffd6cd0bd505</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c8842ccbd8c0e253c1f189088228f9b433f7a93b7196b9e5b6f87dba393f5d5d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f1e7b36bdff50103af95a80923bf1853f6823dd62f2d2a2524b66ed74103e49</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bba97b8e8883a8038606480d6b6772289f4c907f6ba780fa1f7b7da7dfd76f06</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a7f615270fe534548112a74e790cd9d4f5509d744dd718cd442bf016626c22e4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e6c8c8693df718c5ecbc7babb12c69a4e3677fd11de8886f05ab22d4e6b1c43b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-linux_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">73db2dc1b201d20ab7083e7041946910bb991e7e9761a0394bbc3c2632326483</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-macosx_10_10_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">407b26b7f7bbd4f4751dbc9767a1f0716f9fe72d3d7e96bb3ccfc4aace07c8de</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-manylinux_2_17_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f8de7c8cef9261a2d0a62edf2ccea3d741a523c6b8a6477a340a1f2e417658de</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9bd5c8a1af40ec305d001c60236308a67e25419003e9bb3ebfab5695a8d0b369</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">be0477cb31da67846a33b1a75c611f88bfbcd427fe17701b6317aefceee1b96f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">60dcd824df166ba266ee0cfaf35a31406cd16ef602b49f5d4dfb21f014b0dedd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">973c49086cabab773525f6077f95e5a993bfc03ba8fc32e32f2c279497780585</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">12859468e8918d3bd243d213cd6fd6ab07208195dc140763c00dfe901ce1e1b4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b7209117bbeebdfa5d898205cc55153a51285757902dd73c47de498ad4d11332</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/grpcio/#grpcio-1.62.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6c455e008fa86d9e9a9d85bb76da4277c0d7d9668a3bfa70dbe86e9f3c759947</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="h11@0.14.0">
+      <name>h11</name>
+      <version>0.14.0</version>
+      <description>A pure-Python, bring-your-own-I/O implementation of HTTP/1.1</description>
+      <purl>pkg:pypi/h11@0.14.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/h11/#h11-0.14.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/h11/#h11-0.14.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="httptools@0.6.1">
+      <name>httptools</name>
+      <version>0.6.1</version>
+      <description>A collection of framework independent HTTP protocol utils.</description>
+      <purl>pkg:pypi/httptools@0.6.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d2f6c3c4cb1948d912538217838f6e9960bc4a521d7f9b323b3da579cd14532f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">00d5d4b68a717765b1fabfd9ca755bd12bf44105eeb806c03d1962acd9b8e563</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">639dc4f381a870c9ec860ce5c45921db50205a37cc3334e756269736ff0aac58</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e57997ac7fb7ee43140cc03664de5f268813a481dff6245e0075925adc6aa185</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0ac5a0ae3d9f4fe004318d64b8a854edd85ab76cffbf7ef5e32920faef62f142</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3f30d3ce413088a98b9db71c60a6ada2001a08945cb42dd65a9a9fe228627658</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1ed99a373e327f0107cb513b61820102ee4f3675656a37a50083eda05dc9541b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7a7ea483c1a4485c71cb5f38be9db078f8b0e8b4c4dc0210f531cdd2ddac1ef1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">85ed077c995e942b6f1b07583e4eb0a8d324d418954fc6af913d36db7c05a5a0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8b0bb634338334385351a1600a73e558ce619af390c2b38386206ac6a27fecfc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7d9ceb2c957320def533671fc9c715a80c47025139c8d1f3797477decbc6edd2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f0f8271c0a4db459f9dc807acd0eadd4839934a4b9b892f6f160e94da309837</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6a4f5ccead6d18ec072ac0b84420e95d27c1cdf5c9f1bc8fbd8daf86bd94f43d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5cceac09f164bcba55c0500a18fe3c47df29b62353198e4f37bbcc5d591172c3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">75c8022dca7935cba14741a42744eee13ba05db00b27a4b940f0d646bd4d56d0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48ed8129cd9a0d62cf4d1575fcf90fb37e3ff7d5654d3a5814eb3d55f36478c2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6f58e335a1402fb5a650e271e8c2d03cfa7cea46ae124649346d17bd30d59c90</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">93ad80d7176aa5788902f207a4e79885f0576134695dfb0fefc15b7a4648d503</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9bb68d3a085c2174c2477eb3ffe84ae9fb4fde8792edb7bcd09a1d8467e30a84</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b512aa728bc02354e5ac086ce76c3ce635b62f5fbc32ab7082b5e582d27867bb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">97662ce7fb196c785344d00d638fc9ad69e18ee4bfb4000b35a52efe5adcc949</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp38-cp38-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8e216a038d2d52ea13fdd9b9c9c7459fb80d78302b257828285eca1c773b99b3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3e802e0b2378ade99cd666b5bffb8b2a7cc8f3d28988685dc300469ea8dd86cb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4bd3e488b447046e386a30f07af05f9b38d3d368d1f7b4d8f7e10af85393db97</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fe467eb086d80217b7584e61313ebadc8d187a4d95bb62031b7bab4b205c3ba3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3c3b214ce057c54675b00108ac42bacf2ab8f85c58e3f324a4e963bbc46424f4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8ae5b97f690badd2ca27cbf668494ee1b6d34cf1c464271ef7bfa9ca6b83ffaf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">405784577ba6540fa7d6ff49e37daf104e04f4b4ff2d1ac0469eaa6a20fde084</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">95fb92dd3649f9cb139e9c56604cc2d7c7bf0fc2e7c8d7fbd58f96e35eddd2a3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dcbab042cc3ef272adc11220517278519adf8f53fd3056d0e68f0a6f891ba94e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0cf2372e98406efb42e93bfe10f2948e467edfd792b015f1b4ecd897903d3e8d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">678fcbae74477a17d103b7cae78b74800d795d702083867ce160fc202104d0da</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e0b281cf5a125c35f7f6722b65d8542d2e57331be573e9e88bc8b0115c4a7a81</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">95658c342529bba4e1d3d2b1a874db16c7cca435e8827422154c9da76ac4e13a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7ebaec1bf683e4bf5e9fbb49b8cc36da482033596a415b3e4ebab5a4c0d7ec5e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/httptools/#httptools-0.6.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c6e26c30455600b95d94b1b836085138e82f177351454ee841c148f93a9bad5a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="idna@3.6">
+      <name>idna</name>
+      <version>3.6</version>
+      <description>Internationalized Domain Names in Applications (IDNA)</description>
+      <purl>pkg:pypi/idna@3.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/#idna-3.6-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/#idna-3.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="jsonschema@4.21.1">
+      <name>jsonschema</name>
+      <version>4.21.1</version>
+      <description>An implementation of JSON Schema validation for Python</description>
+      <purl>pkg:pypi/jsonschema@4.21.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema/#jsonschema-4.21.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7996507afae316306f9e2290407761157c6f78002dcf7419acb99822143d1c6f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema/#jsonschema-4.21.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">85727c00279f5fa6bedbe6238d2aa6403bedd8b4864ab11207d07df3cc1b2ee5</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="jsonschema-specifications@2023.12.1">
+      <name>jsonschema-specifications</name>
+      <version>2023.12.1</version>
+      <description>The JSON Schema meta-schemas and vocabularies, exposed as a Registry</description>
+      <purl>pkg:pypi/jsonschema-specifications@2023.12.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.12.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">87e4fdf3a94858b8a2ba2778d9ba57d8a9cafca7c7489c46ba0d30a8bc6a9c3c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.12.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48a76787b3e70f5ed53f1160d2b81f586e4ca6d1548c5de7085d1682674764cc</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="msgpack@1.0.8">
+      <name>msgpack</name>
+      <version>1.0.8</version>
+      <description>MessagePack serializer</description>
+      <purl>pkg:pypi/msgpack@1.0.8</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">505fe3d03856ac7d215dbe005414bc28505d26f0c128906037e66d98c4e95868</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e6b7842518a63a9f17107eb176320960ec095a8ee3b4420b5f688e24bf50c53c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">376081f471a2ef24828b83a641a02c575d6103a3ad7fd7dade5486cad10ea659</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5e390971d082dba073c05dbd56322427d3280b7cc8b53484c9377adfbae67dc2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">00e073efcba9ea99db5acef3959efa45b52bc67b61b00823d2a1a6944bf45982</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">82d92c773fbc6942a7a8b520d22c11cfc8fd83bba86116bfcf962c2f5c2ecdaa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9ee32dcb8e531adae1f1ca568822e9b3a738369b3b686d1477cbc643c4a9c128</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e3aa7e51d738e0ec0afbed661261513b38b3014754c9459508399baf14ae0c9d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">69284049d07fce531c17404fcba2bb1df472bc2dcdac642ae71a2d079d950653</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">13577ec9e247f8741c84d06b9ece5f654920d8365a4b636ce0e44f15e07ec693</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e532dbd6ddfe13946de050d7474e3f5fb6ec774fbb1a188aaf469b08cf04189a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9517004e21664f2b5a5fd6333b0731b9cf0817403a941b393d89a2f1dc2bd836</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d16a786905034e7e34098634b184a7d81f91d4c3d246edc6bd7aefb2fd8ea6ad</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e2872993e209f7ed04d963e4b4fbae72d034844ec66bc4ca403329db2074377b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5c330eace3dd100bdb54b5653b966de7f51c26ec4a7d4e87132d9b4f738220ba</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">83b5c044f3eff2a6534768ccfd50425939e7a8b5cf9a7261c385de1e20dcfc85</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1876b0b653a808fcd50123b953af170c535027bf1d053b59790eebb0aeb38950</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dfe1f0f0ed5785c187144c46a292b8c34c1295c01da12e10ccddfc16def4448a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3528807cbbb7f315bb81959d5961855e7ba52aa60a3097151cb21956fbc7502b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e2f879ab92ce502a1e65fce390eab619774dda6a6ff719718069ac94084098ce</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">26ee97a8261e6e35885c2ecd2fd4a6d38252246f94a2aec23665a4e66d066305</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eadb9f826c138e6cf3c49d6f8de88225a3c0ab181a9b4ba792e006e5292d150e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">114be227f5213ef8b215c22dde19532f5da9652e56e8ce969bf0a26d7c419fee</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d661dc4785affa9d0edfdd1e59ec056a58b3dbb9f196fa43587f3ddac654ac7b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d56fd9f1f1cdc8227d7b7918f55091349741904d9520c65f0139a9755952c9e8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0726c282d188e204281ebd8de31724b7d749adebc086873a59efb8cf7ae27df3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8db8e423192303ed77cff4dce3a4b88dbfaf43979d280181558af5e2c3c71afc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">99881222f4a8c2f641f25703963a5cefb076adffd959e0558dc9f803a52d6a58</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b5505774ea2a73a86ea176e8a9a4a7c8bf5d521050f0f6f8426afe798689243f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ef254a06bcea461e65ff0373d8a0dd1ed3aa004af48839f002a0c994a6f72d04</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e1dd7839443592d00e96db831eddb4111a2a81a46b028f0facd60a09ebbdd543</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">64d0fcd436c5683fdd7c907eeae5e2cbb5eb872fafbc03a43609d7941840995c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">74398a4cf19de42e1498368c36eed45d9528f5fd0155241e82c4082b7e16cffd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0ceea77719d45c839fd73abcb190b8390412a890df2f83fb8cf49b2a4b5c2f40</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1ab0bbcd4d1f7b6991ee7c753655b481c50084294218de69365f8f1970d4c151</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1cce488457370ffd1f953846f82323cb6b2ad2190987cd4d70b2713e17268d24</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3923a1778f7e5ef31865893fdca12a8d7dc03a44b33e2a5f3295416314c09f5d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a22e47578b30a3e199ab067a4d43d790249b3c0587d9a771921f86250c8435db</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bd739c9251d01e0279ce729e37b39d49a08c0420d3fee7f2a4968c0576678f77</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d3420522057ebab1728b21ad473aa950026d07cb09da41103f8e597dfbfaeb13</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5845fdf5e5d5b78a49b826fcdc0eb2e2aa7191980e3d2cfd2a30303a74f212e2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6a0e76621f6e1f908ae52860bdcb58e1ca85231a9b0545e64509c931dd34275a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">374a8e88ddab84b9ada695d255679fb99c53513c0a51778796fcf0944d6c789c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f3709997b228685fe53e8c433e2df9f0cdb5f4542bd5114ed17ac3c0129b0480</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f51bab98d52739c50c56658cc303f190785f9a2cd97b823357e7aeae54c8f68a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">73ee792784d48aa338bba28063e19a27e8d989344f34aad14ea6e1b9bd83f596</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f9904e24646570539a8950400602d66d2b2c492b9010ea7e965025cb71d0c86d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e75753aeda0ddc4c28dce4c32ba2f6ec30b1b02f6c0b14e547841ba5b24f753f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5dbf059fb4b7c240c873c1245ee112505be27497e90f7c6591261c7d3c3a8228</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4916727e31c28be8beaf11cf117d6f6f188dcc36daae4e851fee88646f5b6b18</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7938111ed1358f536daf311be244f34df7bf3cdedb3ed883787aca97778b28d8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">493c5c5e44b06d6c9268ce21b302c9ca055c1fd3484c25ba41d34476c76ee746</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/msgpack/#msgpack-1.0.8.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="multidict@6.0.5">
+      <name>multidict</name>
+      <version>6.0.5</version>
+      <description>multidict implementation</description>
+      <purl>pkg:pypi/multidict@6.0.5</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">228b644ae063c10e7f324ab1ab6b548bdf6f8b47f3ec234fef1093bc2735e5f9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">896ebdcf62683551312c30e20614305f53125750803b614e9e6ce74a96232604</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">411bf8515f3be9813d06004cac41ccf7d1cd46dfe233705933dd163b60e37600</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1d147090048129ce3c453f0292e7697d333db95e52616b3793922945804a433c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">215ed703caf15f578dca76ee6f6b21b7603791ae090fbf1ef9d865571039ade5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7c6390cf87ff6234643428991b7359b5f59cc15155695deb4eda5c777d2b880f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">21fd81c4ebdb4f214161be351eb5bcf385426bf023041da2fd9e60681f3cebae</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3cc2ad10255f903656017363cd59436f2111443a76f996584d1077e43ee51182</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6939c95381e003f54cd4c5516740faba40cf5ad3eeff460c3ad1d3e0ea2549bf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">220dd781e3f7af2c2c1053da9fa96d9cf3072ca58f057f4c5adaaa1cab8fc442</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">766c8f7511df26d9f11cd3a8be623e59cca73d44643abab3f8c8c07620524e4a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fe5d7785250541f7f5019ab9cba2c71169dc7d74d0f45253f8313f436458a4ef</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c1c1496e73051918fcd4f58ff2e0f2f3066d1c76a0c6aeffd9b45d53243702cc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7afcdd1fc07befad18ec4523a782cde4e93e0a2bf71239894b8d61ee578c1319</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">99f60d34c048c5c2fabc766108c103612344c46e35d4ed9ae0673d33c8fb26e8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f285e862d2f153a70586579c15c44656f888806ed0e5b56b64489afe4a2dbfba</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">53689bb4e102200a4fafa9de9c7c3c212ab40a7ab2c8e474491914d2305f187e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">612d1156111ae11d14afaf3a0669ebf6c170dbb735e510a7438ffe2369a847fd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7be7047bd08accdb7487737631d25735c9a04327911de89ff1b26b81745bd4e3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">de170c7b4fe6859beb8926e84f7d7d6c693dfe8e27372ce3b76f01c46e489fcf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">04bde7a7b3de05732a4eb39c94574db1ec99abb56162d6c520ad26f83267de29</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">85f67aed7bb647f93e7520633d8f51d3cbc6ab96957c71272b286b2f30dc70ed</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">425bf820055005bfc8aa9a0b99ccb52cc2f4070153e34b701acc98d201693733</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d3eb1ceec286eba8220c26f3b0096cf189aea7057b6e7b7a2e60ed36b373b77f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7901c05ead4b3fb75113fb1dd33eb1253c6d3ee37ce93305acd9d38e0b5f21a4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e0e79d91e71b9867c73323a3444724d496c037e578a0e1755ae159ba14f4f3d1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">29bfeb0dff5cb5fdab2023a7a9947b3b4af63e9c47cae2a10ad58394b517fddc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e030047e85cbcedbfc073f71836d62dd5dadfbe7531cae27789ff66bc551bd5e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2f4848aa3baa109e6ab81fe2006c77ed4d3cd1e0ac2c1fbddb7b1277c168788c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2faa5ae9376faba05f630d7e5e6be05be22913782b927b19d12b8145968a85ea</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">51d035609b86722963404f711db441cf7134f1889107fb171a970c9701f92e1e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cbebcd5bcaf1eaf302617c114aa67569dd3f090dd0ce8ba9e35e9985b41ac35b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2ffc42c922dbfddb4a4c3b438eb056828719f07608af27d163191cb3e3aa6cc5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ceb3b7e6a0135e092de86110c5a74e46bda4bd4fbfeeb3a3bcec79c0f861e450</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">79660376075cfd4b2c80f295528aa6beb2058fd289f4c9252f986751a4cd0496</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e4428b29611e989719874670fd152b6625500ad6c686d464e99f5aaeeaca175a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d84a5c3a5f7ce6db1f999fb9438f686bc2e09d38143f2d93d8406ed2dd6b9226</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">76c0de87358b192de7ea9649beb392f107dcad9ad27276324c24c91774ca5271</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">79a6d2ba910adb2cbafc95dad936f8b9386e77c84c35bc0add315b856d7c3abb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">92d16a3e275e38293623ebf639c471d3e03bb20b8ebb845237e0d3664914caef</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fb616be3538599e797a2017cccca78e354c767165e8858ab5116813146041a24</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">14c2976aa9038c2629efa2c148022ed5eb4cb939e15ec7aace7ca932f48f9ba6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">435a0984199d81ca178b9ae2c26ec3d49692d20ee29bc4c11a2a8d4514c67eda</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9fe7b0653ba3d9d65cbe7698cca585bf0f8c83dbbcc710db9c90f478e175f2d5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">01265f5e40f5a17f8241d52656ed27192be03bfa8764d88e8220141d1e4b3556</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">19fe01cea168585ba0f678cad6f58133db2aa14eccaf22f88e4a6dccadfad8b3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6bf7a982604375a8d49b6cc1b781c1747f243d91b81035a9b43a2126c04766f5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">107c0cdefe028703fb5dafe640a409cb146d44a6ae201e55b35a4af8e95457dd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">403c0911cd5d5791605808b942c88a8155c2592e05332d2bf78f18697a5fa15e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aeaf541ddbad8311a87dd695ed9642401131ea39ad7bc8cf3ef3967fd093b626</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e4972624066095e52b569e02b5ca97dbd7a7ddd4294bf4e7247d52635630dd83</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d946b0a9eb8aaa590df1fe082cee553ceab173e6cb5b03239716338629c50c7a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b55358304d7a73d7bdf5de62494aaf70bd33015831ffd98bc498b433dfe5b10c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a3145cb08d8625b2d3fee1b2d596a8766352979c9bffe5d7833e0503d0f0b5e5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d65f25da8e248202bd47445cec78e0025c0fe7582b23ec69c3b27a640dd7a8e3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c9bf56195c6bbd293340ea82eafd0071cb3d450c703d2c93afb89f93b8386ccc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">69db76c09796b313331bb7048229e3bee7928eb62bab5e071e9f7fcc4879caee</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fce28b3c8a81b6b36dfac9feb1de115bab619b3c13905b419ec71d03a3fc1423</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">76f067f5121dcecf0d63a67f29080b26c43c71a98b10c701b0677e4a065fbd54</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b82cc8ace10ab5bd93235dfaab2021c70637005e1ac787031f4d1da63d493c1d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5cb241881eefd96b46f89b1a056187ea8e9ba14ab88ba632e68d7a2ecb7aadf7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e8e94e6912639a02ce173341ff62cc1201232ab86b8a8fcc05572741a5dc7d93</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">09a892e4a9fb47331da06948690ae38eaa2426de97b4ccbfafbdcbe5c8f37ff8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">55205d03e8a598cfc688c71ca8ea5f66447164efff8869517f175ea632c7cb7b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">37b15024f864916b4951adb95d3a80c9431299080341ab9544ed148091b53f50</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f2a1dee728b52b33eebff5072817176c172050d44d67befd681609b4746e1c2e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">edd08e6f2f1a390bf137080507e44ccc086353c8e98c657e666c017718561b89</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">60d698e8179a42ec85172d12f50b1668254628425a6bd611aba022257cac1386</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3d25f19500588cbc47dc19081d78131c32637c25804df8414463ec908631e453</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4cc0ef8b962ac7a5e62b9e826bd0cd5040e7d401bc45a6835910ed699037a461</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eca2e9d0cc5a889850e9bbd68e98314ada174ff6ccd1129500103df7a94a7a44</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4a6a4f196f08c58c59e0b8ef8ec441d12aee4125a7d4f4fef000ccb22f8d7241</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0275e35209c27a3f7951e1ce7aaf93ce0d163b28948444bec61dd7badc6d3f8c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e7be68734bd8c9a513f2b0cfd508802d6609da068f40dc57d4e3494cefc92929</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1d9ea7a7e779d7a3561aade7d596649fbecfa5c08a7674b11b423783217933f9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ea1456df2a27c73ce51120fa2f519f1bea2f4a03a917f4a43c8707cf4cbbae1a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cf590b134eb70629e350691ecca88eac3e3b8b3c86992042fb82e3cb1830d5e1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5c0631926c4f58e9a5ccce555ad7747d9a9f8b10619621f22f9635f069f6233e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dce1c6912ab9ff5f179eaf6efe7365c1f425ed690b03341911bf4939ef2f3046</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c0868d64af83169e4d4152ec612637a543f7a336e4a307b119e98042e852ad9c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">141b43360bfd3bdd75f15ed811850763555a251e38b2405967f8e25fb43f7d40</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7df704ca8cf4a073334e0427ae2345323613e4df18cc224f647f251e5e75a527</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6214c5a5571802c33f80e6c84713b2c79e024995b9c5897f794b43e714daeec9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd6c8fca38178e12c00418de737aef1261576bd1b6e8c6134d3e729a4e858b38</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e02021f87a5b6932fa6ce916ca004c4d441509d33bbdbeca70d05dff5e9d2479</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ebd8d160f91a764652d3e51ce0d2956b38efe37c9231cd82cfc0bed2e40b581c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">04da1bb8c8dbadf2a18a452639771951c662c5ad03aefe4884775454be322c9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d6f6d4f185481c9669b9447bf9d9cf3b95a0e9df9d169bbc17e363b7d5487755</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0d63c74e3d7ab26de115c49bffc92cc77ed23395303d496eae515d4204a625e7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/multidict/#multidict-6.0.5.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f7e301075edaf50500f0b341543c41194d8df3ae5caf4702f2095f3ca73dd8da</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="opencensus@0.11.4">
+      <name>opencensus</name>
+      <version>0.11.4</version>
+      <description>A stats collection and distributed tracing framework</description>
+      <purl>pkg:pypi/opencensus@0.11.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/opencensus/#opencensus-0.11.4-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a18487ce68bc19900336e0ff4655c5a116daf10c1b3685ece8d971bddad6a864</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/opencensus/#opencensus-0.11.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="opencensus-context@0.1.3">
+      <name>opencensus-context</name>
+      <version>0.1.3</version>
+      <description>OpenCensus Runtime Context</description>
+      <purl>pkg:pypi/opencensus-context@0.1.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/opencensus-context/#opencensus-context-0.1.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a03108c3c10d8c80bb5ddf5c8a1f033161fa61972a9917f9b9b3a18517f0088c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/opencensus-context/#opencensus_context-0.1.3-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">073bb0590007af276853009fac7e4bab1d523c3f03baf4cb4511ca38967c6039</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="packaging@24.0">
+      <name>packaging</name>
+      <version>24.0</version>
+      <description>Core utilities for Python packages</description>
+      <purl>pkg:pypi/packaging@24.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/packaging/#packaging-24.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/packaging/#packaging-24.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="platformdirs@4.2.0">
+      <name>platformdirs</name>
+      <version>4.2.0</version>
+      <description>A small Python package for determining appropriate platform-specific dirs, e.g. a &quot;user data dir&quot;.</description>
+      <purl>pkg:pypi/platformdirs@4.2.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/platformdirs/#platformdirs-4.2.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/platformdirs/#platformdirs-4.2.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="prometheus-client@0.20.0">
+      <name>prometheus-client</name>
+      <version>0.20.0</version>
+      <description>Python client for the Prometheus monitoring system.</description>
+      <purl>pkg:pypi/prometheus-client@0.20.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/prometheus-client/#prometheus_client-0.20.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cde524a85bce83ca359cc837f28b8c0db5cac7aa653a588fd7e84ba061c329e7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/prometheus-client/#prometheus_client-0.20.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">287629d00b147a32dcb2be0b9df905da599b2d82f80377083ec8463309a4bb89</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="protobuf@5.26.1">
+      <name>protobuf</name>
+      <version>5.26.1</version>
+      <description/>
+      <purl>pkg:pypi/protobuf@5.26.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp310-abi3-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3c388ea6ddfe735f8cf69e3f7dc7611e73107b60bdfcf5d0f024c3ccd3794e23</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp310-abi3-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e6039957449cb918f331d32ffafa8eb9255769c96aa0560d9a5bf0b4e00a2a33</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp37-abi3-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">38aa5f535721d5bb99861166c445c4105c4e285c765fbb2ac10f116e32dcd46d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp37-abi3-manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fbfe61e7ee8c1860855696e3ac6cfd1b01af5498facc6834fcc345c9684fb2ca</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp37-abi3-manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f7417703f841167e5a27d48be13389d52ad705ec09eade63dfc3180a959215d7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d693d2504ca96750d92d9de8a103102dd648fda04540495535f0fec7577ed8fc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9b557c317ebe6836835ec4ef74ec3e994ad0894ea424314ad3552bc6e8835b4e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b9ba3ca83c2e31219ffbeb9d76b63aad35a3eb1544170c55336993d7a18ae72c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7ee014c2c87582e101d6b54260af03b6596728505c79f17c8586e7523aaa8f8c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">da612f2720c0183417194eeaa2523215c4fcc1a1949772dc65f05047e08d5932</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/protobuf/#protobuf-5.26.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8ca2a1d97c290ec7b16e4e5dff2e5ae150cc1582f55b5ab300d45cb0dfa90e51</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="py-spy@0.3.14">
+      <name>py-spy</name>
+      <version>0.3.14</version>
+      <description>Sampling profiler for Python programs</description>
+      <purl>pkg:pypi/py-spy@0.3.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5b342cc5feb8d160d57a7ff308de153f6be68dcf506ad02b4d67065f2bae7f45</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fe7efe6c91f723442259d428bf1f9ddb9c1679828866b353d539345ca40d9dd2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">590905447241d789d9de36cff9f52067b6f18d8b5e9fb399242041568d414461</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fd6211fe7f587b3532ba9d300784326d9a6f2b890af7bf6fff21a029ebbc812b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3e8e48032e71c94c3dd51694c39e762e4bbfec250df5bf514adcdd64e79371e0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f59b0b52e56ba9566305236375e6fc68888261d0d36b5addbe3cf85affbefc0e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-spy/#py_spy-0.3.14-py2.py3-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8f5b311d09f3a8e33dbd0d44fc6e37b715e8e0c7efefafcda8bfd63b31ab5a31</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pyasn1@0.6.0">
+      <name>pyasn1</name>
+      <version>0.6.0</version>
+      <description>Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)</description>
+      <purl>pkg:pypi/pyasn1@0.6.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyasn1/#pyasn1-0.6.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cca4bb0f2df5504f02f6f8a775b6e416ff9b0b3b16f7ee80b5a3153d9b804473</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyasn1/#pyasn1-0.6.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a35ab2c4b5ef98e17dfdec8ab074046fbda76e281c5a706ccd82328cfc8f64c</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pyasn1-modules@0.4.0">
+      <name>pyasn1-modules</name>
+      <version>0.4.0</version>
+      <description>A collection of ASN.1-based protocols modules</description>
+      <purl>pkg:pypi/pyasn1-modules@0.4.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyasn1-modules/#pyasn1_modules-0.4.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">be04f15b66c206eed667e0bb5ab27e2b1855ea54a842e5037738099e8ca4ae0b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyasn1-modules/#pyasn1_modules-0.4.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">831dbcea1b177b28c9baddf4c6d1013c24c3accd14a1873fffaa6a2e905f17b6</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pydantic@2.6.4">
+      <name>pydantic</name>
+      <version>2.6.4</version>
+      <description>Data validation using Python type hints</description>
+      <purl>pkg:pypi/pydantic@2.6.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic/#pydantic-2.6.4-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cc46fce86607580867bdc3361ad462bab9c222ef042d3da86f2fb333e1d916c5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic/#pydantic-2.6.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b1704e0847db01817624a6b86766967f552dd9dbf3afba4004409f908dcc84e6</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pydantic-core@2.16.3">
+      <name>pydantic-core</name>
+      <version>2.16.3</version>
+      <description/>
+      <purl>pkg:pypi/pydantic-core@2.16.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">75b81e678d1c1ede0785c7f46690621e4c6e63ccd9192af1f0bd9d504bbb6bf4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9c865a7ee6f93783bd5d781af5a4c43dadc37053a5b42f7d18dc019f8c9d2bd1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">162e498303d2b1c036b957a1278fa0899d02b2842f1ff901b6395104c5554a45</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2f583bd01bbfbff4eaee0868e6fc607efdfcc2b03c1c766b06a707abbc856187</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b926dd38db1519ed3043a4de50214e0d600d404099c3392f098a7f9d75029ff8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">716b542728d4c742353448765aa7cdaa519a7b82f9564130e2b3f6766018c9ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fc4ad7f7ee1a13d9cb49d8198cd7d7e3aa93e425f371a68235f784e99741561f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bd87f48924f360e5d1c5f770d6155ce0e7d83f7b4e10c2f9ec001c73cf475c99</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0df446663464884297c793874573549229f9eca73b59360878f382a0fc085979</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4df8a199d9f6afc5ae9a65f8f95ee52cae389a8c6b20163762bde0426275b7db</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">456855f57b413f077dff513a5a28ed838dbbb15082ba00f80750377eed23d132</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp310-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">732da3243e1b8d3eab8c6ae23ae6a58548849d2e4a4e03a1924c8ddf71a387cb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">519ae0312616026bf4cedc0fe459e982734f3ca82ee8c7246c19b650b60a5ee4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3992a322a5617ded0a9f23fd06dbc1e4bd7cf39bc4ccf344b10f80af58beacd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8d62da299c6ecb04df729e4b5c52dc0d53f4f8430b4492b93aa8de1f541c4aac</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2acca2be4bb2f2147ada8cac612f8a98fc09f41c89f87add7256ad27332c2fda</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1b662180108c55dfbf1280d865b2d116633d436cfc0bba82323554873967b340</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e7c6ed0dc9d8e65f24f5824291550139fe6f37fac03788d4580da0d33bc00c97</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a6b1bb0827f56654b4437955555dc3aeeebeddc47c2d7ed575477f082622c49e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e56f8186d6210ac7ece503193ec84104da7ceb98f68ce18c07282fcc2452e76f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">936e5db01dd49476fa8f4383c259b8b1303d5dd5fb34c97de194560698cc2c5e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">33809aebac276089b78db106ee692bdc9044710e26f24a9a2eaa35a0f9fa70ba</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ded1c35f15c9dea16ead9bffcde9bb5c7c031bff076355dc58dcb1cb436c4721</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d89ca19cdd0dd5f31606a9329e309d4fcbb3df860960acec32630297d61820df</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp311-none-win_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6162f8d2dc27ba21027f261e4fa26f8bcb3cf9784b7f9499466a311ac284b5b9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0f56ae86b60ea987ae8bcd6654a887238fd53d1384f9b222ac457070b7ac4cff</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c9bd22a2a639e26171068f8ebb5400ce2c1bc7d17959f60a3b753ae13c632975</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4204e773b4b408062960e65468d5346bdfe139247ee5f1ca2a378983e11388a2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f651dd19363c632f4abe3480a7c87a9773be27cfe1341aef06e8759599454120</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aaf09e615a0bf98d406657e0008e4a8701b11481840be7d31755dc9f97c44053</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8e47755d8152c1ab5b55928ab422a76e2e7b22b5ed8e90a7d584268dd49e9c6b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">500960cb3a0543a724a81ba859da816e8cf01b0e6aaeedf2c3775d12ee49cade</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cf6204fe865da605285c34cf1172879d0314ff267b1c35ff59de7154f35fdc2e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d33dd21f572545649f90c38c227cc8631268ba25c460b5569abebdd0ec5974ca</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">49d5d58abd4b83fb8ce763be7794d09b2f50f10aa65c0f0c1696c677edeb7cbf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f53aace168a2a10582e570b7736cc5bef12cae9cf21775e3eafac597e8551fbe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0d32576b1de5a30d9a97f300cc6a3f4694c428d956adbc7e6e2f9cad279e45ed</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp312-none-win_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ec08be75bb268473677edb83ba71e7e74b43c008e4a7b1907c6d57e940bf34b6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b1f6f5938d63c6139860f044e2538baeee6f0b251a1816e7adb6cbce106a1f01</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2a1ef6a36fdbf71538142ed604ad19b82f67b05749512e47f247a6ddd06afdc7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">704d35ecc7e9c31d48926150afada60401c55efa3b46cd1ded5a01bdffaf1d48</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d937653a696465677ed583124b94a4b2d79f5e30b2c46115a68e482c6a591c8a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c9803edf8e29bd825f43481f19c37f50d2b01899448273b3a7758441b512acf8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">72282ad4892a9fb2da25defeac8c2e84352c108705c972db82ab121d15f14e6d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7f752826b5b8361193df55afcdf8ca6a57d0232653494ba473630a83ba50d8c9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4384a8f68ddb31a0b0c3deae88765f5868a1b9148939c3f4121233314ad5532c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a4b2bf78342c40b3dc830880106f54328928ff03e357935ad26c7128bbd66ce8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">13dcc4802961b5f843a9385fc821a0b0135e8c07fc3d9949fd49627c1a5e6ae5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e3e70c94a0c3841e6aa831edab1619ad5c511199be94d0c11ba75fe06efe107a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp38-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ecdf6bf5f578615f2e985a5e1f6572e23aa632c4bd1dc67f8f406d445ac115ed</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bda1ee3e08252b8d41fa5537413ffdddd58fa73107171a126d3b9ff001b9b820</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">21b888c973e4f26b7a96491c0965a8a312e13be108022ee510248fe379a5fa23</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">be0ec334369316fa73448cc8c982c01e5d2a81c95969d58b8f6e272884df0074</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b5b6079cc452a7c53dd378c6f881ac528246b3ac9aae0f8eef98498a75657805</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7ee8d5f878dccb6d499ba4d30d757111847b6849ae07acdd1205fffa1fc1253c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7233d65d9d651242a68801159763d09e9ec96e8a158dbf118dc090cd77a104c9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c6119dc90483a5cb50a1306adb8d52c66e447da88ea44f323e0ae1a5fcb14256</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">578114bc803a4c1ff9946d977c221e4376620a46cf78da267d946397dc9514a8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d8f99b147ff3fcf6b3cc60cb0c39ea443884d5559a30b1481e92495f2310ff2b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4ac6b4ce1e7283d715c4b729d8f9dab9627586dafce81d9eaa009dd7f25dd972</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e7774b570e61cb998490c5235740d475413a1f6de823169b4cf94e2fe9e9f6b2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-cp39-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9091632a25b8b87b9a605ec0e61f241c456e9248bfdcf7abdf344fdb169c81cf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">36fa178aacbc277bc6b62a2c3da95226520da4f4e9e206fdf076484363895d2c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dcca5d2bf65c6fb591fff92da03f94cd4f315972f97c21975398bd4bd046854a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2a72fb9963cba4cd5793854fd12f4cfee731e86df140f59ff52a49b3552db241</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b60cc1a081f80a2105a59385b92d82278b15d80ebb3adb200542ae165cd7d183</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cbcc558401de90a746d02ef330c528f2e668c83350f045833543cd57ecead1ad</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fee427241c2d9fb7192b658190f9f5fd6dfe41e02f3c1489d2ec1e6a5ab1e04a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f4cb85f693044e0f71f394ff76c98ddc1bc0953e48c061725e540396d5c8a2e1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp310-pypy310_pp73-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b29eeb887aa931c2fcef5aa515d9d176d25006794610c264ddc114c053bf96fe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a425479ee40ff021f8216c9d07a6a3b54b31c8267c6e17aa88b70d7ebd0e5e5b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5c5cbc703168d1b7a838668998308018a2718c2130595e8e190220238addc96f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">99b6add4c0b39a513d323d3b93bc173dac663c27b99860dd5bf491b240d26137</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">75f76ee558751746d6a38f89d60b6228fa174e5172d143886af0f85aa306fd89</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">00ee1c97b5364b84cb0bd82e9bbf645d5e2871fb8c58059d158412fee2d33d8a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">287073c66748f624be4cef893ef9174e3eb88fe0b8a78dc22e88eca4bc357ca6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ed25e1835c00a332cb10c683cd39da96a719ab1dfc08427d476bce41b92531fc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3-pp39-pypy39_pp73-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">86b3d0033580bd6bbe07590152007275bd7af95f98eaa5bd36f3da219dcd93da</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pydantic-core/#pydantic_core-2.16.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1cac689f80a3abab2d3c0048b29eea5751114054f032a941a32de4c852c59cad</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="python-dotenv@1.0.1">
+      <name>python-dotenv</name>
+      <version>1.0.1</version>
+      <description>Read key-value pairs from a .env file and set them as environment variables</description>
+      <purl>pkg:pypi/python-dotenv@1.0.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dotenv/#python-dotenv-1.0.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dotenv/#python_dotenv-1.0.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pyyaml@6.0.1">
+      <name>pyyaml</name>
+      <version>6.0.1</version>
+      <description>YAML parser and emitter for Python</description>
+      <purl>pkg:pypi/pyyaml@6.0.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp36-cp36m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pyyaml/#PyYAML-6.0.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="ray@2.10.0">
+      <name>ray</name>
+      <version>2.10.0</version>
+      <description>Ray provides a simple, universal API for building distributed applications.</description>
+      <purl>pkg:pypi/ray@2.10.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-macosx_10_15_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8a174268c7b6ca9826e4884b837395b695a45c17049927965d1b4cc370184ba2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c193deed7e3f604cdb37047f5646cab14f4337693dd32add8bc902dfadb89f75</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a3db89d22afc7a0a976249715dd90ffe69f7692d32cb599cd1afbc38482060f7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cb74f7d2aa5a21e5f9dcb315a4f9bde822328e76ba95cd0ba370cfda098a67f4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">44ab600fe0b5a12675d0d42d564994ac4e53286217c4de1c4eb00d74ae79ef24</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-macosx_10_15_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8eb606b7d247213b377ccca0f8d425f9c61a48b23e9b2e4566bc75f66d797bb5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8eb11aec8a65946f7546d0e703158c03a85a8be27332dbbf86d9411802700e7e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5b4ec4b5707e18382685d0703ed04afd1602359a3056f6ae4b37588a0551eef3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c7d1438cba8726ec9a59c96964e007b60a0728436647f48c383228692c2f2ee0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eceecea4133e63f5d607cc9f2a4278de51eeeeef552f694895e381aae9ff8522</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-macosx_10_15_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fb92f2d6d4eca602dfb0d3d459a09be59668e1560ce4bd89b692892f25b1933b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">31aa60373fc7291752ee89a5f5ad8effec682b1f165911f38ae95fc43bc668a9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5b7d41eb04f6b67c38170edc0406dc71537eabfd6e5d4e3399a36385ff8b0194</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8a44535e6266fa09e3eb4fc9035906decfc9f3aeda86fe66b1e738a01a51939a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">77ba4120d694e7c3dc7d93a9d3cb33925827d04ad11af2d21fa0db66f227d27a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-macosx_10_15_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b49a8c2b40f02a56a2af2b6026c1eedd485747c6e4c2cf9ac433af6e572bdbb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5fe8fb8847304dd3a6e435b95af9e5436309f2b3612c63c56bf4ac8dea73f9f4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f215eb704f2cb72e984d5a85fe435b4d74808c906950176789ba2101ce739082</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">32d97e5343578a3d37ab5f30148fa193dec46a21fa21f15b6f23fe48a420831a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/ray/#ray-2.10.0-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">917d081fc98500f244ebc0e8da836025e1e4fa52f21030b8336cb0a2c79e84e2</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:required-extra">serve</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="referencing@0.34.0">
+      <name>referencing</name>
+      <version>0.34.0</version>
+      <description>JSON Referencing + Python</description>
+      <purl>pkg:pypi/referencing@0.34.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/#referencing-0.34.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d53ae300ceddd3169f1ffa9caf2cb7b769e92657e4fafb23d34b93679116dfd4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/#referencing-0.34.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5773bd84ef41799a5a8ca72dc34590c041eb01bf9aa02632b4a973fb0181a844</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requests@2.31.0">
+      <name>requests</name>
+      <version>2.31.0</version>
+      <description>Python HTTP for Humans.</description>
+      <purl>pkg:pypi/requests@2.31.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/requests/#requests-2.31.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/requests/#requests-2.31.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="rpds-py@0.18.0">
+      <name>rpds-py</name>
+      <version>0.18.0</version>
+      <description>Python bindings to Rust's persistent data structures (rpds)</description>
+      <purl>pkg:pypi/rpds-py@0.18.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5b4e7d8d6c9b2e8ee2d55c90b59c707ca59bc30058269b3db7b1f8df5763557e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c463ed05f9dfb9baebef68048aed8dcdc94411e4bf3d33a39ba97e271624f8f7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">01e36a39af54a30f28b73096dd39b6802eddd04c90dbe161c1b8dbe22353189f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d62dec4976954a23d7f91f2f4530852b0c7608116c257833922a896101336c51</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dd18772815d5f008fa03d2b9a681ae38d5ae9f0e599f7dda233c439fcaa00d40</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">923d39efa3cfb7279a0327e337a7958bff00cc447fd07a25cddb0a1cc9a6d2da</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">39514da80f971362f9267c600b6d459bfbbc549cffc2cef8e47474fddc9b45b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a34d557a42aa28bd5c48a023c570219ba2593bcbbb8dc1b98d8cf5d529ab1434</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">93df1de2f7f7239dc9cc5a4a12408ee1598725036bd2dedadc14d94525192fc3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">34b18ba135c687f4dac449aa5157d36e2cbb7c03cbea4ddbd88604e076aa836e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-cp310-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c0b5dcf9193625afd8ecc92312d6ed78781c46ecbf39af9ad4681fc9f464af88</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c4325ff0442a12113a6379af66978c3fe562f846763287ef66bdc1d57925d337</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp310-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7223a2a5fe0d217e60a60cdae28d6949140dde9c3bcc714063c5b463065e3d66</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a96e0c6a41dcdba3a0a581bbf6c44bb863f27c541547fb4b9711fd8cf0ffad4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">30f43887bbae0d49113cbaab729a112251a940e9b274536613097ab8b4899cf6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fcb25daa9219b4cf3a0ab24b0eb9a5cc8949ed4dc72acb8fa16b7e1681aa3c58</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d68c93e381010662ab873fea609bf6c0f428b6d0bb00f2c6939782e0818d37bf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b34b7aa8b261c1dbf7720b5d6f01f38243e9b9daf7e6b8bc1fd4657000062f2c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2e6d75ab12b0bbab7215e5d40f1e5b738aa539598db27ef83b2ec46747df90e1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0b8612cd233543a3781bc659c731b9d607de65890085098986dfd573fc2befe5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aec493917dd45e3c69d00a8874e7cbed844efd935595ef78a0f25f14312e33c6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">661d25cbffaf8cc42e971dd570d87cb29a665f49f4abe1f9e76be9a5182c4688</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1df3659d26f539ac74fb3b0c481cdf9d725386e3552c6fa2974f4d33d78e544b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-cp311-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a1ce3ba137ed54f83e56fb983a5859a27d43a40188ba798993812fed73c70836</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">69e64831e22a6b377772e7fb337533c365085b31619005802a79242fee620bc1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp311-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">998e33ad22dc7ec7e030b3df701c43630b5bc0d8fbc2267653577e3fec279afa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7f2facbd386dd60cbbf1a794181e6aa0bd429bd78bfdf775436020172e2a23f0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1d9a5be316c15ffb2b3c405c4ff14448c36b4435be062a7f578ccd8b01f0c4d8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd5bf1af8efe569654bbef5a3e0a56eca45f87cfcffab31dd8dde70da5982475</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5417558f6887e9b6b65b4527232553c139b57ec42c64570569b155262ac0754f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">56a737287efecafc16f6d067c2ea0117abadcd078d58721f967952db329a3e5c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8f03bccbd8586e9dd37219bce4d4e0d3ab492e6b3b533e973fa08a112cb2ffc9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4457a94da0d5c53dc4b3e4de1158bdab077db23c53232f37a3cb7afdb053a4e3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0ab39c1ba9023914297dd88ec3b3b3c3f33671baeb6acf82ad7ce883f6e8e157</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9d54553c1136b50fd12cc17e5b11ad07374c316df307e4cfd6441bea5fb68496</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0af039631b6de0397ab2ba16eaf2872e9f8fca391b44d3d8cac317860a700a3f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-cp312-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">84ffab12db93b5f6bad84c712c92060a2d321b35c3c9960b43d08d0f639d60d7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">685537e07897f173abcf67258bee3c05c374fa6fff89d4c7e42fb391b0605e98</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp312-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e003b002ec72c8d5a3e3da2989c7d6065b47d9eaa70cd8808b5384fbb970f4ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08f9ad53c3f31dfb4baa00da22f1e862900f45908383c062c27628754af2e88e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c0013fe6b46aa496a6749c77e00a3eb07952832ad6166bd481c74bda0dcb6d58</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e32a92116d4f2a80b629778280103d2a510a5b3f6314ceccd6e38006b5e92dcb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e541ec6f2ec456934fd279a3120f856cd0aedd209fc3852eca563f81738f6861</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bed88b9a458e354014d662d47e7a5baafd7ff81c780fd91584a10d6ec842cb73</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2644e47de560eb7bd55c20fc59f6daa04682655c58d08185a9b95c1970fa1e07</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8e8916ae4c720529e18afa0b879473049e95949bf97042e938530e072fde061d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">465a3eb5659338cf2a9243e50ad9b2296fa15061736d6e26240e713522b6235c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ea7d4a99f3b38c37eac212dbd6ec42b7a5ec51e2c74b5d3223e43c811609e65f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">67071a6171e92b6da534b8ae326505f7c18022c6f19072a81dcf40db2638767c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-cp38-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">41ef53e7c58aa4ef281da975f62c258950f54b76ec8e45941e93a3d1d8580594</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fdea4952db2793c4ad0bdccd27c1d8fdd1423a92f04598bc39425bcc2b8ee46e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp38-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7cd863afe7336c62ec78d7d1349a2f34c007a3cc6c2369d667c65aeec412a5b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5307def11a35f5ae4581a0b658b0af8178c65c530e94893345bebf41cc139d33</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">77f195baa60a54ef9d2de16fbbfd3ff8b04edc0c0140a761b56c267ac11aa467</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">39f5441553f1c2aed4de4377178ad8ff8f9d733723d6c66d983d75341de265ab</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9a00312dea9310d4cb7dbd7787e722d2e86a95c2db92fbd7d0155f97127bcb40</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8f2fc11e8fe034ee3c34d316d0ad8808f45bc3b9ce5857ff29d513f3ff2923a1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">586f8204935b9ec884500498ccc91aa869fc652c40c093bd9e1471fbcc25c022</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ddc2f4dfd396c7bfa18e6ce371cba60e4cf9d2e5cdb71376aa2da264605b60b9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5ddcba87675b6d509139d1b521e0c8250e967e63b5909a7e8f8944d0f90ff36f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7bd339195d84439cbe5771546fe8a4e8a7a045417d8f9de9a368c434e42a721e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d7c36232a90d4755b720fbd76739d8891732b18cf240a9c645d75f00639a9024</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-cp39-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b0817e34942b2ca527b0e9298373e7cc75f429e8da2055607f4931fded23e20</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">99f70b740dc04d09e6b2699b675874367885217a2e9f782bdf5395632ac663b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-cp39-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6ef687afab047554a2d366e112dd187b62d261d49eb79b77e386f94644363294</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ad36cfb355e24f1bd37cac88c112cd7730873f20fb0bdaf8ba59eedf8216079f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">36b3ee798c58ace201289024b52788161e1ea133e4ac93fba7d49da5fec0ef9e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f8a2f084546cc59ea99fda8e070be2fd140c3092dc11524a71aa8f0f3d5a55ca</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e4461d0f003a0aa9be2bdd1b798a041f177189c1a0f7619fe8c95ad08d9a45d7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8db715ebe3bb7d86d77ac1826f7d67ec11a70dbd2376b7cc214199360517b641</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">793968759cd0d96cac1e367afd70c235867831983f876a53389ad869b043c948</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">66e6a3af5a75363d2c9a48b07cb27c4ea542938b1a2e93b15a503cdfa8490795</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6ef0befbb5d79cf32d0266f5cff01545602344eda89480e1dd88aca964260b18</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1d4acf42190d449d5e89654d5c1ed3a4f17925eec71f05e2a41414689cda02d1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a5f446dd5055667aabaee78487f2b5ab72e244f9bc0b2ffebfeec79051679984</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9dbbeb27f4e70bfd9eec1be5477517365afe05a9b2c441a0b21929ee61048124</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">22806714311a69fd0af9b35b7be97c18a0fc2826e6827dbb3a8c94eac6cf7eeb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b34ae4636dfc4e76a438ab826a0d1eed2589ca7d9a1b2d5bb546978ac6485461</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8c8370641f1a7f0e0669ddccca22f1da893cef7628396431eb445d46d893e5cd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c8362467a0fdeccd47935f22c256bec5e6abe543bf0d66e3d3d57a8fb5731863</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">11a8c85ef4a07a7638180bf04fe189d12757c696eb41f310d2426895356dcf05</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b316144e85316da2723f9d8dc75bada12fa58489a527091fa1d5a612643d1a0e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cf1ea2e34868f6fbf070e1af291c8180480310173de0b0c43fc38a02929fc0e3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e546e768d08ad55b20b11dbb78a745151acbd938f8f00d0cfbabe8b0199b9880</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4901165d170a5fde6f589acb90a6b33629ad1ec976d4529e769c6f3d885e3e80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">618a3d6cae6ef8ec88bb76dd80b83cfe415ad4f1d942ca2a903bf6b6ff97a2da</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ed4eb745efbff0a8e9587d22a84be94a5eb7d2d99c02dacf7bd0911713ed14dd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6c81e5f372cd0dc5dc4809553d34f832f60a46034a5f187756d9b90586c2c307</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">43fbac5f22e25bee1d482c97474f930a353542855f05c1161fd804c9dc74a09d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6d7faa6f14017c0b1e69f5e2c357b998731ea75a442ab3841c0dbbbfe902d2c4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08231ac30a842bd04daabc4d71fddd7e6d26189406d5a69535638e4dcb88fe76</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">044a3e61a7c2dafacae99d1e722cc2d4c05280790ec5a05031b3876809d89a5c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3f26b5bd1079acdb0c7a5645e350fe54d16b17bfc5e71f371c449383d3342e17</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">482103aed1dfe2f3b71a58eff35ba105289b8d862551ea576bd15479aba01f66</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1374f4129f9bcca53a1bba0bb86bf78325a0374577cf7e9e4cd046b1e6f20e24</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">635dc434ff724b178cb192c70016cc0ad25a275228f749ee0daf0eddbc8183b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bc362ee4e314870a70f4ae88772d72d877246537d9f8cb8f7eacf10884862432</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4832d7d380477521a8c1644bbab6588dfedea5e30a7d967b5fb75977c45fd77f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.18.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">42821446ee7a76f5d9f71f9e33a4fb2ffd724bb3e7f93386150b61a43115788d</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="rsa@4.9">
+      <name>rsa</name>
+      <version>4.9</version>
+      <description>Pure-Python RSA implementation</description>
+      <purl>pkg:pypi/rsa@4.9</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rsa/#rsa-4.9-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rsa/#rsa-4.9.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="smart-open@7.0.4">
+      <name>smart-open</name>
+      <version>7.0.4</version>
+      <description>Utils for streaming large files (S3, HDFS, GCS, Azure Blob Storage, gzip, bz2...)</description>
+      <purl>pkg:pypi/smart-open@7.0.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/smart-open/#smart_open-7.0.4-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4e98489932b3372595cddc075e6033194775165702887216b65eba760dfd8d47</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/smart-open/#smart_open-7.0.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">62b65852bdd1d1d516839fcb1f6bc50cd0f16e05b4ec44b52f43d38bcb838524</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="sniffio@1.3.1">
+      <name>sniffio</name>
+      <version>1.3.1</version>
+      <description>Sniff out which async library your code is running under</description>
+      <purl>pkg:pypi/sniffio@1.3.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/sniffio/#sniffio-1.3.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/sniffio/#sniffio-1.3.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="starlette@0.36.3">
+      <name>starlette</name>
+      <version>0.36.3</version>
+      <description>The little ASGI library that shines.</description>
+      <purl>pkg:pypi/starlette@0.36.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/starlette/#starlette-0.36.3-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">13d429aa93a61dc40bf503e8c801db1f1bca3dc706b10ef2434a36123568f044</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/starlette/#starlette-0.36.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">90a671733cfb35771d8cc605e0b679d23b992f8dcfad48cc60b38cb29aeb7080</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="typing-extensions@4.10.0">
+      <name>typing-extensions</name>
+      <version>4.10.0</version>
+      <description>Backported and Experimental Type Hints for Python 3.8+</description>
+      <purl>pkg:pypi/typing-extensions@4.10.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/typing-extensions/#typing_extensions-4.10.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/typing-extensions/#typing_extensions-4.10.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="urllib3@2.2.1">
+      <name>urllib3</name>
+      <version>2.2.1</version>
+      <description>HTTP library with thread-safe connection pooling, file post, and more.</description>
+      <purl>pkg:pypi/urllib3@2.2.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/urllib3/#urllib3-2.2.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/urllib3/#urllib3-2.2.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="uvicorn@0.29.0">
+      <name>uvicorn</name>
+      <version>0.29.0</version>
+      <description>The lightning-fast ASGI server.</description>
+      <purl>pkg:pypi/uvicorn@0.29.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvicorn/#uvicorn-0.29.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2c2aac7ff4f4365c206fd773a39bf4ebd1047c238f8b8268ad996829323473de</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvicorn/#uvicorn-0.29.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6a69214c0b6a087462412670b3ef21224fa48cae0e452b5883e8e8bdfdd11dd0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:python:package:required-extra">standard</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="uvloop@0.19.0">
+      <name>uvloop</name>
+      <version>0.19.0</version>
+      <description>Fast implementation of asyncio event loop on top of libuv</description>
+      <purl>pkg:pypi/uvloop@0.19.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">de4313d7f575474c8f5a12e163f6d89c0a878bc49219641d49e6f1444369a90e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5588bd21cf1fcf06bded085f37e43ce0e00424197e7c10e77afd4bbefffef428</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7b1fd71c3843327f3bbc3237bedcdb6504fd50368ab3e04d0410e52ec293f5b8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5a05128d315e2912791de6088c34136bfcdd0c7cbc1cf85fd6fd1bb321b7c849</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd81bdc2b8219cb4b2556eea39d2e36bfa375a2dd021404f90a62e44efaaf957</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5f17766fb6da94135526273080f3455a112f82570b2ee5daa64d682387fe0dcd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4ce6b0af8f2729a02a5d1575feacb2a94fc7b2e983868b009d51c9a9d2149bef</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">31e672bb38b45abc4f26e273be83b72a0d28d074d5b370fc4dcf4c4eb15417d2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">570fc0ed613883d8d30ee40397b79207eedd2624891692471808a95069a007c1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5138821e40b0c3e6c9478643b4660bd44372ae1e16a322b8fc07478f92684e24</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">91ab01c6cd00e39cde50173ba4ec68a1e578fee9279ba64f5221810a9e786533</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">47bf3e9312f63684efe283f7342afb414eea4d3011542155c7e625cd799c3b12</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">da8435a3bd498419ee8c13c34b89b5005130a476bda1d6ca8cfdde3de35cd650</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">02506dc23a5d90e04d4f65c7791e65cf44bd91b37f24cfc3ef6cf2aff05dc7ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2693049be9d36fef81741fddb3f441673ba12a34a704e7b4361efb75cf30befc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7010271303961c6f0fe37731004335401eb9075a12680738731e9c92ddd96ad6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5daa304d2161d2918fa9a17d5635099a2f78ae5b5960e742b2fcfbb7aefaa593</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7207272c9520203fea9b93843bb775d03e1cf88a80a936ce760f60bb5add92f3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp38-cp38-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">78ab247f0b5671cc887c31d33f9b3abfb88d2614b84e4303f1a63b46c046c8bd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">472d61143059c84947aa8bb74eabbace30d577a03a1805b77933d6bd13ddebbd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">45bf4c24c19fb8a50902ae37c5de50da81de4922af65baf760f7c0c42e1088be</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">271718e26b3e17906b28b67314c45d19106112067205119dddbd834c2b7ce797</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">34175c9fd2a4bc3adc1380e1261f60306344e3407c20a4d684fd5f3be010fa3d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e27f100e1ff17f6feeb1f33968bc185bf8ce41ca557deee9d9bbbffeb72030b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">13dfdf492af0aa0a0edf66807d2b465607d11c4fa48f4a1fd41cbea5b18e8e8b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6e3d4e85ac060e2342ff85e90d0c04157acb210b9ce508e784a944f852a40e67</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8ca4956c9ab567d87d59d49fa3704cf29e37109ad348f2d5223c9bf761a332e7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f467a5fd23b4fc43ed86342641f3936a68ded707f4627622fa3f82a120e18256</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">492e2c32c2af3f971473bc22f086513cedfc66a130756145a931a90c3958cb17</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2df95fca285a9f5bfe730e51945ffe2fa71ccbfdde3b0da5772b4ee4f2e770d5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uvloop/#uvloop-0.19.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0246f4fd1bf2bf702e06b0d45ee91677ee5c31242f39aab4ea6fe0c51aedd0fd</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="virtualenv@20.25.1">
+      <name>virtualenv</name>
+      <version>20.25.1</version>
+      <description>Virtual Python Environment builder</description>
+      <purl>pkg:pypi/virtualenv@20.25.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/virtualenv/#virtualenv-20.25.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961c026ac520bac5f69acb8ea063e8a4f071bcc9457b9c1f28f6b085c511583a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/virtualenv/#virtualenv-20.25.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e08e13ecdca7a0bd53798f356d5831434afa5b07b93f0abdf0797b7a06ffe197</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="watchfiles@0.21.0">
+      <name>watchfiles</name>
+      <version>0.21.0</version>
+      <description>Simple, modern and high performance file watching and code reload in python.</description>
+      <purl>pkg:pypi/watchfiles@0.21.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">27b4035013f1ea49c6c0b42d983133b136637a527e48c132d368eb19bf1ac6aa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c81818595eff6e92535ff32825f31c116f867f64ff8cdf6562cd1d6b2e1e8f3e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6c107ea3cf2bd07199d66f156e3ea756d1b84dfd43b542b2d870b77868c98c03</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0d9ac347653ebd95839a7c607608703b20bc07e577e870d824fa4801bc1cb124</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5eb86c6acb498208e7663ca22dbe68ca2cf42ab5bf1c776670a50919a56e64ab</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f564bf68404144ea6b87a78a3f910cc8de216c6b12a4cf0b27718bf4ec38d303</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3d0f32ebfaa9c6011f8454994f86108c2eb9c79b8b7de00b36d558cadcedaa3d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b6d45d9b699ecbac6c7bd8e0a2609767491540403610962968d258fd6405c17c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aff06b2cac3ef4616e26ba17a9c250c1fe9dd8a5d907d0193f84c499b1b6e6a9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d9792dff410f266051025ecfaa927078b94cc7478954b06796a9756ccc7e14a9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">214cee7f9e09150d4fb42e24919a1e74d8c9b8a9306ed1474ecaddcd5479c293</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp310-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1ad7247d79f9f55bb25ab1778fd47f32d70cf36053941f07de0b7c4e96b5d235</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">668c265d90de8ae914f860d3eeb164534ba2e836811f91fecc7050416ee70aa7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a23092a992e61c3a6a70f350a56db7197242f3490da9c87b500f389b2d01eef</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e7941bbcfdded9c26b0bf720cb7e6fd803d95a55d2c14b4bd1f6a2772230c586</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">11cd0c3100e2233e9c53106265da31d574355c288e15259c0d40a4405cbae317</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d78f30cbe8b2ce770160d3c08cff01b2ae9306fe66ce899b73f0409dc1846c1b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6674b00b9756b0af620aa2a3346b01f8e2a3dc729d25617e1b89cf6af4a54eb1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fd7ac678b92b29ba630d8c842d8ad6c555abda1b9ef044d6cc092dacbfc9719d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9c873345680c1b87f1e09e0eaf8cf6c891b9851d8b4d3645e7efe2ec20a20cc7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">49f56e6ecc2503e7dbe233fa328b2be1a7797d31548e7a193237dcdf1ad0eee0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">02d91cbac553a3ad141db016e3350b03184deaafeba09b9d6439826ee594b365</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ebe684d7d26239e23d102a2bad2a358dedf18e462e8808778703427d1f584400</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4566006aa44cb0d21b8ab53baf4b9c667a0ed23efe4aaad8c227bfba0bf15cbe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp311-none-win_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c550a56bf209a3d987d5a975cdf2063b3389a5d16caf29db4bdddeae49f22078</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">51ddac60b96a42c15d24fbdc7a4bfcd02b5a29c047b7f8bf63d3f6f5a860949a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">511f0b034120cd1989932bf1e9081aa9fb00f1f949fbd2d9cab6264916ae89b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cfb92d49dbb95ec7a07511bc9efb0faff8fe24ef3805662b8d6808ba8409a71a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3f92944efc564867bbf841c823c8b71bb0be75e06b8ce45c084b46411475a915</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">642d66b75eda909fd1112d35c53816d59789a4b38c141a96d62f50a3ef9b3360</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d23bcd6c8eaa6324fe109d8cac01b41fe9a54b8c498af9ce464c1aeeb99903d6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">18d5b4da8cf3e41895b34e8c37d13c9ed294954907929aacd95153508d5d89d7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1b8d1eae0f65441963d805f766c7e9cd092f91e0c600c820c764a4ff71a0764c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1fd9a5205139f3c6bb60d11f6072e0552f0a20b712c85f43d42342d162be1235</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a1e3014a625bcf107fbf38eece0e47fa0190e52e45dc6eee5a8265ddc6dc5ea7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9d09869f2c5a6f2d9df50ce3064b3391d3ecb6dced708ad64467b9e4f2c9bef3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">18722b50783b5e30a18a8a5db3006bab146d2b705c92eb9a94f78c72beb94094</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp312-none-win_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a3b9bec9579a15fb3ca2d9878deae789df72f2b0fdaf90ad49ee389cad5edab6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4ea10a29aa5de67de02256a28d1bf53d21322295cb00bd2d57fcd19b850ebd99</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">40bca549fdc929b470dd1dbfcb47b3295cb46a6d2c90e50588b0a1b3bd98f429</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9b37a7ba223b2f26122c148bb8d09a9ff312afca998c48c725ff5a0a632145f7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ec8c8900dc5c83650a63dd48c4d1d245343f904c4b64b48798c67a3767d7e165</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8ad3fe0a3567c2f0f629d800409cd528cb6251da12e81a1f765e5c5345fd0137</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9d353c4cfda586db2a176ce42c88f2fc31ec25e50212650c89fdd0f560ee507b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">83a696da8922314ff2aec02987eefb03784f473281d740bf9170181829133765</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5a03651352fc20975ee2a707cd2d74a386cd303cc688f407296064ad1e6d1562</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3ad692bc7792be8c32918c699638b660c0de078a6cbe464c46e1340dadb94c19</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">06247538e8253975bdb328e7683f8515ff5ff041f43be6c40bff62d989b7d0b0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9a0aa47f94ea9a0b39dd30850b0adf2e1cd32a8b4f9c7aa443d852aacf9ca214</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp38-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8d5f400326840934e3507701f9f7269247f7c026d1b6cfd49477d2be0933cfca</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7f762a1a85a12cc3484f77eee7be87b10f8c50b0b787bb02f4e357403cad0c0e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6e9be3ef84e2bb9710f3f777accce25556f4a71e15d2b73223788d528fcc2052</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4c48a10d17571d1275701e14a601e36959ffada3add8cdbc9e5061a6e3579a5d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6c889025f59884423428c261f212e04d438de865beda0b1e1babab85ef4c0f01</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">66fac0c238ab9a2e72d026b5fb91cb902c146202bbd29a9a1a44e8db7b710b6f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b4a21f71885aa2744719459951819e7bf5a906a6448a6b2bbce8e9cc9f2c8128</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1c9198c989f47898b2c22201756f73249de3748e0fc9de44adaf54a8b259cc0c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d8f57c4461cd24fda22493109c45b3980863c58a25b8bec885ca8bea6b8d4b28</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">853853cbf7bf9408b404754b92512ebe3e3a83587503d766d23e6bf83d092ee6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d5b1dc0e708fad9f92c296ab2f948af403bf201db8fb2eb4c8179db143732e49</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">59137c0c6826bd56c710d1d2bda81553b5e6b7c84d5a676747d80caf0409ad94</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-cp39-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6cb8fdc044909e2078c248986f2fc76f911f72b51ea4a4fbbf472e01d14faa58</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ab03a90b305d2588e8352168e8c5a1520b721d2d367f31e9332c4235b30b8994</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">927c589500f9f41e370b0125c12ac9e7d3a2fd166b89e9ee2828b3dda20bfe6f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1bd467213195e76f838caf2c28cd65e58302d0254e636e7c0fca81efa4a2e62c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">02b73130687bc3f6bb79d8a170959042eb56eb3a42df3671c79b428cd73f17cc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08dca260e85ffae975448e344834d765983237ad6dc308231aa16e7933db763e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3ccceb50c611c433145502735e0370877cced72a6c70fd2410238bcbc7fe51d8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">57d430f5fb63fea141ab71ca9c064e80de3a20b427ca2febcbfcef70ff0ce895</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0dd5fad9b9c0dd89904bbdea978ce89a2b692a7ee8a0ce19b940e538c88a809c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">be6dd5d52b73018b21adc1c5d28ac0c68184a64769052dfeb0c5d9998e7f56a2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3cab0e06143768499384a8a5efb9c4dc53e19382952859e4802f294214f36ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8c6ed10c2497e5fedadf61e465b3ca12a19f96004c15dcffe4bd442ebadc2d85</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">43babacef21c519bc6631c5fce2a61eccdfc011b4bcb9047255e9620732c8097</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/watchfiles/#watchfiles-0.21.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c76c635fabf542bb78524905718c39f736a98e5ab25b23ec6d4abede1a85a6a3</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="websockets@12.0">
+      <name>websockets</name>
+      <version>12.0</version>
+      <description>An implementation of the WebSocket Protocol (RFC 6455 &amp; 7692)</description>
+      <purl>pkg:pypi/websockets@12.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d554236b2a2006e0ce16315c16eaa0d628dab009c33b63ea03f41c6107958374</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2d225bb6886591b1746b17c0573e29804619c8f755b5598d875bb4235ea639be</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eb809e816916a3b210bed3c82fb88eaf16e8afcf9c115ebb2bacede1797d2547</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c588f6abc13f78a67044c6b1273a99e1cf31038ad51815b3b016ce699f0d75c2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5aa9348186d79a5f232115ed3fa9020eab66d6c3437d72f9d2c8ac0c6858c558</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6350b14a40c95ddd53e775dbdbbbc59b124a5c8ecd6fbb09c2e52029f7a9f480</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">70ec754cc2a769bcd218ed8d7209055667b30860ffecb8633a834dde27d6307c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6e96f5ed1b83a8ddb07909b45bd94833b0710f738115751cdaa9da1fb0cb66e8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d87be612cbef86f994178d5186add3d94e9f31cc3cb499a0482b866ec477603</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">befe90632d66caaf72e8b2ed4d7f02b348913813c8b0a32fae1cc5fe3730902f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">363f57ca8bc8576195d0540c648aa58ac18cf85b76ad5202b9f976918f4219cf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5d873c7de42dea355d73f170be0f23788cf3fa9f7bed718fd2830eefedce01b4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3f61726cae9f65b872502ff3c1496abc93ffbe31b278455c418492016e2afc8f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ed2fcf7a07334c77fc8a230755c2209223a7cc44fc27597729b8ef5425aa61a3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8e332c210b14b57904869ca9f9bf4ca32f5427a03eeb625da9b616c85a3a506c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5693ef74233122f8ebab026817b1b37fe25c411ecfca084b29bc7d6efc548f45</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6e9e7db18b4539a29cc5ad8c8b252738a30e2b13f033c2d6e9d0549b45841c04</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6e2df67b8014767d0f785baa98393725739287684b9f8d8a1001eb2839031447</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bea88d71630c5900690fcb03161ab18f8f244805c59e2e0dc4ffadae0a7ee0ca</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dff6cdf35e31d1315790149fee351f9e52978130cef6c87c4b6c9b3baf78bc53</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3e3aa8c468af01d70332a382350ee95f6986db479ce7af14d5e81ec52aa2b402</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">25eb766c8ad27da0f79420b2af4b85d29914ba0edf69f547cc4f06ca6f1d403b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e6e2711d5a8e6e482cacb927a49a3d432345dfe7dea8ace7b5790df5932e4df</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dbcf72a37f0b3316e993e13ecf32f10c0e1259c28ffd0a85cee26e8549595fbc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">12743ab88ab2af1d17dd4acb4645677cb7063ef4db93abffbf164218a5d54c6b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7b645f491f3c48d3f8a00d1fce07445fab7347fec54a3e65f0725d730d5b99cb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9893d1aa45a7f8b3bc4510f6ccf8db8c3b62120917af15e3de247f0780294b92</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f38a7b376117ef7aff996e737583172bdf535932c9ca021746573bce40165ed</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f764ba54e33daf20e167915edc443b6f88956f37fb606449b4a5b10ba42235a5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e4b3f8ea6a9cfa8be8484c9221ec0257508e3a1ec43c36acdefb2a9c3b00aa2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9fdf06fd06c32205a07e47328ab49c40fc1407cdec801d698a7c41167ea45113</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">baa386875b70cbd81798fa9f71be689c1bf484f65fd6fb08d051a0ee4e79924d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ae0a5da8f35a5be197f328d4727dbcfafa53d1824fac3d96cdd3a642fe09394f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5f6ffe2c6598f7f7207eef9a1228b6f5c818f9f4d53ee920aacd35cec8110438</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9edf3fc590cc2ec20dc9d7a45108b5bbaf21c0d89f9fd3fd1685e223771dc0b2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8572132c7be52632201a35f5e08348137f658e5ffd21f51f94572ca6c05ea81d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">604428d1b87edbf02b233e2c207d7d528460fa978f9e391bd8aaf9c8311de137</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1a9d160fd080c6285e202327aba140fc9a0d910b09e423afff4ae5cbbf1c7205</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">87b4aafed34653e465eb77b7c93ef058516cb5acf3eb21e42f33928616172def</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2ee7288b85959797970114deae81ab41b731f19ebcd3bd499ae9ca0e3f1d2c8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7fa3d25e81bfe6a89718e9791128398a50dec6d57faf23770787ff441d851967</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a571f035a47212288e3b3519944f6bf4ac7bc7553243e41eac50dd48552b6df7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3c6cc1360c10c17463aadd29dd3af332d4a1adaa8796f6b0e9f9df1fdb0bad62</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1bf386089178ea69d720f8db6199a0504a406209a0fc23e603b27b300fdd6892</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ab3d732ad50a4fbd04a4490ef08acd0517b6ae6b77eb967251f4c263011a990d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a1d9697f3337a89691e3bd8dc56dea45a6f6d975f92e7d5f773bc715c15dde28</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1df2fbd2c8a98d38a66f5238484405b8d1d16f929bb7a33ed73e4801222a6f53</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">23509452b3bc38e3a057382c2e941d5ac2e01e251acce7adc74011d7d8de434c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2e5fc14ec6ea568200ea4ef46545073da81900a2b67b3e666f04adf53ad452ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">46e71dbbd12850224243f5d2aeec90f0aaa0f2dde5aeeb8fc8df21e04d99eff9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b81f90dcc6c85a9b7f29873beb56c94c85d6f0dac2ea8b60d995bd18bf3e2aae</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a02413bc474feda2849c59ed2dfb2cddb4cd3d2f03a2fedec51d6e959d9b608b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bbe6013f9f791944ed31ca08b077e26249309639313fff132bfbf3ba105673b9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cbe83a6bbdf207ff0541de01e11904827540aa069293696dd528a6640bd6a5f6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fc4e7fa5414512b481a2483775a8e8be7803a35b30ca805afa4998a84f9fd9e8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">248d8e2446e13c1d4326e0a6a4e9629cb13a11195051a73acf414812700badbd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f44069528d45a933997a6fef143030d8ca8042f0dfaad753e2906398290e2870</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c4e37d36f0d19f0a4413d3e18c0d03d0c268ada2061868c1e6f5ab1a6d575077</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3d829f975fc2e527a3ef2f9c8f25e553eb7bc779c6665e8e1d52aa22800bb38b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-pp310-pypy310_pp73-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2c71bd45a777433dd9113847af751aae36e448bc6b8c361a566cb043eda6ec30</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0bee75f400895aef54157b36ed6d3b308fcab62e5260703add87f44cee9c82a6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">423fc1ed29f7512fceb727e2d2aecb952c46aa34895e9ed96071821309951123</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">27a5e9964ef509016759f2ef3f2c1e13f403725a5e6a1775555994966a66e931</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c3181df4583c4d3994d31fb235dc681d2aaad744fbdbf94c4802485ececdecf2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-pp38-pypy38_pp73-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b067cb952ce8bf40115f6c19f478dc71c5e719b7fbaa511359795dfd9d1a6468</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">00700340c6c7ab788f176d118775202aadea7602c5cc6be6ae127761c16d6b0b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e469d01137942849cff40517c97a30a93ae79917752b34029f0ec72df6b46399</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ffefa1374cd508d633646d51a8e9277763a9b78ae71324183693959cf94635a7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ba0cab91b3956dfa9f512147860783a1829a8d905ee218a9837c18f683239611</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-pp39-pypy39_pp73-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2cb388a5bfb56df4d9a406783b7f9dbefb888c09b71629351cc6b036e9259370</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dc284bbc8d7c78a6c69e0c7325ab46ee5e40bb4d50e494d8131a07ef47500e9e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/websockets/#websockets-12.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">81df9cbcbb6c260de1e007e58c011bfebe2dafc8435107b0537f393dd38c8b1b</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="wrapt@1.16.0">
+      <name>wrapt</name>
+      <version>1.16.0</version>
+      <description>Module for decorators, wrappers and monkey patching.</description>
+      <purl>pkg:pypi/wrapt@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ffa565331890b90056c01db69c0fe634a776f8019c143a5ae265f9c6bc4bd6d4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e4fdb9275308292e880dcbeb12546df7f3e0f96c6b41197e0cf37d2826359020</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bb2dee3874a500de01c93d5c71415fcaef1d858370d405824783e7a8ef5db440</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2a88e6010048489cda82b1326889ec075a8c856c2e6a256072b28eaee3ccf487</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac83a914ebaf589b69f7d0a1277602ff494e21f4c2f743313414378f8f50a4cf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">73aa7d98215d39b8455f103de64391cb79dfcad601701a3aa0dddacf74911d72</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">807cc8543a477ab7422f1120a217054f958a66ef7314f76dd9e77d3f02cdccd0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bf5703fdeb350e36885f2875d853ce13172ae281c56e509f4e6eca049bdfb136</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f6b2d0c6703c988d334f297aa5df18c45e97b0af3679bb75059e0e0bd8b1069d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">decbfa2f618fa8ed81c95ee18a387ff973143c656ef800c9f24fb7e9c16054e2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1a5db485fe2de4403f13fafdc231b0dbae5eca4359232d2efc79025527375b09</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">75ea7d0ee2a15733684badb16de6794894ed9c55aa5e9903260922f0482e687d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a452f9ca3e3267cd4d0fcf2edd0d035b1934ac2bd7e0e57ac91ad6b95c0c6389</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">43aa59eadec7890d9958748db829df269f0368521ba6dc68cc172d5d03ed8060</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">72554a23c78a8e7aa02abbd699d129eead8b147a23c56e08d08dfc29cfdddca1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d2efee35b4b0a347e0d99d28e884dfd82797852d62fcd7ebdeee26f3ceb72cf3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6dcfcffe73710be01d90cae08c3e548d90932d37b39ef83969ae135d36ef3956</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eb6e651000a19c96f452c85132811d25e9264d836951022d6e81df2fff38337d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">66027d667efe95cc4fa945af59f92c5a02c6f5bb6012bff9e60542c74c75c362</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5eb404d89131ec9b4f748fa5cfb5346802e5ee8836f57d516576e61f304f3b7b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9090c9e676d5236a6948330e83cb89969f433b1943a558968f659ead07cb3b36</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">94265b00870aa407bd0cbcfd536f17ecde43b94fb8d228560a1e9d3041462d73</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f2058f813d4f2b5e3a9eb2eb3faf8f1d99b81c3e51aeda4b168406443e8ba809</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">98b5e1f498a8ca1858a1cdbffb023bfd954da4e3fa2c0cb5853d40014557248b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">14d7dc606219cdd7405133c713f2c218d4252f2a469003f8c46bb92d5d095d81</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">49aac49dc4782cb04f58986e81ea0b4768e4ff197b57324dcbd7699c5dfb40b9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">418abb18146475c310d7a6dc71143d6f7adec5b004ac9ce08dc7a34e2babdc5c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">685f568fa5e627e93f3b52fda002c7ed2fa1800b50ce51f6ed1d572d8ab3e7fc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dcdba5c86e368442528f7060039eda390cc4091bfd1dca41e8046af7c910dda8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d462f28826f4657968ae51d2181a074dfe03c200d6131690b7d65d55b0f360f8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a33a747400b94b6d6b8a165e4480264a64a78c8a4c734b62136062e9a248dd39</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3646eefa23daeba62643a58aac816945cadc0afaf21800a1421eeba5f6cfb9c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3ebf019be5c09d400cf7b024aa52b1f3aeebeff51550d007e92c3c1c4afc2a40</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0d2691979e93d06a95a26257adb7bfd0c93818e89b1406f5a28f36e0d8c1e1fc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1acd723ee2a8826f3d53910255643e33673e1d11db84ce5880675954183ec47e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bc57efac2da352a51cc4658878a68d2b1b67dbe9d33c36cb826ca449d80a8465</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">da4813f751142436b075ed7aa012a8778aa43a99f7b36afe9b742d3ed8bdc95e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp36-cp36m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6f6eac2360f2d543cc875a0e5efd413b6cbd483cb3ad7ebf888884a6e0d2e966</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a0ea261ce52b5952bf669684a251a66df239ec6d441ccb59ec7afa882265d593</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7bd2d7ff69a2cac767fbf7a2b206add2e9a210e57947dd7ce03e25d03d2de292</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9159485323798c8dc530a224bd3ffcf76659319ccc7bbd52e01e73bd0241a0c5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a86373cf37cd7764f2201b76496aba58a52e76dedfaa698ef9e9688bfd9e41cf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">73870c364c11f03ed072dda68ff7aea6d2a3a5c3fe250d917a429c7432e15228</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b935ae30c6e7400022b50f8d359c03ed233d45b725cfdd299462f41ee5ffba6f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">db98ad84a55eb09b3c32a96c576476777e87c520a34e2519d3e59c44710c002c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9153ed35fc5e4fa3b2fe97bddaa7cbec0ed22412b85bcdaf54aeba92ea37428c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">66dfbaa7cfa3eb707bbfcd46dab2bc6207b005cbc9caa2199bcbc81d95071a00</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1dd50a2696ff89f57bd8847647a1c363b687d3d796dc30d4dd4a9d1689a706f0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">44a2754372e32ab315734c6c73b24351d06e77ffff6ae27d2ecf14cf3d229202</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8e9723528b9f787dc59168369e42ae1c3b0d3fadb2f1a71de14531d321ee05b0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dbed418ba5c3dce92619656802cc5355cb679e58d0d89b50f116e4a9d5a9603e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">941988b89b4fd6b41c3f0bfb20e92bd23746579736b7343283297c4c8cbae68f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6a42cd0cfa8ffc1915aef79cb4284f6383d8a3e9dcca70c445dcfdd639d51267</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1ca9b6085e4f866bd584fb135a041bfc32cab916e69f714a7d1d397f8c4891ca</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d5e49454f19ef621089e204f862388d29e6e8d8b162efce05208913dde5b9ad6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c31f72b1b6624c9d863fc095da460802f43a7c6868c5dda140f51da24fd47d7b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">490b0ee15c1a55be9c1bd8609b8cecd60e325f0575fc98f50058eae366e01f41</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9b201ae332c3637a42f02d1045e1d0cccfdc41f1f2f801dafbaa7e9b4797bfc2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2076fad65c6736184e77d7d4729b63a6d1ae0b70da4868adeec40989858eb3fb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c5cd603b575ebceca7da5a3a251e69561bec509e0b46e4993e1cac402b7247b8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b47cfad9e9bbbed2339081f4e346c93ecd7ab504299403320bf85f7f85c7d46c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5f15814a33e42b04e3de432e573aa557f9f0f56458745c2074952f564c50e664</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">db2e408d983b0e61e238cf579c09ef7020560441906ca990fe8412153e3b291f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">edfad1d29c73f9b863ebe7082ae9321374ccb10879eeabc84ba3b69f2579d537</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ed867c42c268f876097248e05b6117a65bcd1e63b779e916fe2e33cd6fd0d3c3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/wrapt/#wrapt-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="yarl@1.9.4">
+      <name>yarl</name>
+      <version>1.9.4</version>
+      <description>Yet another URL library</description>
+      <purl>pkg:pypi/yarl@1.9.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a8c1df72eb746f4136fe9a2e72b0c9dc1da1cbd23b5372f94b5820ff8ae30e0e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a3a6ed1d525bfb91b3fc9b690c5a21bb52de28c018530ad85093cc488bee2dd2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c38c9ddb6103ceae4e4498f9c08fac9b590c5c71b0370f98714768e22ac6fa66</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d9e09c9d74f4566e905a0b8fa668c58109f7624db96a2171f21747abc7524234</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b8477c1ee4bd47c57d49621a062121c3023609f7a13b8a46953eb6c9716ca392</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d5ff2c858f5f6a42c2a8e751100f237c5e869cbde669a724f2062d4c4ef93551</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">357495293086c5b6d34ca9616a43d329317feab7917518bc97a08f9e55648455</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">54525ae423d7b7a8ee81ba189f131054defdb122cde31ff17477951464c1691c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">801e9264d19643548651b9db361ce3287176671fb0117f96b5ac0ee1c3530d53</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e516dc8baf7b380e6c1c26792610230f37147bb754d6426462ab115a02944385</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7d5aaac37d19b2904bb9dfe12cdb08c8443e7ba7d2852894ad448d4b8f442863</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">54beabb809ffcacbd9d28ac57b0db46e42a6e341a030293fb3185c409e626b8b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bac8d525a8dbc2a1507ec731d2867025d11ceadcb4dd421423a5d42c56818541</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7855426dfbddac81896b6e533ebefc0af2f132d4a47340cee6d22cac7190022d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">848cd2a1df56ddbffeb375535fb62c9d1645dde33ca4d51341378b3f5954429b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">35a2b9396879ce32754bd457d31a51ff0a9d426fd9e0e3c33394bf4b9036b099</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4c7d56b293cc071e82532f70adcbd8b61909eec973ae9d2d1f9b233f3d943f2c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d8a1c6c0be645c745a081c192e747c5de06e944a0d21245f4cf7c05e457c36e0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4b3c1ffe10069f655ea2d731808e76e0f452fc6c749bea04781daf18e6039525</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">549d19c84c55d11687ddbd47eeb348a89df9cb30e1993f1b128f4685cd0ebbf8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a7409f968456111140c1c95301cadf071bd30a81cbd7ab829169fb9e3d72eae9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e23a6d84d9d1738dbc6e38167776107e63307dfc8ad108e580548d1f2c587f42</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d8b889777de69897406c9fb0b76cdf2fd0f31267861ae7501d93003d55f54fbe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">03caa9507d3d3c83bca08650678e25364e1843b484f19986a527630ca376ecce</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4e9035df8d0880b2f1c7f5031f33f69e071dfe72ee9310cfc76f7b605958ceb9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c0ec0ed476f77db9fb29bca17f0a8fcc7bc97ad4c6c1d8959c507decb22e8572</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ee04010f26d5102399bd17f8df8bc38dc7ccd7701dc77f4a68c5b8d733406958</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">49a180c2e0743d5d6e0b4d1a9e5f633c62eca3f8a86ba5dd3c471060e352ca98</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">81eb57278deb6098a5b62e88ad8281b2ba09f2f1147c4767522353eaa6260b31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d1d2532b340b692880261c15aee4dc94dd22ca5d61b9db9a8a361953d36410b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0d2454f0aef65ea81037759be5ca9947539667eecebca092733b2eb43c965a81</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">44d8ffbb9c06e5a7f529f38f53eda23e50d1ed33c6c869e01481d3fafa6b8142</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aaaea1e536f98754a6e5c56091baa1b6ce2f2700cc4a00b0d49eca8dea471074</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3777ce5536d17989c91696db1d459574e9a9bd37660ea7ee4d3344579bb6f129</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9fc5fc1eeb029757349ad26bbc5880557389a03fa6ada41703db5e068881e5f2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ea65804b5dc88dacd4a40279af0cdadcfe74b3e5b4c897aa0d81cf86927fee78</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aa102d6d280a5455ad6a0f9e6d769989638718e938a6a0a2ff3f4a7ff8c62cc4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">09efe4615ada057ba2d30df871d2f668af661e971dfeedf0c159927d48bbeff0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">008d3e808d03ef28542372d01057fd09168419cdc8f848efe2804f894ae03e51</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6f5cb257bc2ec58f437da2b37a8cd48f666db96d47b8a3115c29f316313654ff</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">992f18e0ea248ee03b5a6e8b3b4738850ae7dbb172cc41c966462801cbf62cf7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e9d124c191d5b881060a9e5060627694c3bdd1fe24c5eecc8d5d7d0eb6faabc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3986b6f41ad22988e53d5778f91855dc0399b043fc8946d4f2e68af22ee9ff10</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4b21516d181cd77ebd06ce160ef8cc2a5e9ad35fb1c5930882baff5ac865eee7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a9bd00dc3bc395a662900f33f74feb3e757429e545d831eef5bb280252631984</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">63b20738b5aac74e239622d2fe30df4fca4942a86e31bf47a81a0e94c14df94f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d7d7f7de27b8944f1fee2c26a88b4dabc2409d2fea7a9ed3df79b67277644e17</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c74018551e31269d56fab81a728f683667e7c28c04e807ba08f8c9e3bba32f14</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ca06675212f94e7a610e85ca36948bb8fc023e458dd6c63ef71abfd482481aa5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5aef935237d60a51a62b86249839b51345f47564208c6ee615ed2a40878dccdd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2b134fd795e2322b7684155b7855cc99409d10b2e408056db2b93b51a52accc7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d25039a474c4c72a5ad4b52495056f843a7ff07b632c1b92ea9043a3d9950f6e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f7d6b36dd2e029b6bcb8a13cf19664c7b8e19ab3a58e0fefbb5b8461447ed5ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">957b4774373cf6f709359e5c8c4a0af9f6d7875db657adb0feaf8d6cb3c3964c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d7eeb6d22331e2fd42fce928a81c697c9ee2d51400bd1a28803965883e13cead</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6a962e04b8f91f8c4e5917e518d17958e3bdee71fd1d8b88cdce74dd0ebbf434</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f3bc6af6e2b8f92eced34ef6a96ffb248e863af20ef4fde9448cc8c9b858b749</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ad4d7a90a92e528aadf4965d685c17dacff3df282db1121136c382dc0b6014d2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ec61d826d80fc293ed46c9dd26995921e3a82146feacd952ef0757236fc137be</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8be9e837ea9113676e5754b43b940b50cce76d9ed7d2461df1af39a8ee674d9f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bef596fdaa8f26e3d66af846bbe77057237cb6e8efff8cd7cc8dff9a62278bbf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2d47552b6e52c3319fede1b60b3de120fe83bde9b7bddad11a69fb0af7db32f1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">84fc30f71689d7fc9168b92788abc977dc8cefa806909565fc2951d02f6b7d57</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4aa9741085f635934f3a2583e16fcf62ba835719a8b2b28fb2917bb0537c1dfa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">206a55215e6d05dbc6c98ce598a59e6fbd0c493e2de4ea6cc2f4934d5a18d130</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">07574b007ee20e5c375a8fe4a0789fad26db905f9813be0f9fef5a68080de559</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5a2e2433eb9344a163aced6a5f6c9222c0786e5a9e9cac2c89f0b28433f56e23</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6ad6d10ed9b67a382b45f29ea028f92d25bc0bc1daf6c5b801b90b5aa70fb9ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6fe79f998a4052d79e1c30eeb7d6c1c1056ad33300f682465e1b4e9b5a188b78</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a825ec844298c791fd28ed14ed1bffc56a98d15b8c58a20e0e08c1f5f2bea1be</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8619d6915b3b0b34420cf9b2bb6d81ef59d984cb0fde7544e9ece32b4b3043c3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">686a0c2f85f83463272ddffd4deb5e591c98aac1897d65e92319f729c320eece</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a00862fb23195b6b8322f7d781b0dc1d82cb3bcac346d1e38689370cc1cc398b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-macosx_10_9_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">604f31d97fa493083ea21bd9b92c419012531c4e17ea6da0f65cacdcf5d0bd27</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-macosx_10_9_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8a854227cf581330ffa2c4824d96e52ee621dd571078a252c25e3a3b3d94a1b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ba6f52cbc7809cd8d74604cce9c14868306ae4aa0282016b641c661f981a6e91</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a6327976c7c2f4ee6816eff196e25385ccc02cb81427952414a64811037bbc8b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8397a3817d7dcdd14bb266283cd1d6fc7264a48c186b986f32e86d86d35fbac5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e0381b4ce23ff92f8170080c97678040fc5b08da85e9e292292aba67fdac6c34</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">23d32a2594cb5d565d358a92e151315d1b2268bc10f4610d098f96b147370136</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ddb2a5c08a4eaaba605340fdee8fc08e406c56617566d9643ad8bf6852778fc7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">26a1dc6285e03f3cc9e839a2da83bcbf31dcb0d004c72d0730e755b33466c30e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">18580f672e44ce1238b82f7fb87d727c4a131f3a9d33a5e0e82b793362bf18b4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">29e0f83f37610f173eb7e7b5562dd71467993495e568e708d99e9d1944f561ec</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f23e4fe1e8794f74b6027d7cf19dc25f8b63af1483d91d595d4a07eca1fb26c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">db8e58b9d79200c76956cefd14d5c90af54416ff5353c5bfd7cbe58818e26ef0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c7224cab95645c7ab53791022ae77a4509472613e839dab722a72abe5a684575</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">824d6c50492add5da9374875ce72db7a0733b29c2394890aef23d533106e2b15</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">928cecb0ef9d5a7946eb6ff58417ad2fe9375762382f1bf5c55e61645f2c43ad</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/yarl/#yarl-1.9.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">566db86717cf8080b99b58b083b773a908ae40f06681e87e589a976faf8246bf</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="aiohttp-cors@0.7.0">
+      <dependency ref="aiohttp@3.9.3"/>
+    </dependency>
+    <dependency ref="aiohttp@3.9.3">
+      <dependency ref="aiosignal@1.3.1"/>
+      <dependency ref="async-timeout@4.0.3"/>
+      <dependency ref="attrs@23.2.0"/>
+      <dependency ref="frozenlist@1.4.1"/>
+      <dependency ref="multidict@6.0.5"/>
+      <dependency ref="yarl@1.9.4"/>
+    </dependency>
+    <dependency ref="aiosignal@1.3.1">
+      <dependency ref="frozenlist@1.4.1"/>
+    </dependency>
+    <dependency ref="annotated-types@0.6.0"/>
+    <dependency ref="anyio@4.3.0">
+      <dependency ref="exceptiongroup@1.2.0"/>
+      <dependency ref="idna@3.6"/>
+      <dependency ref="sniffio@1.3.1"/>
+      <dependency ref="typing-extensions@4.10.0"/>
+    </dependency>
+    <dependency ref="async-timeout@4.0.3"/>
+    <dependency ref="attrs@23.2.0"/>
+    <dependency ref="cachetools@5.3.3"/>
+    <dependency ref="certifi@2024.2.2"/>
+    <dependency ref="charset-normalizer@3.3.2"/>
+    <dependency ref="click@8.1.7">
+      <dependency ref="colorama@0.4.6"/>
+    </dependency>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="colorful@0.5.6">
+      <dependency ref="colorama@0.4.6"/>
+    </dependency>
+    <dependency ref="distlib@0.3.8"/>
+    <dependency ref="exceptiongroup@1.2.0"/>
+    <dependency ref="fastapi@0.110.0">
+      <dependency ref="pydantic@2.6.4"/>
+      <dependency ref="starlette@0.36.3"/>
+      <dependency ref="typing-extensions@4.10.0"/>
+    </dependency>
+    <dependency ref="filelock@3.13.3"/>
+    <dependency ref="frozenlist@1.4.1"/>
+    <dependency ref="google-api-core@2.8.0">
+      <dependency ref="google-auth@2.29.0"/>
+      <dependency ref="googleapis-common-protos@1.56.1"/>
+      <dependency ref="protobuf@5.26.1"/>
+      <dependency ref="requests@2.31.0"/>
+    </dependency>
+    <dependency ref="google-auth@2.29.0">
+      <dependency ref="cachetools@5.3.3"/>
+      <dependency ref="pyasn1-modules@0.4.0"/>
+      <dependency ref="rsa@4.9"/>
+    </dependency>
+    <dependency ref="googleapis-common-protos@1.56.1">
+      <dependency ref="protobuf@5.26.1"/>
+    </dependency>
+    <dependency ref="grpcio@1.62.1"/>
+    <dependency ref="h11@0.14.0"/>
+    <dependency ref="httptools@0.6.1"/>
+    <dependency ref="idna@3.6"/>
+    <dependency ref="jsonschema-specifications@2023.12.1">
+      <dependency ref="referencing@0.34.0"/>
+    </dependency>
+    <dependency ref="jsonschema@4.21.1">
+      <dependency ref="attrs@23.2.0"/>
+      <dependency ref="jsonschema-specifications@2023.12.1"/>
+      <dependency ref="referencing@0.34.0"/>
+      <dependency ref="rpds-py@0.18.0"/>
+    </dependency>
+    <dependency ref="msgpack@1.0.8"/>
+    <dependency ref="multidict@6.0.5"/>
+    <dependency ref="opencensus-context@0.1.3"/>
+    <dependency ref="opencensus@0.11.4">
+      <dependency ref="google-api-core@2.8.0"/>
+      <dependency ref="opencensus-context@0.1.3"/>
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="packaging@24.0"/>
+    <dependency ref="platformdirs@4.2.0"/>
+    <dependency ref="prometheus-client@0.20.0"/>
+    <dependency ref="protobuf@5.26.1"/>
+    <dependency ref="py-spy@0.3.14"/>
+    <dependency ref="pyasn1-modules@0.4.0">
+      <dependency ref="pyasn1@0.6.0"/>
+    </dependency>
+    <dependency ref="pyasn1@0.6.0"/>
+    <dependency ref="pydantic-core@2.16.3">
+      <dependency ref="typing-extensions@4.10.0"/>
+    </dependency>
+    <dependency ref="pydantic@2.6.4">
+      <dependency ref="annotated-types@0.6.0"/>
+      <dependency ref="pydantic-core@2.16.3"/>
+      <dependency ref="typing-extensions@4.10.0"/>
+    </dependency>
+    <dependency ref="python-dotenv@1.0.1"/>
+    <dependency ref="pyyaml@6.0.1"/>
+    <dependency ref="ray@2.10.0">
+      <dependency ref="aiohttp-cors@0.7.0"/>
+      <dependency ref="aiohttp@3.9.3"/>
+      <dependency ref="aiosignal@1.3.1"/>
+      <dependency ref="click@8.1.7"/>
+      <dependency ref="colorful@0.5.6"/>
+      <dependency ref="fastapi@0.110.0"/>
+      <dependency ref="filelock@3.13.3"/>
+      <dependency ref="frozenlist@1.4.1"/>
+      <dependency ref="grpcio@1.62.1"/>
+      <dependency ref="jsonschema@4.21.1"/>
+      <dependency ref="msgpack@1.0.8"/>
+      <dependency ref="opencensus@0.11.4"/>
+      <dependency ref="packaging@24.0"/>
+      <dependency ref="prometheus-client@0.20.0"/>
+      <dependency ref="protobuf@5.26.1"/>
+      <dependency ref="py-spy@0.3.14"/>
+      <dependency ref="pydantic@2.6.4"/>
+      <dependency ref="pyyaml@6.0.1"/>
+      <dependency ref="requests@2.31.0"/>
+      <dependency ref="smart-open@7.0.4"/>
+      <dependency ref="starlette@0.36.3"/>
+      <dependency ref="uvicorn@0.29.0"/>
+      <dependency ref="virtualenv@20.25.1"/>
+      <dependency ref="watchfiles@0.21.0"/>
+    </dependency>
+    <dependency ref="referencing@0.34.0">
+      <dependency ref="attrs@23.2.0"/>
+      <dependency ref="rpds-py@0.18.0"/>
+    </dependency>
+    <dependency ref="regression-issue702">
+      <dependency ref="ray@2.10.0"/>
+    </dependency>
+    <dependency ref="requests@2.31.0">
+      <dependency ref="certifi@2024.2.2"/>
+      <dependency ref="charset-normalizer@3.3.2"/>
+      <dependency ref="idna@3.6"/>
+      <dependency ref="urllib3@2.2.1"/>
+    </dependency>
+    <dependency ref="rpds-py@0.18.0"/>
+    <dependency ref="rsa@4.9">
+      <dependency ref="pyasn1@0.6.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="smart-open@7.0.4">
+      <dependency ref="wrapt@1.16.0"/>
+    </dependency>
+    <dependency ref="sniffio@1.3.1"/>
+    <dependency ref="starlette@0.36.3">
+      <dependency ref="anyio@4.3.0"/>
+    </dependency>
+    <dependency ref="typing-extensions@4.10.0"/>
+    <dependency ref="urllib3@2.2.1"/>
+    <dependency ref="uvicorn@0.29.0">
+      <dependency ref="click@8.1.7"/>
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="h11@0.14.0"/>
+      <dependency ref="httptools@0.6.1"/>
+      <dependency ref="python-dotenv@1.0.1"/>
+      <dependency ref="pyyaml@6.0.1"/>
+      <dependency ref="typing-extensions@4.10.0"/>
+      <dependency ref="uvloop@0.19.0"/>
+      <dependency ref="watchfiles@0.21.0"/>
+      <dependency ref="websockets@12.0"/>
+    </dependency>
+    <dependency ref="uvloop@0.19.0"/>
+    <dependency ref="virtualenv@20.25.1">
+      <dependency ref="distlib@0.3.8"/>
+      <dependency ref="filelock@3.13.3"/>
+      <dependency ref="platformdirs@4.2.0"/>
+    </dependency>
+    <dependency ref="watchfiles@0.21.0">
+      <dependency ref="anyio@4.3.0"/>
+    </dependency>
+    <dependency ref="websockets@12.0"/>
+    <dependency ref="wrapt@1.16.0"/>
+    <dependency ref="yarl@1.9.4">
+      <dependency ref="idna@3.6"/>
+      <dependency ref="multidict@6.0.5"/>
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_with-extras_lock10_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-extras_lock10_1.6.json.bin
@@ -1,0 +1,34 @@
+{
+  "dependencies": [
+    {
+      "ref": "with-extras"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "with-extras",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_with-extras_lock10_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-extras_lock10_1.6.xml.bin
@@ -1,0 +1,55 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-extras">
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <dependencies>
+    <dependency ref="with-extras"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_with-extras_lock11_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-extras_lock11_1.6.json.bin
@@ -1,0 +1,34 @@
+{
+  "dependencies": [
+    {
+      "ref": "with-extras"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "with-extras",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_with-extras_lock11_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-extras_lock11_1.6.xml.bin
@@ -1,0 +1,55 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-extras">
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <dependencies>
+    <dependency ref="with-extras"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_with-extras_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-extras_lock20_1.6.json.bin
@@ -1,0 +1,34 @@
+{
+  "dependencies": [
+    {
+      "ref": "with-extras"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "with-extras",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_with-extras_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-extras_lock20_1.6.xml.bin
@@ -1,0 +1,55 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-extras">
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <dependencies>
+    <dependency ref="with-extras"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.6.json.bin
@@ -1,0 +1,151 @@
+{
+  "components": [
+    {
+      "bom-ref": "Pillow@10.1.0",
+      "description": "Python Imaging Library (Fork)",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+https://github.com/python-pillow/Pillow.git#da59ad000d1405eaecd557175e29083a87d19f7c"
+        }
+      ],
+      "name": "Pillow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:poetry:source:package:reference",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        }
+      ],
+      "purl": "pkg:pypi/pillow@10.1.0?vcs_url=git%2Bhttps://github.com/python-pillow/Pillow.git%40da59ad000d1405eaecd557175e29083a87d19f7c",
+      "type": "library",
+      "version": "10.1.0"
+    },
+    {
+      "bom-ref": "numpy@1.24.4",
+      "description": "Fundamental package for array computing in Python",
+      "externalReferences": [
+        {
+          "comment": "from url",
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/a4/9b/027bec52c633f6556dba6b722d9a0befb40498b9ceddd29cbe67a45a127c/numpy-1.24.4.tar.gz"
+        }
+      ],
+      "name": "numpy",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/numpy@1.24.4",
+      "type": "library",
+      "version": "1.24.4"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+ssh://git@github.com/benjaminp/six.git#65486e4383f9f411da95937451205d3c7b61b9e1"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:poetry:source:package:reference",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0?vcs_url=git%2Bssh://git%40github.com/benjaminp/six.git%4065486e4383f9f411da95937451205d3c7b61b9e1",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "wxPython@4.2.2a1.dev5618+1f82021f",
+      "description": "Cross platform GUI toolkit for Python, \"Phoenix\" version",
+      "externalReferences": [
+        {
+          "comment": "from url",
+          "type": "distribution",
+          "url": "https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618+1f82021f-cp38-cp38-win32.whl"
+        }
+      ],
+      "name": "wxPython",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/wxpython@4.2.2a1.dev5618%2B1f82021f?download_url=https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618%2B1f82021f-cp38-cp38-win32.whl",
+      "type": "library",
+      "version": "4.2.2a1.dev5618+1f82021f"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "Pillow@10.1.0"
+    },
+    {
+      "ref": "numpy@1.24.4"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "dependsOn": [
+        "Pillow@10.1.0",
+        "numpy@1.24.4",
+        "six@1.16.0",
+        "wxPython@4.2.2a1.dev5618+1f82021f"
+      ],
+      "ref": "with-urls"
+    },
+    {
+      "dependsOn": [
+        "Pillow@10.1.0",
+        "numpy@1.24.4",
+        "six@1.16.0"
+      ],
+      "ref": "wxPython@4.2.2a1.dev5618+1f82021f"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "with-urls",
+      "description": "packages from direct urls",
+      "name": "with-urls",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.6.xml.bin
@@ -1,0 +1,132 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-urls">
+      <name>with-urls</name>
+      <version>0.1.0</version>
+      <description>packages from direct urls</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="Pillow@10.1.0">
+      <name>Pillow</name>
+      <version>10.1.0</version>
+      <description>Python Imaging Library (Fork)</description>
+      <purl>pkg:pypi/pillow@10.1.0?vcs_url=git%2Bhttps://github.com/python-pillow/Pillow.git%40da59ad000d1405eaecd557175e29083a87d19f7c</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/python-pillow/Pillow.git#da59ad000d1405eaecd557175e29083a87d19f7c</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:source:package:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="numpy@1.24.4">
+      <name>numpy</name>
+      <version>1.24.4</version>
+      <description>Fundamental package for array computing in Python</description>
+      <purl>pkg:pypi/numpy@1.24.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/a4/9b/027bec52c633f6556dba6b722d9a0befb40498b9ceddd29cbe67a45a127c/numpy-1.24.4.tar.gz</url>
+          <comment>from url</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0?vcs_url=git%2Bssh://git%40github.com/benjaminp/six.git%4065486e4383f9f411da95937451205d3c7b61b9e1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+ssh://git@github.com/benjaminp/six.git#65486e4383f9f411da95937451205d3c7b61b9e1</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:source:package:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">
+      <name>wxPython</name>
+      <version>4.2.2a1.dev5618+1f82021f</version>
+      <description>Cross platform GUI toolkit for Python, &quot;Phoenix&quot; version</description>
+      <purl>pkg:pypi/wxpython@4.2.2a1.dev5618%2B1f82021f?download_url=https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618%2B1f82021f-cp38-cp38-win32.whl</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618+1f82021f-cp38-cp38-win32.whl</url>
+          <comment>from url</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="Pillow@10.1.0"/>
+    <dependency ref="numpy@1.24.4"/>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="with-urls">
+      <dependency ref="Pillow@10.1.0"/>
+      <dependency ref="numpy@1.24.4"/>
+      <dependency ref="six@1.16.0"/>
+      <dependency ref="wxPython@4.2.2a1.dev5618+1f82021f"/>
+    </dependency>
+    <dependency ref="wxPython@4.2.2a1.dev5618+1f82021f">
+      <dependency ref="Pillow@10.1.0"/>
+      <dependency ref="numpy@1.24.4"/>
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.6.json.bin
@@ -1,0 +1,159 @@
+{
+  "components": [
+    {
+      "bom-ref": "Pillow@10.1.0",
+      "description": "Python Imaging Library (Fork)",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+https://github.com/python-pillow/Pillow.git#da59ad000d1405eaecd557175e29083a87d19f7c"
+        }
+      ],
+      "name": "Pillow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:poetry:package:source:resolved_reference",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
+          "name": "cdx:poetry:source:package:reference",
+          "value": "10.1.0"
+        }
+      ],
+      "purl": "pkg:pypi/pillow@10.1.0?vcs_url=git%2Bhttps://github.com/python-pillow/Pillow.git%40da59ad000d1405eaecd557175e29083a87d19f7c",
+      "type": "library",
+      "version": "10.1.0"
+    },
+    {
+      "bom-ref": "numpy@1.24.4",
+      "description": "Fundamental package for array computing in Python",
+      "externalReferences": [
+        {
+          "comment": "from url",
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/a4/9b/027bec52c633f6556dba6b722d9a0befb40498b9ceddd29cbe67a45a127c/numpy-1.24.4.tar.gz"
+        }
+      ],
+      "name": "numpy",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/numpy@1.24.4",
+      "type": "library",
+      "version": "1.24.4"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+ssh://git@github.com/benjaminp/six.git#65486e4383f9f411da95937451205d3c7b61b9e1"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:poetry:package:source:resolved_reference",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
+          "name": "cdx:poetry:source:package:reference",
+          "value": "1.16.0"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0?vcs_url=git%2Bssh://git%40github.com/benjaminp/six.git%4065486e4383f9f411da95937451205d3c7b61b9e1",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "wxPython@4.2.2a1.dev5618+1f82021f",
+      "description": "Cross platform GUI toolkit for Python, \"Phoenix\" version",
+      "externalReferences": [
+        {
+          "comment": "from url",
+          "type": "distribution",
+          "url": "https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618+1f82021f-cp38-cp38-win32.whl"
+        }
+      ],
+      "name": "wxPython",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/wxpython@4.2.2a1.dev5618%2B1f82021f?download_url=https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618%2B1f82021f-cp38-cp38-win32.whl",
+      "type": "library",
+      "version": "4.2.2a1.dev5618+1f82021f"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "Pillow@10.1.0"
+    },
+    {
+      "ref": "numpy@1.24.4"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "dependsOn": [
+        "Pillow@10.1.0",
+        "numpy@1.24.4",
+        "six@1.16.0",
+        "wxPython@4.2.2a1.dev5618+1f82021f"
+      ],
+      "ref": "with-urls"
+    },
+    {
+      "dependsOn": [
+        "Pillow@10.1.0",
+        "numpy@1.24.4",
+        "six@1.16.0"
+      ],
+      "ref": "wxPython@4.2.2a1.dev5618+1f82021f"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "with-urls",
+      "description": "packages from direct urls",
+      "name": "with-urls",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.6.xml.bin
@@ -1,0 +1,134 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-urls">
+      <name>with-urls</name>
+      <version>0.1.0</version>
+      <description>packages from direct urls</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="Pillow@10.1.0">
+      <name>Pillow</name>
+      <version>10.1.0</version>
+      <description>Python Imaging Library (Fork)</description>
+      <purl>pkg:pypi/pillow@10.1.0?vcs_url=git%2Bhttps://github.com/python-pillow/Pillow.git%40da59ad000d1405eaecd557175e29083a87d19f7c</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/python-pillow/Pillow.git#da59ad000d1405eaecd557175e29083a87d19f7c</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+        <property name="cdx:poetry:source:package:reference">10.1.0</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="numpy@1.24.4">
+      <name>numpy</name>
+      <version>1.24.4</version>
+      <description>Fundamental package for array computing in Python</description>
+      <purl>pkg:pypi/numpy@1.24.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/a4/9b/027bec52c633f6556dba6b722d9a0befb40498b9ceddd29cbe67a45a127c/numpy-1.24.4.tar.gz</url>
+          <comment>from url</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0?vcs_url=git%2Bssh://git%40github.com/benjaminp/six.git%4065486e4383f9f411da95937451205d3c7b61b9e1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+ssh://git@github.com/benjaminp/six.git#65486e4383f9f411da95937451205d3c7b61b9e1</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+        <property name="cdx:poetry:source:package:reference">1.16.0</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">
+      <name>wxPython</name>
+      <version>4.2.2a1.dev5618+1f82021f</version>
+      <description>Cross platform GUI toolkit for Python, &quot;Phoenix&quot; version</description>
+      <purl>pkg:pypi/wxpython@4.2.2a1.dev5618%2B1f82021f?download_url=https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618%2B1f82021f-cp38-cp38-win32.whl</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618+1f82021f-cp38-cp38-win32.whl</url>
+          <comment>from url</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="Pillow@10.1.0"/>
+    <dependency ref="numpy@1.24.4"/>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="with-urls">
+      <dependency ref="Pillow@10.1.0"/>
+      <dependency ref="numpy@1.24.4"/>
+      <dependency ref="six@1.16.0"/>
+      <dependency ref="wxPython@4.2.2a1.dev5618+1f82021f"/>
+    </dependency>
+    <dependency ref="wxPython@4.2.2a1.dev5618+1f82021f">
+      <dependency ref="Pillow@10.1.0"/>
+      <dependency ref="numpy@1.24.4"/>
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.6.json.bin
@@ -1,0 +1,171 @@
+{
+  "components": [
+    {
+      "bom-ref": "Pillow@10.1.0",
+      "description": "Python Imaging Library (Fork)",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+https://github.com/python-pillow/Pillow.git#da59ad000d1405eaecd557175e29083a87d19f7c"
+        }
+      ],
+      "name": "Pillow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:poetry:package:source:resolved_reference",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
+          "name": "cdx:poetry:source:package:reference",
+          "value": "10.1.0"
+        }
+      ],
+      "purl": "pkg:pypi/pillow@10.1.0?vcs_url=git%2Bhttps://github.com/python-pillow/Pillow.git%40da59ad000d1405eaecd557175e29083a87d19f7c",
+      "type": "library",
+      "version": "10.1.0"
+    },
+    {
+      "bom-ref": "numpy@1.24.4",
+      "description": "Fundamental package for array computing in Python",
+      "externalReferences": [
+        {
+          "comment": "from url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "80f5e3a4e498641401868df4208b74581206afbee7cf7b8329daae82676d9463"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/a4/9b/027bec52c633f6556dba6b722d9a0befb40498b9ceddd29cbe67a45a127c/numpy-1.24.4.tar.gz"
+        }
+      ],
+      "name": "numpy",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/numpy@1.24.4",
+      "type": "library",
+      "version": "1.24.4"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+ssh://git@github.com/benjaminp/six.git#65486e4383f9f411da95937451205d3c7b61b9e1"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:poetry:package:source:resolved_reference",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
+          "name": "cdx:poetry:source:package:reference",
+          "value": "1.16.0"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0?vcs_url=git%2Bssh://git%40github.com/benjaminp/six.git%4065486e4383f9f411da95937451205d3c7b61b9e1",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "wxPython@4.2.2a1.dev5618+1f82021f",
+      "description": "Cross platform GUI toolkit for Python, \"Phoenix\" version",
+      "externalReferences": [
+        {
+          "comment": "from url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6ebb5019c6b999941a6cddd298dff7951d826239d663f6ce698b9547ae72d6b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618+1f82021f-cp38-cp38-win32.whl"
+        }
+      ],
+      "name": "wxPython",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/wxpython@4.2.2a1.dev5618%2B1f82021f?download_url=https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618%2B1f82021f-cp38-cp38-win32.whl",
+      "type": "library",
+      "version": "4.2.2a1.dev5618+1f82021f"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "Pillow@10.1.0"
+    },
+    {
+      "ref": "numpy@1.24.4"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "dependsOn": [
+        "Pillow@10.1.0",
+        "numpy@1.24.4",
+        "six@1.16.0",
+        "wxPython@4.2.2a1.dev5618+1f82021f"
+      ],
+      "ref": "with-urls"
+    },
+    {
+      "dependsOn": [
+        "Pillow@10.1.0",
+        "numpy@1.24.4",
+        "six@1.16.0"
+      ],
+      "ref": "wxPython@4.2.2a1.dev5618+1f82021f"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "with-urls",
+      "description": "packages from direct urls",
+      "name": "with-urls",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.6.xml.bin
@@ -1,0 +1,140 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-urls">
+      <name>with-urls</name>
+      <version>0.1.0</version>
+      <description>packages from direct urls</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="Pillow@10.1.0">
+      <name>Pillow</name>
+      <version>10.1.0</version>
+      <description>Python Imaging Library (Fork)</description>
+      <purl>pkg:pypi/pillow@10.1.0?vcs_url=git%2Bhttps://github.com/python-pillow/Pillow.git%40da59ad000d1405eaecd557175e29083a87d19f7c</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/python-pillow/Pillow.git#da59ad000d1405eaecd557175e29083a87d19f7c</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+        <property name="cdx:poetry:source:package:reference">10.1.0</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="numpy@1.24.4">
+      <name>numpy</name>
+      <version>1.24.4</version>
+      <description>Fundamental package for array computing in Python</description>
+      <purl>pkg:pypi/numpy@1.24.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/a4/9b/027bec52c633f6556dba6b722d9a0befb40498b9ceddd29cbe67a45a127c/numpy-1.24.4.tar.gz</url>
+          <comment>from url</comment>
+          <hashes>
+            <hash alg="SHA-256">80f5e3a4e498641401868df4208b74581206afbee7cf7b8329daae82676d9463</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0?vcs_url=git%2Bssh://git%40github.com/benjaminp/six.git%4065486e4383f9f411da95937451205d3c7b61b9e1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+ssh://git@github.com/benjaminp/six.git#65486e4383f9f411da95937451205d3c7b61b9e1</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+        <property name="cdx:poetry:source:package:reference">1.16.0</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">
+      <name>wxPython</name>
+      <version>4.2.2a1.dev5618+1f82021f</version>
+      <description>Cross platform GUI toolkit for Python, &quot;Phoenix&quot; version</description>
+      <purl>pkg:pypi/wxpython@4.2.2a1.dev5618%2B1f82021f?download_url=https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618%2B1f82021f-cp38-cp38-win32.whl</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://wxpython.org/Phoenix/snapshot-builds/wxPython-4.2.2a1.dev5618+1f82021f-cp38-cp38-win32.whl</url>
+          <comment>from url</comment>
+          <hashes>
+            <hash alg="SHA-256">6ebb5019c6b999941a6cddd298dff7951d826239d663f6ce698b9547ae72d6b9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="Pillow@10.1.0"/>
+    <dependency ref="numpy@1.24.4"/>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="with-urls">
+      <dependency ref="Pillow@10.1.0"/>
+      <dependency ref="numpy@1.24.4"/>
+      <dependency ref="six@1.16.0"/>
+      <dependency ref="wxPython@4.2.2a1.dev5618+1f82021f"/>
+    </dependency>
+    <dependency ref="wxPython@4.2.2a1.dev5618+1f82021f">
+      <dependency ref="Pillow@10.1.0"/>
+      <dependency ref="numpy@1.24.4"/>
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/some-extras_with-extras_lock10_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/some-extras_with-extras_lock10_1.6.json.bin
@@ -1,0 +1,191 @@
+{
+  "components": [
+    {
+      "bom-ref": "boolean.py@4.0",
+      "description": "Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.",
+      "name": "boolean.py",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/boolean.py@4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.0"
+    },
+    {
+      "bom-ref": "cyclonedx-python-lib@5.1.1",
+      "description": "Python library for CycloneDX",
+      "name": "cyclonedx-python-lib",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "json-validation"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "xml-validation"
+        }
+      ],
+      "purl": "pkg:pypi/cyclonedx-python-lib@5.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "5.1.1"
+    },
+    {
+      "bom-ref": "defusedxml@0.7.1",
+      "description": "XML bomb protection for Python stdlib modules",
+      "name": "defusedxml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/defusedxml@0.7.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.7.1"
+    },
+    {
+      "bom-ref": "license-expression@30.1.1",
+      "description": "license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.",
+      "name": "license-expression",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/license-expression@30.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "30.1.1"
+    },
+    {
+      "bom-ref": "packageurl-python@0.11.2",
+      "description": "A purl aka. Package URL parser and builder",
+      "name": "packageurl-python",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/packageurl-python@0.11.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.11.2"
+    },
+    {
+      "bom-ref": "py-serializable@0.15.0",
+      "description": "Library for serializing and deserializing Python Objects to and from JSON and XML.",
+      "name": "py-serializable",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/py-serializable@0.15.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.15.0"
+    },
+    {
+      "bom-ref": "sortedcontainers@2.4.0",
+      "description": "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set",
+      "name": "sortedcontainers",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/sortedcontainers@2.4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.4.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "boolean.py@4.0"
+    },
+    {
+      "dependsOn": [
+        "license-expression@30.1.1",
+        "packageurl-python@0.11.2",
+        "py-serializable@0.15.0",
+        "sortedcontainers@2.4.0"
+      ],
+      "ref": "cyclonedx-python-lib@5.1.1"
+    },
+    {
+      "ref": "defusedxml@0.7.1"
+    },
+    {
+      "dependsOn": [
+        "boolean.py@4.0"
+      ],
+      "ref": "license-expression@30.1.1"
+    },
+    {
+      "ref": "packageurl-python@0.11.2"
+    },
+    {
+      "dependsOn": [
+        "defusedxml@0.7.1"
+      ],
+      "ref": "py-serializable@0.15.0"
+    },
+    {
+      "ref": "sortedcontainers@2.4.0"
+    },
+    {
+      "dependsOn": [
+        "cyclonedx-python-lib@5.1.1"
+      ],
+      "ref": "with-extras"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "with-extras",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "properties": [
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "my-extra"
+        }
+      ],
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/some-extras_with-extras_lock10_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/some-extras_with-extras_lock10_1.6.xml.bin
@@ -1,0 +1,150 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-extras">
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+      <properties>
+        <property name="cdx:python:package:required-extra">my-extra</property>
+      </properties>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="boolean.py@4.0">
+      <name>boolean.py</name>
+      <version>4.0</version>
+      <description>Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/boolean.py@4.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="cyclonedx-python-lib@5.1.1">
+      <name>cyclonedx-python-lib</name>
+      <version>5.1.1</version>
+      <description>Python library for CycloneDX</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/cyclonedx-python-lib@5.1.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:required-extra">json-validation</property>
+        <property name="cdx:python:package:required-extra">xml-validation</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="defusedxml@0.7.1">
+      <name>defusedxml</name>
+      <version>0.7.1</version>
+      <description>XML bomb protection for Python stdlib modules</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/defusedxml@0.7.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="license-expression@30.1.1">
+      <name>license-expression</name>
+      <version>30.1.1</version>
+      <description>license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/license-expression@30.1.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="packageurl-python@0.11.2">
+      <name>packageurl-python</name>
+      <version>0.11.2</version>
+      <description>A purl aka. Package URL parser and builder</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/packageurl-python@0.11.2</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="py-serializable@0.15.0">
+      <name>py-serializable</name>
+      <version>0.15.0</version>
+      <description>Library for serializing and deserializing Python Objects to and from JSON and XML.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/py-serializable@0.15.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="sortedcontainers@2.4.0">
+      <name>sortedcontainers</name>
+      <version>2.4.0</version>
+      <description>Sorted Containers -- Sorted List, Sorted Dict, Sorted Set</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/sortedcontainers@2.4.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="boolean.py@4.0"/>
+    <dependency ref="cyclonedx-python-lib@5.1.1">
+      <dependency ref="license-expression@30.1.1"/>
+      <dependency ref="packageurl-python@0.11.2"/>
+      <dependency ref="py-serializable@0.15.0"/>
+      <dependency ref="sortedcontainers@2.4.0"/>
+    </dependency>
+    <dependency ref="defusedxml@0.7.1"/>
+    <dependency ref="license-expression@30.1.1">
+      <dependency ref="boolean.py@4.0"/>
+    </dependency>
+    <dependency ref="packageurl-python@0.11.2"/>
+    <dependency ref="py-serializable@0.15.0">
+      <dependency ref="defusedxml@0.7.1"/>
+    </dependency>
+    <dependency ref="sortedcontainers@2.4.0"/>
+    <dependency ref="with-extras">
+      <dependency ref="cyclonedx-python-lib@5.1.1"/>
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/some-extras_with-extras_lock11_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/some-extras_with-extras_lock11_1.6.json.bin
@@ -1,0 +1,2138 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "attrs@23.1.0",
+      "description": "Classes Without Boilerplate",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/#attrs-23.1.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/#attrs-23.1.0.tar.gz"
+        }
+      ],
+      "name": "attrs",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/attrs@23.1.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "23.1.0"
+    },
+    {
+      "bom-ref": "boolean.py@4.0",
+      "description": "Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.",
+      "name": "boolean.py",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/boolean.py@4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.0"
+    },
+    {
+      "bom-ref": "cyclonedx-python-lib@5.1.1",
+      "description": "Python library for CycloneDX",
+      "name": "cyclonedx-python-lib",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "json-validation"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "xml-validation"
+        }
+      ],
+      "purl": "pkg:pypi/cyclonedx-python-lib@5.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "5.1.1"
+    },
+    {
+      "bom-ref": "defusedxml@0.7.1",
+      "description": "XML bomb protection for Python stdlib modules",
+      "name": "defusedxml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/defusedxml@0.7.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.7.1"
+    },
+    {
+      "bom-ref": "fqdn@1.5.1",
+      "description": "Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fqdn/#fqdn-1.5.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fqdn/#fqdn-1.5.1.tar.gz"
+        }
+      ],
+      "name": "fqdn",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/fqdn@1.5.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.5.1"
+    },
+    {
+      "bom-ref": "idna@3.4",
+      "description": "Internationalized Domain Names in Applications (IDNA)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/#idna-3.4-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/#idna-3.4.tar.gz"
+        }
+      ],
+      "name": "idna",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/idna@3.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "3.4"
+    },
+    {
+      "bom-ref": "importlib-resources@6.1.1",
+      "description": "Read resources from Python packages",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e8bf90d8213b486f428c9c39714b920041cb02c184686a3dee24905aaa8105d6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1.tar.gz"
+        }
+      ],
+      "name": "importlib-resources",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/importlib-resources@6.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "6.1.1"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "jsonpointer@2.4",
+      "description": "Identify specific nodes in a JSON document (RFC 6901)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonpointer/#jsonpointer-2.4-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonpointer/#jsonpointer-2.4.tar.gz"
+        }
+      ],
+      "name": "jsonpointer",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/jsonpointer@2.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.4"
+    },
+    {
+      "bom-ref": "jsonschema@4.19.2",
+      "description": "An implementation of JSON Schema validation for Python",
+      "name": "jsonschema",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "format"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema@4.19.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.19.2"
+    },
+    {
+      "bom-ref": "jsonschema-specifications@2023.7.1",
+      "description": "The JSON Schema meta-schemas and vocabularies, exposed as a Registry",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05adf340b659828a004220a9613be00fa3f223f2b82002e273dee62fd50524b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c91a50404e88a1f6ba40636778e2ee08f6e24c5613fe4c53ac24578a5a7f72bb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1.tar.gz"
+        }
+      ],
+      "name": "jsonschema-specifications",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema-specifications@2023.7.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "2023.7.1"
+    },
+    {
+      "bom-ref": "license-expression@30.1.1",
+      "description": "license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.",
+      "name": "license-expression",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/license-expression@30.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "30.1.1"
+    },
+    {
+      "bom-ref": "lxml@4.9.3",
+      "description": "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.",
+      "name": "lxml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/lxml@4.9.3",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.9.3"
+    },
+    {
+      "bom-ref": "packageurl-python@0.11.2",
+      "description": "A purl aka. Package URL parser and builder",
+      "name": "packageurl-python",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/packageurl-python@0.11.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.11.2"
+    },
+    {
+      "bom-ref": "pkgutil-resolve-name@1.3.10",
+      "description": "Resolve a name to an object.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10.tar.gz"
+        }
+      ],
+      "name": "pkgutil-resolve-name",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/pkgutil-resolve-name@1.3.10",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.10"
+    },
+    {
+      "bom-ref": "py-serializable@0.15.0",
+      "description": "Library for serializing and deserializing Python Objects to and from JSON and XML.",
+      "name": "py-serializable",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/py-serializable@0.15.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.15.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "referencing@0.30.2",
+      "description": "JSON Referencing + Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "449b6669b6121a9e96a7f9e410b245d471e8d48964c67113ce9afe50c8dd7bdf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/#referencing-0.30.2-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "794ad8003c65938edcdbc027f1933215e0d0ccc0291e3ce20a4d87432b59efc0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/#referencing-0.30.2.tar.gz"
+        }
+      ],
+      "name": "referencing",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/referencing@0.30.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.30.2"
+    },
+    {
+      "bom-ref": "rfc3339-validator@0.1.4",
+      "description": "A pure python RFC3339 validator",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4.tar.gz"
+        }
+      ],
+      "name": "rfc3339-validator",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/rfc3339-validator@0.1.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.1.4"
+    },
+    {
+      "bom-ref": "rfc3987@1.3.8",
+      "description": "Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3987/#rfc3987-1.3.8-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3987/#rfc3987-1.3.8.tar.gz"
+        }
+      ],
+      "name": "rfc3987",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/rfc3987@1.3.8",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.8"
+    },
+    {
+      "bom-ref": "rpds-py@0.12.0",
+      "description": "Python bindings to Rust's persistent data structures (rpds)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c694bee70ece3b232df4678448fdda245fd3b1bb4ba481fb6cd20e13bb784c46"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "30e5ce9f501fb1f970e4a59098028cf20676dee64fc496d55c33e04bbbee097d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d72a4315514e5a0b9837a086cb433b004eea630afb0cc129de76d77654a9606f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eebaf8c76c39604d52852366249ab807fe6f7a3ffb0dd5484b9944917244cdbe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a239303acb0315091d54c7ff36712dba24554993b9a93941cf301391d8a997ee"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ced40cdbb6dd47a032725a038896cceae9ce267d340f59508b23537f05455431"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3c8c0226c71bd0ce9892eaf6afa77ae8f43a3d9313124a03df0b389c01f832de"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b8e11715178f3608874508f08e990d3771e0b8c66c73eb4e183038d600a9b274"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5210a0018c7e09c75fa788648617ebba861ae242944111d3079034e14498223f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "171d9a159f1b2f42a42a64a985e4ba46fc7268c78299272ceba970743a67ee50"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "57ec6baec231bb19bb5fd5fc7bae21231860a1605174b11585660236627e390e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7188ddc1a8887194f984fa4110d5a3d5b9b5cd35f6bafdff1b649049cbc0ce29"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e04581c6117ad9479b6cfae313e212fe0dfa226ac727755f0d539cd54792963"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0a38612d07a36138507d69646c470aedbfe2b75b43a4643f7bd8e51e52779624"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f12d69d568f5647ec503b64932874dade5a20255736c89936bf690951a5e79f5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f8a1d990dc198a6c68ec3d9a637ba1ce489b38cbfb65440a27901afbc5df575"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8c567c664fc2f44130a20edac73e0a867f8e012bf7370276f15c6adc3586c37c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e9e976e0dbed4f51c56db10831c9623d0fd67aac02853fe5476262e5a22acb7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efddca2d02254a52078c35cadad34762adbae3ff01c6b0c7787b59d038b63e0d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d9e7f29c00577aff6b318681e730a519b235af292732a149337f6aaa4d1c5e31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "389c0e38358fdc4e38e9995e7291269a3aead7acfcf8942010ee7bc5baee091c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "33ab498f9ac30598b6406e2be1b45fd231195b83d948ebd4bd77f337cb6a2bff"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d56b1cd606ba4cedd64bb43479d56580e147c6ef3f5d1c5e64203a1adab784a2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1fa73ed22c40a1bec98d7c93b5659cd35abcfa5a0a95ce876b91adbda170537c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dbc25baa6abb205766fb8606f8263b02c3503a55957fcb4576a6bb0a59d37d10"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c6b52b7028b547866c2413f614ee306c2d4eafdd444b1ff656bf3295bf1484aa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9620650c364c01ed5b497dcae7c3d4b948daeae6e1883ae185fef1c927b6b534"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2124f9e645a94ab7c853bc0a3644e0ca8ffbe5bb2d72db49aef8f9ec1c285733"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "281c8b219d4f4b3581b918b816764098d04964915b2f272d1476654143801aa2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27ccc93c7457ef890b0dd31564d2a05e1aca330623c942b7e818e9e7c2669ee4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d1c562a9bb72244fa767d1c1ab55ca1d92dd5f7c4d77878fee5483a22ffac808"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e57919c32ee295a2fca458bb73e4b20b05c115627f96f95a10f9f5acbd61172d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fa35ad36440aaf1ac8332b4a4a433d4acd28f1613f0d480995f5cfd3580e90b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e6aea5c0eb5b0faf52c7b5c4a47c8bb64437173be97227c819ffa31801fa4e34"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81cf9d306c04df1b45971c13167dc3bad625808aa01281d55f3cf852dde0e206"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08e6e7ff286254016b945e1ab632ee843e43d45e40683b66dd12b73791366dd1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d0a675a7acbbc16179188d8c6d0afb8628604fc1241faf41007255957335a0b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2287c09482949e0ca0c0eb68b2aca6cf57f8af8c6dfd29dcd3bc45f17b57978"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8015835494b21aa7abd3b43fdea0614ee35ef6b03db7ecba9beb58eadf01c24f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6174d6ad6b58a6bcf67afbbf1723420a53d06c4b89f4c50763d6fa0a6ac9afd2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a689e1ded7137552bea36305a7a16ad2b40be511740b80748d3140614993db98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f45321224144c25a62052035ce96cbcf264667bcb0d81823b1bbc22c4addd194"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aa32205358a76bf578854bf31698a86dc8b2cb591fd1d79a833283f4a403f04b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "91bd2b7cf0f4d252eec8b7046fa6a43cee17e8acdfc00eaa8b3dbf2f9a59d061"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3acadbab8b59f63b87b518e09c4c64b142e7286b9ca7a208107d6f9f4c393c5c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "429349a510da82c85431f0f3e66212d83efe9fd2850f50f339341b6532c62fe4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05942656cb2cb4989cd50ced52df16be94d344eae5097e8583966a1d27da73a5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0c5441b7626c29dbd54a3f6f3713ec8e956b009f419ffdaaa3c80eaf98ddb523"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b6b0e17d39d21698185097652c611f9cf30f7c56ccec189789920e3e7f1cee56"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3b7a64d43e2a1fa2dd46b678e00cabd9a49ebb123b339ce799204c44a593ae1c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e5bbe011a2cea9060fef1bb3d668a2fd8432b8888e6d92e74c9c794d3c101595"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bec29b801b4adbf388314c0d050e851d53762ab424af22657021ce4b6eb41543"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1096ca0bf2d3426cbe79d4ccc91dc5aaa73629b08ea2d8467375fad8447ce11a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48aa98987d54a46e13e6954880056c204700c65616af4395d1f0639eba11764b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7979d90ee2190d000129598c2b0c82f13053dba432b94e45e68253b09bb1f0f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "88857060b690a57d2ea8569bca58758143c8faa4639fb17d745ce60ff84c867e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4eb74d44776b0fb0782560ea84d986dffec8ddd94947f383eba2284b0f32e35e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f62581d7e884dd01ee1707b7c21148f61f2febb7de092ae2f108743fcbef5985"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6f5dcb658d597410bb7c967c1d24eaf9377b0d621358cbe9d2ff804e5dd12e81"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9bf9acce44e967a5103fcd820fc7580c7b0ab8583eec4e2051aec560f7b31a63"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "240687b5be0f91fbde4936a329c9b7589d9259742766f74de575e1b2046575e4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25740fb56e8bd37692ed380e15ec734be44d7c71974d8993f452b4527814601e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a54917b7e9cd3a67e429a630e237a90b096e0ba18897bfb99ee8bd1068a5fea0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b92aafcfab3d41580d54aca35a8057341f1cfc7c9af9e8bdfc652f83a20ced31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd316dbcc74c76266ba94eb021b0cc090b97cca122f50bd7a845f587ff4bf03f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0853da3d5e9bc6a07b2486054a410b7b03f34046c123c6561b535bb48cc509e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cb41ad20064e18a900dd427d7cf41cfaec83bcd1184001f3d91a1f76b3fcea4e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b710bf7e7ae61957d5c4026b486be593ed3ec3dca3e5be15e0f6d8cf5d0a4990"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a952ae3eb460c6712388ac2ec706d24b0e651b9396d90c9a9e0a69eb27737fdc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0bedd91ae1dd142a4dc15970ed2c729ff6c73f33a40fa84ed0cdbf55de87c777"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "761531076df51309075133a6bc1db02d98ec7f66e22b064b1d513bc909f29743"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a2baa6be130e8a00b6cbb9f18a33611ec150b4537f8563bddadb54c1b74b8193"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f05450fa1cd7c525c0b9d1a7916e595d3041ac0afbed2ff6926e5afb6a781b7f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81c4d1a3a564775c44732b94135d06e33417e829ff25226c164664f4a1046213"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e888be685fa42d8b8a3d3911d5604d14db87538aa7d0b29b1a7ea80d354c732d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6f8d7fe73d1816eeb5378409adc658f9525ecbfaf9e1ede1e2d67a338b0c7348"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0831d3ecdea22e4559cc1793f22e77067c9d8c451d55ae6a75bf1d116a8e7f42"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "513ccbf7420c30e283c25c82d5a8f439d625a838d3ba69e79a110c260c46813f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "301bd744a1adaa2f6a5e06c98f1ac2b6f8dc31a5c23b838f862d65e32fca0d4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f8832a4f83d4782a8f5a7b831c47e8ffe164e43c2c148c8160ed9a6d630bc02a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b2416ed743ec5debcf61e1242e012652a4348de14ecc7df3512da072b074440"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "35585a8cb5917161f42c2104567bb83a1d96194095fc54a543113ed5df9fa436"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d389ff1e95b6e46ebedccf7fd1fadd10559add595ac6a7c2ea730268325f832c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9b007c2444705a2dc4a525964fd4dd28c3320b19b3410da6517cab28716f27d3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "188912b22b6c8225f4c4ffa020a2baa6ad8fabb3c141a12dbe6edbb34e7f1425"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b4cf9ab9a0ae0cb122685209806d3f1dcb63b9fccdf1424fb42a129dc8c2faa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2d34a5450a402b00d20aeb7632489ffa2556ca7b26f4a63c35f6fccae1977427"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "466030a42724780794dea71eb32db83cc51214d66ab3fb3156edd88b9c8f0d78"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "68172622a5a57deb079a2c78511c40f91193548e8ab342c31e8cb0764d362459"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54cdfcda59251b9c2f87a05d038c2ae02121219a04d4a1e6fc345794295bdc07"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b75b912a0baa033350367a8a07a8b2d44fd5b90c890bfbd063a8a5f945f644b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "47aeceb4363851d17f63069318ba5721ae695d9da55d599b4d6fb31508595278"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0525847f83f506aa1e28eb2057b696fe38217e12931c8b1b02198cfe6975e142"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efbe0b5e0fd078ed7b005faa0170da4f72666360f66f0bb2d7f73526ecfd99f9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0fadfdda275c838cba5102c7f90a20f2abd7727bf8f4a2b654a5b617529c5c18"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "56dd500411d03c5e9927a1eb55621e906837a83b02350a9dc401247d0353717c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6915fc9fa6b3ec3569566832e1bb03bd801c12cea030200e68663b9a87974e76"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5f1519b080d8ce0a814f17ad9fb49fb3a1d4d7ce5891f5c85fc38631ca3a8dc4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7036316cc26b93e401cedd781a579be606dad174829e6ad9e9c5a0da6e036f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0.tar.gz"
+        }
+      ],
+      "name": "rpds-py",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/rpds-py@0.12.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.12.0"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "sortedcontainers@2.4.0",
+      "description": "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set",
+      "name": "sortedcontainers",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/sortedcontainers@2.4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.4.0"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.8.19.14"
+    },
+    {
+      "bom-ref": "uri-template@1.3.0",
+      "description": "RFC 6570 URI Template Processor",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uri-template/#uri-template-1.3.0.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uri-template/#uri_template-1.3.0-py3-none-any.whl"
+        }
+      ],
+      "name": "uri-template",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/uri-template@1.3.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "webcolors@1.13",
+      "description": "A library for working with the color formats defined by HTML and CSS.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/webcolors/#webcolors-1.13-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/webcolors/#webcolors-1.13.tar.gz"
+        }
+      ],
+      "name": "webcolors",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/webcolors@1.13",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.13"
+    },
+    {
+      "bom-ref": "zipp@3.17.0",
+      "description": "Backport of pathlib-compatible object wrapper for zip files",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/zipp/#zipp-3.17.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/zipp/#zipp-3.17.0.tar.gz"
+        }
+      ],
+      "name": "zipp",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/zipp@3.17.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "3.17.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "attrs@23.1.0"
+    },
+    {
+      "ref": "boolean.py@4.0"
+    },
+    {
+      "dependsOn": [
+        "jsonschema@4.19.2",
+        "license-expression@30.1.1",
+        "lxml@4.9.3",
+        "packageurl-python@0.11.2",
+        "py-serializable@0.15.0",
+        "sortedcontainers@2.4.0"
+      ],
+      "ref": "cyclonedx-python-lib@5.1.1"
+    },
+    {
+      "ref": "defusedxml@0.7.1"
+    },
+    {
+      "ref": "fqdn@1.5.1"
+    },
+    {
+      "ref": "idna@3.4"
+    },
+    {
+      "dependsOn": [
+        "zipp@3.17.0"
+      ],
+      "ref": "importlib-resources@6.1.1"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "ref": "jsonpointer@2.4"
+    },
+    {
+      "dependsOn": [
+        "importlib-resources@6.1.1",
+        "referencing@0.30.2"
+      ],
+      "ref": "jsonschema-specifications@2023.7.1"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.1.0",
+        "fqdn@1.5.1",
+        "idna@3.4",
+        "importlib-resources@6.1.1",
+        "isoduration@20.11.0",
+        "jsonpointer@2.4",
+        "jsonschema-specifications@2023.7.1",
+        "pkgutil-resolve-name@1.3.10",
+        "referencing@0.30.2",
+        "rfc3339-validator@0.1.4",
+        "rfc3987@1.3.8",
+        "rpds-py@0.12.0",
+        "uri-template@1.3.0",
+        "webcolors@1.13"
+      ],
+      "ref": "jsonschema@4.19.2"
+    },
+    {
+      "dependsOn": [
+        "boolean.py@4.0"
+      ],
+      "ref": "license-expression@30.1.1"
+    },
+    {
+      "ref": "lxml@4.9.3"
+    },
+    {
+      "ref": "packageurl-python@0.11.2"
+    },
+    {
+      "ref": "pkgutil-resolve-name@1.3.10"
+    },
+    {
+      "dependsOn": [
+        "defusedxml@0.7.1"
+      ],
+      "ref": "py-serializable@0.15.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.1.0",
+        "rpds-py@0.12.0"
+      ],
+      "ref": "referencing@0.30.2"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "rfc3339-validator@0.1.4"
+    },
+    {
+      "ref": "rfc3987@1.3.8"
+    },
+    {
+      "ref": "rpds-py@0.12.0"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "sortedcontainers@2.4.0"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    },
+    {
+      "ref": "uri-template@1.3.0"
+    },
+    {
+      "ref": "webcolors@1.13"
+    },
+    {
+      "dependsOn": [
+        "cyclonedx-python-lib@5.1.1"
+      ],
+      "ref": "with-extras"
+    },
+    {
+      "ref": "zipp@3.17.0"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "with-extras",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "properties": [
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "my-extra"
+        }
+      ],
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/some-extras_with-extras_lock11_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/some-extras_with-extras_lock11_1.6.xml.bin
@@ -1,0 +1,1399 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-extras">
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+      <properties>
+        <property name="cdx:python:package:required-extra">my-extra</property>
+      </properties>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="attrs@23.1.0">
+      <name>attrs</name>
+      <version>23.1.0</version>
+      <description>Classes Without Boilerplate</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/attrs@23.1.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/#attrs-23.1.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/#attrs-23.1.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="boolean.py@4.0">
+      <name>boolean.py</name>
+      <version>4.0</version>
+      <description>Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/boolean.py@4.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="cyclonedx-python-lib@5.1.1">
+      <name>cyclonedx-python-lib</name>
+      <version>5.1.1</version>
+      <description>Python library for CycloneDX</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/cyclonedx-python-lib@5.1.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:required-extra">json-validation</property>
+        <property name="cdx:python:package:required-extra">xml-validation</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="defusedxml@0.7.1">
+      <name>defusedxml</name>
+      <version>0.7.1</version>
+      <description>XML bomb protection for Python stdlib modules</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/defusedxml@0.7.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="fqdn@1.5.1">
+      <name>fqdn</name>
+      <version>1.5.1</version>
+      <description>Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/fqdn@1.5.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fqdn/#fqdn-1.5.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fqdn/#fqdn-1.5.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="idna@3.4">
+      <name>idna</name>
+      <version>3.4</version>
+      <description>Internationalized Domain Names in Applications (IDNA)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/idna@3.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/#idna-3.4-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/#idna-3.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="importlib-resources@6.1.1">
+      <name>importlib-resources</name>
+      <version>6.1.1</version>
+      <description>Read resources from Python packages</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/importlib-resources@6.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e8bf90d8213b486f428c9c39714b920041cb02c184686a3dee24905aaa8105d6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonpointer@2.4">
+      <name>jsonpointer</name>
+      <version>2.4</version>
+      <description>Identify specific nodes in a JSON document (RFC 6901)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonpointer@2.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonpointer/#jsonpointer-2.4-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonpointer/#jsonpointer-2.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema@4.19.2">
+      <name>jsonschema</name>
+      <version>4.19.2</version>
+      <description>An implementation of JSON Schema validation for Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonschema@4.19.2</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:required-extra">format</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema-specifications@2023.7.1">
+      <name>jsonschema-specifications</name>
+      <version>2023.7.1</version>
+      <description>The JSON Schema meta-schemas and vocabularies, exposed as a Registry</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonschema-specifications@2023.7.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">05adf340b659828a004220a9613be00fa3f223f2b82002e273dee62fd50524b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c91a50404e88a1f6ba40636778e2ee08f6e24c5613fe4c53ac24578a5a7f72bb</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="license-expression@30.1.1">
+      <name>license-expression</name>
+      <version>30.1.1</version>
+      <description>license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/license-expression@30.1.1</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="lxml@4.9.3">
+      <name>lxml</name>
+      <version>4.9.3</version>
+      <description>Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/lxml@4.9.3</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="packageurl-python@0.11.2">
+      <name>packageurl-python</name>
+      <version>0.11.2</version>
+      <description>A purl aka. Package URL parser and builder</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/packageurl-python@0.11.2</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pkgutil-resolve-name@1.3.10">
+      <name>pkgutil-resolve-name</name>
+      <version>1.3.10</version>
+      <description>Resolve a name to an object.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/pkgutil-resolve-name@1.3.10</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="py-serializable@0.15.0">
+      <name>py-serializable</name>
+      <version>0.15.0</version>
+      <description>Library for serializing and deserializing Python Objects to and from JSON and XML.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/py-serializable@0.15.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="referencing@0.30.2">
+      <name>referencing</name>
+      <version>0.30.2</version>
+      <description>JSON Referencing + Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/referencing@0.30.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/#referencing-0.30.2-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">449b6669b6121a9e96a7f9e410b245d471e8d48964c67113ce9afe50c8dd7bdf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/#referencing-0.30.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">794ad8003c65938edcdbc027f1933215e0d0ccc0291e3ce20a4d87432b59efc0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rfc3339-validator@0.1.4">
+      <name>rfc3339-validator</name>
+      <version>0.1.4</version>
+      <description>A pure python RFC3339 validator</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rfc3339-validator@0.1.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rfc3987@1.3.8">
+      <name>rfc3987</name>
+      <version>1.3.8</version>
+      <description>Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rfc3987@1.3.8</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3987/#rfc3987-1.3.8-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3987/#rfc3987-1.3.8.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="rpds-py@0.12.0">
+      <name>rpds-py</name>
+      <version>0.12.0</version>
+      <description>Python bindings to Rust's persistent data structures (rpds)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rpds-py@0.12.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c694bee70ece3b232df4678448fdda245fd3b1bb4ba481fb6cd20e13bb784c46</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">30e5ce9f501fb1f970e4a59098028cf20676dee64fc496d55c33e04bbbee097d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d72a4315514e5a0b9837a086cb433b004eea630afb0cc129de76d77654a9606f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eebaf8c76c39604d52852366249ab807fe6f7a3ffb0dd5484b9944917244cdbe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a239303acb0315091d54c7ff36712dba24554993b9a93941cf301391d8a997ee</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ced40cdbb6dd47a032725a038896cceae9ce267d340f59508b23537f05455431</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3c8c0226c71bd0ce9892eaf6afa77ae8f43a3d9313124a03df0b389c01f832de</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b8e11715178f3608874508f08e990d3771e0b8c66c73eb4e183038d600a9b274</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5210a0018c7e09c75fa788648617ebba861ae242944111d3079034e14498223f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">171d9a159f1b2f42a42a64a985e4ba46fc7268c78299272ceba970743a67ee50</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">57ec6baec231bb19bb5fd5fc7bae21231860a1605174b11585660236627e390e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7188ddc1a8887194f984fa4110d5a3d5b9b5cd35f6bafdff1b649049cbc0ce29</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e04581c6117ad9479b6cfae313e212fe0dfa226ac727755f0d539cd54792963</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0a38612d07a36138507d69646c470aedbfe2b75b43a4643f7bd8e51e52779624</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f12d69d568f5647ec503b64932874dade5a20255736c89936bf690951a5e79f5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f8a1d990dc198a6c68ec3d9a637ba1ce489b38cbfb65440a27901afbc5df575</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8c567c664fc2f44130a20edac73e0a867f8e012bf7370276f15c6adc3586c37c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e9e976e0dbed4f51c56db10831c9623d0fd67aac02853fe5476262e5a22acb7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efddca2d02254a52078c35cadad34762adbae3ff01c6b0c7787b59d038b63e0d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d9e7f29c00577aff6b318681e730a519b235af292732a149337f6aaa4d1c5e31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">389c0e38358fdc4e38e9995e7291269a3aead7acfcf8942010ee7bc5baee091c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">33ab498f9ac30598b6406e2be1b45fd231195b83d948ebd4bd77f337cb6a2bff</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d56b1cd606ba4cedd64bb43479d56580e147c6ef3f5d1c5e64203a1adab784a2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1fa73ed22c40a1bec98d7c93b5659cd35abcfa5a0a95ce876b91adbda170537c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dbc25baa6abb205766fb8606f8263b02c3503a55957fcb4576a6bb0a59d37d10</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c6b52b7028b547866c2413f614ee306c2d4eafdd444b1ff656bf3295bf1484aa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9620650c364c01ed5b497dcae7c3d4b948daeae6e1883ae185fef1c927b6b534</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2124f9e645a94ab7c853bc0a3644e0ca8ffbe5bb2d72db49aef8f9ec1c285733</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">281c8b219d4f4b3581b918b816764098d04964915b2f272d1476654143801aa2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">27ccc93c7457ef890b0dd31564d2a05e1aca330623c942b7e818e9e7c2669ee4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d1c562a9bb72244fa767d1c1ab55ca1d92dd5f7c4d77878fee5483a22ffac808</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e57919c32ee295a2fca458bb73e4b20b05c115627f96f95a10f9f5acbd61172d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fa35ad36440aaf1ac8332b4a4a433d4acd28f1613f0d480995f5cfd3580e90b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e6aea5c0eb5b0faf52c7b5c4a47c8bb64437173be97227c819ffa31801fa4e34</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">81cf9d306c04df1b45971c13167dc3bad625808aa01281d55f3cf852dde0e206</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08e6e7ff286254016b945e1ab632ee843e43d45e40683b66dd12b73791366dd1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d0a675a7acbbc16179188d8c6d0afb8628604fc1241faf41007255957335a0b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2287c09482949e0ca0c0eb68b2aca6cf57f8af8c6dfd29dcd3bc45f17b57978</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8015835494b21aa7abd3b43fdea0614ee35ef6b03db7ecba9beb58eadf01c24f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6174d6ad6b58a6bcf67afbbf1723420a53d06c4b89f4c50763d6fa0a6ac9afd2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a689e1ded7137552bea36305a7a16ad2b40be511740b80748d3140614993db98</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f45321224144c25a62052035ce96cbcf264667bcb0d81823b1bbc22c4addd194</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aa32205358a76bf578854bf31698a86dc8b2cb591fd1d79a833283f4a403f04b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">91bd2b7cf0f4d252eec8b7046fa6a43cee17e8acdfc00eaa8b3dbf2f9a59d061</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3acadbab8b59f63b87b518e09c4c64b142e7286b9ca7a208107d6f9f4c393c5c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">429349a510da82c85431f0f3e66212d83efe9fd2850f50f339341b6532c62fe4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">05942656cb2cb4989cd50ced52df16be94d344eae5097e8583966a1d27da73a5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0c5441b7626c29dbd54a3f6f3713ec8e956b009f419ffdaaa3c80eaf98ddb523</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b6b0e17d39d21698185097652c611f9cf30f7c56ccec189789920e3e7f1cee56</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3b7a64d43e2a1fa2dd46b678e00cabd9a49ebb123b339ce799204c44a593ae1c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e5bbe011a2cea9060fef1bb3d668a2fd8432b8888e6d92e74c9c794d3c101595</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bec29b801b4adbf388314c0d050e851d53762ab424af22657021ce4b6eb41543</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1096ca0bf2d3426cbe79d4ccc91dc5aaa73629b08ea2d8467375fad8447ce11a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48aa98987d54a46e13e6954880056c204700c65616af4395d1f0639eba11764b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7979d90ee2190d000129598c2b0c82f13053dba432b94e45e68253b09bb1f0f6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">88857060b690a57d2ea8569bca58758143c8faa4639fb17d745ce60ff84c867e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4eb74d44776b0fb0782560ea84d986dffec8ddd94947f383eba2284b0f32e35e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f62581d7e884dd01ee1707b7c21148f61f2febb7de092ae2f108743fcbef5985</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6f5dcb658d597410bb7c967c1d24eaf9377b0d621358cbe9d2ff804e5dd12e81</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9bf9acce44e967a5103fcd820fc7580c7b0ab8583eec4e2051aec560f7b31a63</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">240687b5be0f91fbde4936a329c9b7589d9259742766f74de575e1b2046575e4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">25740fb56e8bd37692ed380e15ec734be44d7c71974d8993f452b4527814601e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a54917b7e9cd3a67e429a630e237a90b096e0ba18897bfb99ee8bd1068a5fea0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b92aafcfab3d41580d54aca35a8057341f1cfc7c9af9e8bdfc652f83a20ced31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd316dbcc74c76266ba94eb021b0cc090b97cca122f50bd7a845f587ff4bf03f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0853da3d5e9bc6a07b2486054a410b7b03f34046c123c6561b535bb48cc509e1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cb41ad20064e18a900dd427d7cf41cfaec83bcd1184001f3d91a1f76b3fcea4e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b710bf7e7ae61957d5c4026b486be593ed3ec3dca3e5be15e0f6d8cf5d0a4990</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a952ae3eb460c6712388ac2ec706d24b0e651b9396d90c9a9e0a69eb27737fdc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0bedd91ae1dd142a4dc15970ed2c729ff6c73f33a40fa84ed0cdbf55de87c777</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">761531076df51309075133a6bc1db02d98ec7f66e22b064b1d513bc909f29743</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a2baa6be130e8a00b6cbb9f18a33611ec150b4537f8563bddadb54c1b74b8193</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f05450fa1cd7c525c0b9d1a7916e595d3041ac0afbed2ff6926e5afb6a781b7f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">81c4d1a3a564775c44732b94135d06e33417e829ff25226c164664f4a1046213</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e888be685fa42d8b8a3d3911d5604d14db87538aa7d0b29b1a7ea80d354c732d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6f8d7fe73d1816eeb5378409adc658f9525ecbfaf9e1ede1e2d67a338b0c7348</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0831d3ecdea22e4559cc1793f22e77067c9d8c451d55ae6a75bf1d116a8e7f42</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">513ccbf7420c30e283c25c82d5a8f439d625a838d3ba69e79a110c260c46813f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">301bd744a1adaa2f6a5e06c98f1ac2b6f8dc31a5c23b838f862d65e32fca0d4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f8832a4f83d4782a8f5a7b831c47e8ffe164e43c2c148c8160ed9a6d630bc02a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4b2416ed743ec5debcf61e1242e012652a4348de14ecc7df3512da072b074440</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">35585a8cb5917161f42c2104567bb83a1d96194095fc54a543113ed5df9fa436</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d389ff1e95b6e46ebedccf7fd1fadd10559add595ac6a7c2ea730268325f832c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9b007c2444705a2dc4a525964fd4dd28c3320b19b3410da6517cab28716f27d3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">188912b22b6c8225f4c4ffa020a2baa6ad8fabb3c141a12dbe6edbb34e7f1425</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1b4cf9ab9a0ae0cb122685209806d3f1dcb63b9fccdf1424fb42a129dc8c2faa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2d34a5450a402b00d20aeb7632489ffa2556ca7b26f4a63c35f6fccae1977427</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">466030a42724780794dea71eb32db83cc51214d66ab3fb3156edd88b9c8f0d78</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">68172622a5a57deb079a2c78511c40f91193548e8ab342c31e8cb0764d362459</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">54cdfcda59251b9c2f87a05d038c2ae02121219a04d4a1e6fc345794295bdc07</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b75b912a0baa033350367a8a07a8b2d44fd5b90c890bfbd063a8a5f945f644b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">47aeceb4363851d17f63069318ba5721ae695d9da55d599b4d6fb31508595278</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0525847f83f506aa1e28eb2057b696fe38217e12931c8b1b02198cfe6975e142</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efbe0b5e0fd078ed7b005faa0170da4f72666360f66f0bb2d7f73526ecfd99f9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0fadfdda275c838cba5102c7f90a20f2abd7727bf8f4a2b654a5b617529c5c18</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">56dd500411d03c5e9927a1eb55621e906837a83b02350a9dc401247d0353717c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6915fc9fa6b3ec3569566832e1bb03bd801c12cea030200e68663b9a87974e76</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5f1519b080d8ce0a814f17ad9fb49fb3a1d4d7ce5891f5c85fc38631ca3a8dc4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7036316cc26b93e401cedd781a579be606dad174829e6ad9e9c5a0da6e036f80</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="sortedcontainers@2.4.0">
+      <name>sortedcontainers</name>
+      <version>2.4.0</version>
+      <description>Sorted Containers -- Sorted List, Sorted Dict, Sorted Set</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/sortedcontainers@2.4.0</purl>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="uri-template@1.3.0">
+      <name>uri-template</name>
+      <version>1.3.0</version>
+      <description>RFC 6570 URI Template Processor</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/uri-template@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uri-template/#uri-template-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uri-template/#uri_template-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="webcolors@1.13">
+      <name>webcolors</name>
+      <version>1.13</version>
+      <description>A library for working with the color formats defined by HTML and CSS.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/webcolors@1.13</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/webcolors/#webcolors-1.13-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/webcolors/#webcolors-1.13.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="zipp@3.17.0">
+      <name>zipp</name>
+      <version>3.17.0</version>
+      <description>Backport of pathlib-compatible object wrapper for zip files</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/zipp@3.17.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/zipp/#zipp-3.17.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/zipp/#zipp-3.17.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="attrs@23.1.0"/>
+    <dependency ref="boolean.py@4.0"/>
+    <dependency ref="cyclonedx-python-lib@5.1.1">
+      <dependency ref="jsonschema@4.19.2"/>
+      <dependency ref="license-expression@30.1.1"/>
+      <dependency ref="lxml@4.9.3"/>
+      <dependency ref="packageurl-python@0.11.2"/>
+      <dependency ref="py-serializable@0.15.0"/>
+      <dependency ref="sortedcontainers@2.4.0"/>
+    </dependency>
+    <dependency ref="defusedxml@0.7.1"/>
+    <dependency ref="fqdn@1.5.1"/>
+    <dependency ref="idna@3.4"/>
+    <dependency ref="importlib-resources@6.1.1">
+      <dependency ref="zipp@3.17.0"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="jsonpointer@2.4"/>
+    <dependency ref="jsonschema-specifications@2023.7.1">
+      <dependency ref="importlib-resources@6.1.1"/>
+      <dependency ref="referencing@0.30.2"/>
+    </dependency>
+    <dependency ref="jsonschema@4.19.2">
+      <dependency ref="attrs@23.1.0"/>
+      <dependency ref="fqdn@1.5.1"/>
+      <dependency ref="idna@3.4"/>
+      <dependency ref="importlib-resources@6.1.1"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="jsonpointer@2.4"/>
+      <dependency ref="jsonschema-specifications@2023.7.1"/>
+      <dependency ref="pkgutil-resolve-name@1.3.10"/>
+      <dependency ref="referencing@0.30.2"/>
+      <dependency ref="rfc3339-validator@0.1.4"/>
+      <dependency ref="rfc3987@1.3.8"/>
+      <dependency ref="rpds-py@0.12.0"/>
+      <dependency ref="uri-template@1.3.0"/>
+      <dependency ref="webcolors@1.13"/>
+    </dependency>
+    <dependency ref="license-expression@30.1.1">
+      <dependency ref="boolean.py@4.0"/>
+    </dependency>
+    <dependency ref="lxml@4.9.3"/>
+    <dependency ref="packageurl-python@0.11.2"/>
+    <dependency ref="pkgutil-resolve-name@1.3.10"/>
+    <dependency ref="py-serializable@0.15.0">
+      <dependency ref="defusedxml@0.7.1"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="referencing@0.30.2">
+      <dependency ref="attrs@23.1.0"/>
+      <dependency ref="rpds-py@0.12.0"/>
+    </dependency>
+    <dependency ref="rfc3339-validator@0.1.4">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="rfc3987@1.3.8"/>
+    <dependency ref="rpds-py@0.12.0"/>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="sortedcontainers@2.4.0"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+    <dependency ref="uri-template@1.3.0"/>
+    <dependency ref="webcolors@1.13"/>
+    <dependency ref="with-extras">
+      <dependency ref="cyclonedx-python-lib@5.1.1"/>
+    </dependency>
+    <dependency ref="zipp@3.17.0"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/some-extras_with-extras_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/some-extras_with-extras_lock20_1.6.json.bin
@@ -1,0 +1,3184 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "attrs@23.1.0",
+      "description": "Classes Without Boilerplate",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/#attrs-23.1.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/attrs/#attrs-23.1.0.tar.gz"
+        }
+      ],
+      "name": "attrs",
+      "purl": "pkg:pypi/attrs@23.1.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "23.1.0"
+    },
+    {
+      "bom-ref": "boolean-py@4.0",
+      "description": "Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2876f2051d7d6394a531d82dc6eb407faa0b01a0a0b3083817ccd7323b8d96bd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/boolean-py/#boolean.py-4.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "17b9a181630e43dde1851d42bef546d616d5d9b4480357514597e78b203d06e4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/boolean-py/#boolean.py-4.0.tar.gz"
+        }
+      ],
+      "name": "boolean-py",
+      "purl": "pkg:pypi/boolean-py@4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.0"
+    },
+    {
+      "bom-ref": "cyclonedx-python-lib@5.1.1",
+      "description": "Python library for CycloneDX",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2989db0cd8bb4c0c442423d71ed7a84ae059e16a2d0f932cc4bf92da7385cdb3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/cyclonedx-python-lib/#cyclonedx_python_lib-5.1.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "215a636a4e77385d2cf4c6c9801c9bad4791849634f2c6daa45ab2c6cb0a85f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/cyclonedx-python-lib/#cyclonedx_python_lib-5.1.1.tar.gz"
+        }
+      ],
+      "name": "cyclonedx-python-lib",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "json-validation"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "xml-validation"
+        }
+      ],
+      "purl": "pkg:pypi/cyclonedx-python-lib@5.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "5.1.1"
+    },
+    {
+      "bom-ref": "defusedxml@0.7.1",
+      "description": "XML bomb protection for Python stdlib modules",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/defusedxml/#defusedxml-0.7.1-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/defusedxml/#defusedxml-0.7.1.tar.gz"
+        }
+      ],
+      "name": "defusedxml",
+      "purl": "pkg:pypi/defusedxml@0.7.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.7.1"
+    },
+    {
+      "bom-ref": "fqdn@1.5.1",
+      "description": "Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fqdn/#fqdn-1.5.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/fqdn/#fqdn-1.5.1.tar.gz"
+        }
+      ],
+      "name": "fqdn",
+      "purl": "pkg:pypi/fqdn@1.5.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.5.1"
+    },
+    {
+      "bom-ref": "idna@3.4",
+      "description": "Internationalized Domain Names in Applications (IDNA)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/#idna-3.4-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/#idna-3.4.tar.gz"
+        }
+      ],
+      "name": "idna",
+      "purl": "pkg:pypi/idna@3.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "3.4"
+    },
+    {
+      "bom-ref": "importlib-resources@6.1.1",
+      "description": "Read resources from Python packages",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e8bf90d8213b486f428c9c39714b920041cb02c184686a3dee24905aaa8105d6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1.tar.gz"
+        }
+      ],
+      "name": "importlib-resources",
+      "purl": "pkg:pypi/importlib-resources@6.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "6.1.1"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "jsonpointer@2.4",
+      "description": "Identify specific nodes in a JSON document (RFC 6901)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonpointer/#jsonpointer-2.4-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonpointer/#jsonpointer-2.4.tar.gz"
+        }
+      ],
+      "name": "jsonpointer",
+      "purl": "pkg:pypi/jsonpointer@2.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.4"
+    },
+    {
+      "bom-ref": "jsonschema@4.19.2",
+      "description": "An implementation of JSON Schema validation for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eee9e502c788e89cb166d4d37f43084e3b64ab405c795c03d343a4dbc2c810fc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema/#jsonschema-4.19.2-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c9ff4d7447eed9592c23a12ccee508baf0dd0d59650615e847feb6cdca74f392"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema/#jsonschema-4.19.2.tar.gz"
+        }
+      ],
+      "name": "jsonschema",
+      "properties": [
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "format"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema@4.19.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.19.2"
+    },
+    {
+      "bom-ref": "jsonschema-specifications@2023.7.1",
+      "description": "The JSON Schema meta-schemas and vocabularies, exposed as a Registry",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05adf340b659828a004220a9613be00fa3f223f2b82002e273dee62fd50524b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c91a50404e88a1f6ba40636778e2ee08f6e24c5613fe4c53ac24578a5a7f72bb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1.tar.gz"
+        }
+      ],
+      "name": "jsonschema-specifications",
+      "purl": "pkg:pypi/jsonschema-specifications@2023.7.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "2023.7.1"
+    },
+    {
+      "bom-ref": "license-expression@30.1.1",
+      "description": "license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "42375df653ad85e6f5b4b0385138b2dbea1f5d66360783d8625c3e4f97f11f0c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/license-expression/#license-expression-30.1.1.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d7e5e2de0d04fc104a4f952c440e8f08a5ba63480a0dad015b294770b7e58ec"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/license-expression/#license_expression-30.1.1-py3-none-any.whl"
+        }
+      ],
+      "name": "license-expression",
+      "purl": "pkg:pypi/license-expression@30.1.1",
+      "scope": "optional",
+      "type": "library",
+      "version": "30.1.1"
+    },
+    {
+      "bom-ref": "lxml@4.9.3",
+      "description": "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b0a545b46b526d418eb91754565ba5b63b1c0b12f9bd2f808c852d9b4b2f9b5c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "075b731ddd9e7f68ad24c635374211376aa05a281673ede86cbe1d1b3455279d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e224d5755dba2f4a9498e150c43792392ac9b5380aa1b845f98a1618c94eeef"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2c74524e179f2ad6d2a4f7caf70e2d96639c0954c943ad601a9e146c76408ed7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1026bc732b6a7f96369f7bfe1a4f2290fb34dce00d8644bc3036fb351a4ca1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c0781a98ff5e6586926293e59480b64ddd46282953203c76ae15dbbbf302e8bb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cef2502e7e8a96fe5ad686d60b49e1ab03e438bd9123987994528febd569868e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b86164d2cff4d3aaa1f04a14685cbc072efd0b4f99ca5708b2ad1b9b5988a991"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "42871176e7896d5d45138f6d28751053c711ed4d48d8e30b498da155af39aebd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ae8b9c6deb1e634ba4f1930eb67ef6e6bf6a44b6eb5ad605642b2d6d5ed9ce3c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "411007c0d88188d9f621b11d252cce90c4a2d1a49db6c068e3c16422f306eab8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd47b4a0d41d2afa3e58e5bf1f62069255aa2fd6ff5ee41604418ca925911d76"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e2cb47860da1f7e9a5256254b74ae331687b9672dfa780eed355c4c9c3dbd23"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1247694b26342a7bf47c02e513d32225ededd18045264d40758abeb3c838a51f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cdb650fc86227eba20de1a29d4b2c1bfe139dc75a0669270033cb2ea3d391b85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "97047f0d25cd4bcae81f9ec9dc290ca3e15927c192df17331b53bebe0e3ff96d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f447ea5429b54f9582d4b955f5f1985f278ce5cf169f72eea8afd9502973dd5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-macosx_11_0_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "57d6ba0ca2b0c462f339640d22882acc711de224d769edf29962b09f77129cbf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9767e79108424fb6c3edf8f81e6730666a50feb01a328f4a016464a5893f835a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "71c52db65e4b56b8ddc5bb89fb2e66c558ed9d1a74a45ceb7dcb20c191c3df2f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d73d8ecf8ecf10a3bd007f2192725a34bd62898e8da27eb9d32a58084f93962b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0a3d3487f07c1d7f150894c238299934a2a074ef590b583103a45002035be120"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9e28c51fa0ce5674be9f560c6761c1b441631901993f76700b1b30ca6c8378d6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0bfd0767c5c1de2551a120673b72e5d4b628737cb05414f03c3277bf9bed3305"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25f32acefac14ef7bd53e4218fe93b804ef6f6b92ffdb4322bb6d49d94cad2bc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d3ff32724f98fbbbfa9f49d82852b159e9784d6094983d9a8b7f2ddaebb063d4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-macosx_11_0_universal2.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48d6ed886b343d11493129e019da91d4039826794a3e3027321c56d9e71505be"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9a92d3faef50658dd2c5470af249985782bf754c4e18e15afb67d3ab06233f13"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b4e4bc18382088514ebde9328da057775055940a1f2e18f6ad2d78aa0f3ec5b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fc9b106a1bf918db68619fdcd6d5ad4f972fdd19c01d19bdb6bf63f3589a9ec5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d37017287a7adb6ab77e1c5bee9bcf9660f90ff445042b790402a654d2ad81d8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "56dc1f1ebccc656d1b3ed288f11e27172a01503fc016bcabdcbc0978b19352b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "578695735c5a3f51569810dfebd05dd6f888147a34f0f98d4bb27e92b76e05c2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "704f61ba8c1283c71b16135caf697557f5ecf3e74d9e453233e4771d68a1f42d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c41bfca0bd3532d53d16fd34d20806d5c2b1ace22a2f2e4c0008570bf2c58833"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "64f479d719dc9f4c813ad9bb6b28f8390360660b73b2e4beb4cb0ae7104f1c12"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dd708cf4ee4408cf46a48b108fb9427bfa00b9b85812a9262b5c668af2533ea5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c31c7462abdf8f2ac0577d9f05279727e698f97ecbb02f17939ea99ae8daa98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e3cd95e10c2610c360154afdc2f1480aea394f4a4f1ea0a5eacce49640c9b190"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4930be26af26ac545c3dffb662521d4e6268352866956672231887d18f0eaab2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4aec80cde9197340bc353d2768e2a75f5f60bacda2bab72ab1dc499589b3878c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "14e019fd83b831b2e61baed40cab76222139926b1fb5ed0e79225bc0cae14584"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0c0850c8b02c298d3c7006b23e98249515ac57430e16a166873fc47a5d549287"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aca086dc5f9ef98c512bac8efea4483eb84abbf926eaeedf7b91479feb092458"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "50baa9c1c47efcaef189f31e3d00d697c6d4afda5c3cde0302d063492ff9b477"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bef4e656f7d98aaa3486d2627e7d2df1157d7e88e7efd43a65aa5dd4714916cf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "46f409a2d60f634fe550f7133ed30ad5321ae2e6630f13657fb9479506b00601"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4c28a9144688aef80d6ea666c809b4b0e50010a2aca784c97f5e6bf143d9f129"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "141f1d1a9b663c679dc524af3ea1773e618907e96075262726c7612c02b149a4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "53ace1c1fd5a74ef662f844a0413446c0629d151055340e9893da958a374f70d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "17a753023436a18e27dd7769e798ce302963c236bc4114ceee5b25c18c52c693"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7d298a1bd60c067ea75d9f684f5f3992c9d6766fadbc0bcedd39750bf344c2f4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "081d32421db5df44c41b7f08a334a090a545c54ba977e47fd7cc2deece78809a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "23eed6d7b1a3336ad92d8e39d4bfe09073c31bfe502f20ca5116b2a334f8ec02"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1509dd12b773c02acd154582088820893109f6ca27ef7291b003d0e81666109f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "120fa9349a24c7043854c53cae8cec227e1f79195a7493e09e0c12e29f918e52"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d2d1edbca80b510443f51afd8496be95529db04a509bc8faee49c7b0fb6d2cc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d7e43bd40f65f7d97ad8ef5c9b1778943d02f04febef12def25f7583d19baac"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "71d66ee82e7417828af6ecd7db817913cb0cf9d4e61aa0ac1fde0583d84358db"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6fc3c450eaa0b56f815c7b62f2b7fba7266c4779adcf1cece9e6deb1de7305ce"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "65299ea57d82fb91c7f019300d24050c4ddeb7c5a190e076b5f48a2b43d19c42"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eadfbbbfb41b44034a4c757fd5d70baccd43296fb894dba0295606a7cf3124aa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e9bdd30efde2b9ccfa9cb5768ba04fe71b018a25ea093379c857c9dad262c40"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fcdd00edfd0a3001e0181eab3e63bd5c74ad3e67152c84f93f13769a40e073a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "57aba1bbdf450b726d58b2aea5fe47c7875f5afb2c4a23784ed78f19a0462574"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "92af161ecbdb2883c4593d5ed4815ea71b31fafd7fd05789b23100d081ecac96"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9bb6ad405121241e99a86efff22d3ef469024ce22875a7ae045896ad23ba2340"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8ed74706b26ad100433da4b9d807eae371efaa266ffc3e9191ea436087a9d6a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fbf521479bcac1e25a663df882c46a641a9bff6b56dc8b0fafaebd2f66fb231b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "303bf1edce6ced16bf67a18a1cf8339d0db79577eec5d9a6d4a80f0fb10aa2da"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5515edd2a6d1a5a70bfcdee23b42ec33425e405c5b351478ab7dc9347228f96e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "690dafd0b187ed38583a648076865d8c229661ed20e48f2335d68e2cf7dc829d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b6420a005548ad52154c8ceab4a1290ff78d757f9e5cbc68f8c77089acd3c432"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bb3bb49c7a6ad9d981d734ef7c7193bc349ac338776a0360cc671eaee89bcf69"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-musllinux_1_1_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d27be7405547d1f958b60837dc4c1007da90b8b23f54ba1f8b728c78fdb19d50"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-musllinux_1_1_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8df133a2ea5e74eef5e8fc6f19b9e085f758768a16e9877a60aec455ed2609b2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4dd9a263e845a72eacb60d12401e37c616438ea2e5442885f65082c276dfb2b2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6689a3d7fd13dc687e9102a27e98ef33730ac4fe37795d5036d18b4d527abd35"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f6bdac493b949141b733c5345b6ba8f87a226029cbabc7e9e121a413e49441e0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05186a0f1346ae12553d66df1cfce6f251589fea3ad3da4f3ef4e34b2d58c6a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c2006f5c8d28dee289f7020f721354362fa304acbaaf9745751ac4006650254b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5c245b783db29c4e4fbbbfc9c5a78be496c9fea25517f90606aa1f6b2b3d5f7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4fb960a632a49f2f089d522f70496640fdf1218f1243889da3822e0a9f5f3ba7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "50670615eaf97227d5dc60de2dc99fb134a7130d310d783314e7724bf163f75d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9719fe17307a9e814580af1f5c6e05ca593b12fb7e44fe62450a5384dbf61b4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3331bece23c9ee066e0fb3f96c61322b9e0f54d775fccefff4c38ca488de283a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ed667f49b11360951e201453fc3967344d0d0263aa415e1619e85ae7fd17b4e0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-macosx_11_0_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8b77946fd508cbf0fccd8e400a7f71d4ac0e1595812e66025bac475a8e811694"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e4da8ca0c0c0aea88fd46be8e44bd49716772358d648cce45fe387f7b92374a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fe4bda6bd4340caa6e5cf95e73f8fea5c4bfc55763dd42f1b50a94c1b4a2fbd4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f3df3db1d336b9356dd3112eae5f5c2b8b377f3bc826848567f10bfddfee77e9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48628bd53a426c9eb9bc066a923acaa0878d1e86129fd5359aee99285f4eed9c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/lxml/#lxml-4.9.3.tar.gz"
+        }
+      ],
+      "name": "lxml",
+      "purl": "pkg:pypi/lxml@4.9.3",
+      "scope": "optional",
+      "type": "library",
+      "version": "4.9.3"
+    },
+    {
+      "bom-ref": "packageurl-python@0.11.2",
+      "description": "A purl aka. Package URL parser and builder",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "01fbf74a41ef85cf413f1ede529a1411f658bda66ed22d45d27280ad9ceba471"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/packageurl-python/#packageurl-python-0.11.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "799acfe8d9e6e3534bbc19660be97d5b66754bc033e62c39f1e2f16323fcfa84"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/packageurl-python/#packageurl_python-0.11.2-py3-none-any.whl"
+        }
+      ],
+      "name": "packageurl-python",
+      "purl": "pkg:pypi/packageurl-python@0.11.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.11.2"
+    },
+    {
+      "bom-ref": "pkgutil-resolve-name@1.3.10",
+      "description": "Resolve a name to an object.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10.tar.gz"
+        }
+      ],
+      "name": "pkgutil-resolve-name",
+      "purl": "pkg:pypi/pkgutil-resolve-name@1.3.10",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.10"
+    },
+    {
+      "bom-ref": "py-serializable@0.15.0",
+      "description": "Library for serializing and deserializing Python Objects to and from JSON and XML.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8fc41457d8ee5f5c5a12f41fd87bf1a4f2ecf9da39fee92059b728e78f320771"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-serializable/#py-serializable-0.15.0.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d3f1201b33420c481aa83f7860c7bf2c2f036ba3ea82b6e15a96696457c36cd2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/py-serializable/#py_serializable-0.15.0-py3-none-any.whl"
+        }
+      ],
+      "name": "py-serializable",
+      "purl": "pkg:pypi/py-serializable@0.15.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.15.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "referencing@0.30.2",
+      "description": "JSON Referencing + Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "449b6669b6121a9e96a7f9e410b245d471e8d48964c67113ce9afe50c8dd7bdf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/#referencing-0.30.2-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "794ad8003c65938edcdbc027f1933215e0d0ccc0291e3ce20a4d87432b59efc0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/referencing/#referencing-0.30.2.tar.gz"
+        }
+      ],
+      "name": "referencing",
+      "purl": "pkg:pypi/referencing@0.30.2",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.30.2"
+    },
+    {
+      "bom-ref": "rfc3339-validator@0.1.4",
+      "description": "A pure python RFC3339 validator",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4.tar.gz"
+        }
+      ],
+      "name": "rfc3339-validator",
+      "purl": "pkg:pypi/rfc3339-validator@0.1.4",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.1.4"
+    },
+    {
+      "bom-ref": "rfc3987@1.3.8",
+      "description": "Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3987/#rfc3987-1.3.8-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rfc3987/#rfc3987-1.3.8.tar.gz"
+        }
+      ],
+      "name": "rfc3987",
+      "purl": "pkg:pypi/rfc3987@1.3.8",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.8"
+    },
+    {
+      "bom-ref": "rpds-py@0.12.0",
+      "description": "Python bindings to Rust's persistent data structures (rpds)",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c694bee70ece3b232df4678448fdda245fd3b1bb4ba481fb6cd20e13bb784c46"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "30e5ce9f501fb1f970e4a59098028cf20676dee64fc496d55c33e04bbbee097d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d72a4315514e5a0b9837a086cb433b004eea630afb0cc129de76d77654a9606f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eebaf8c76c39604d52852366249ab807fe6f7a3ffb0dd5484b9944917244cdbe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a239303acb0315091d54c7ff36712dba24554993b9a93941cf301391d8a997ee"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ced40cdbb6dd47a032725a038896cceae9ce267d340f59508b23537f05455431"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3c8c0226c71bd0ce9892eaf6afa77ae8f43a3d9313124a03df0b389c01f832de"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b8e11715178f3608874508f08e990d3771e0b8c66c73eb4e183038d600a9b274"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5210a0018c7e09c75fa788648617ebba861ae242944111d3079034e14498223f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "171d9a159f1b2f42a42a64a985e4ba46fc7268c78299272ceba970743a67ee50"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "57ec6baec231bb19bb5fd5fc7bae21231860a1605174b11585660236627e390e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7188ddc1a8887194f984fa4110d5a3d5b9b5cd35f6bafdff1b649049cbc0ce29"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e04581c6117ad9479b6cfae313e212fe0dfa226ac727755f0d539cd54792963"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0a38612d07a36138507d69646c470aedbfe2b75b43a4643f7bd8e51e52779624"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f12d69d568f5647ec503b64932874dade5a20255736c89936bf690951a5e79f5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f8a1d990dc198a6c68ec3d9a637ba1ce489b38cbfb65440a27901afbc5df575"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8c567c664fc2f44130a20edac73e0a867f8e012bf7370276f15c6adc3586c37c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e9e976e0dbed4f51c56db10831c9623d0fd67aac02853fe5476262e5a22acb7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efddca2d02254a52078c35cadad34762adbae3ff01c6b0c7787b59d038b63e0d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d9e7f29c00577aff6b318681e730a519b235af292732a149337f6aaa4d1c5e31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "389c0e38358fdc4e38e9995e7291269a3aead7acfcf8942010ee7bc5baee091c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "33ab498f9ac30598b6406e2be1b45fd231195b83d948ebd4bd77f337cb6a2bff"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d56b1cd606ba4cedd64bb43479d56580e147c6ef3f5d1c5e64203a1adab784a2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1fa73ed22c40a1bec98d7c93b5659cd35abcfa5a0a95ce876b91adbda170537c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dbc25baa6abb205766fb8606f8263b02c3503a55957fcb4576a6bb0a59d37d10"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c6b52b7028b547866c2413f614ee306c2d4eafdd444b1ff656bf3295bf1484aa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9620650c364c01ed5b497dcae7c3d4b948daeae6e1883ae185fef1c927b6b534"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2124f9e645a94ab7c853bc0a3644e0ca8ffbe5bb2d72db49aef8f9ec1c285733"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "281c8b219d4f4b3581b918b816764098d04964915b2f272d1476654143801aa2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27ccc93c7457ef890b0dd31564d2a05e1aca330623c942b7e818e9e7c2669ee4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d1c562a9bb72244fa767d1c1ab55ca1d92dd5f7c4d77878fee5483a22ffac808"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e57919c32ee295a2fca458bb73e4b20b05c115627f96f95a10f9f5acbd61172d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fa35ad36440aaf1ac8332b4a4a433d4acd28f1613f0d480995f5cfd3580e90b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e6aea5c0eb5b0faf52c7b5c4a47c8bb64437173be97227c819ffa31801fa4e34"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81cf9d306c04df1b45971c13167dc3bad625808aa01281d55f3cf852dde0e206"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08e6e7ff286254016b945e1ab632ee843e43d45e40683b66dd12b73791366dd1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4d0a675a7acbbc16179188d8c6d0afb8628604fc1241faf41007255957335a0b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2287c09482949e0ca0c0eb68b2aca6cf57f8af8c6dfd29dcd3bc45f17b57978"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8015835494b21aa7abd3b43fdea0614ee35ef6b03db7ecba9beb58eadf01c24f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6174d6ad6b58a6bcf67afbbf1723420a53d06c4b89f4c50763d6fa0a6ac9afd2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a689e1ded7137552bea36305a7a16ad2b40be511740b80748d3140614993db98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f45321224144c25a62052035ce96cbcf264667bcb0d81823b1bbc22c4addd194"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aa32205358a76bf578854bf31698a86dc8b2cb591fd1d79a833283f4a403f04b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "91bd2b7cf0f4d252eec8b7046fa6a43cee17e8acdfc00eaa8b3dbf2f9a59d061"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3acadbab8b59f63b87b518e09c4c64b142e7286b9ca7a208107d6f9f4c393c5c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "429349a510da82c85431f0f3e66212d83efe9fd2850f50f339341b6532c62fe4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05942656cb2cb4989cd50ced52df16be94d344eae5097e8583966a1d27da73a5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0c5441b7626c29dbd54a3f6f3713ec8e956b009f419ffdaaa3c80eaf98ddb523"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b6b0e17d39d21698185097652c611f9cf30f7c56ccec189789920e3e7f1cee56"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3b7a64d43e2a1fa2dd46b678e00cabd9a49ebb123b339ce799204c44a593ae1c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e5bbe011a2cea9060fef1bb3d668a2fd8432b8888e6d92e74c9c794d3c101595"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bec29b801b4adbf388314c0d050e851d53762ab424af22657021ce4b6eb41543"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1096ca0bf2d3426cbe79d4ccc91dc5aaa73629b08ea2d8467375fad8447ce11a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "48aa98987d54a46e13e6954880056c204700c65616af4395d1f0639eba11764b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7979d90ee2190d000129598c2b0c82f13053dba432b94e45e68253b09bb1f0f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "88857060b690a57d2ea8569bca58758143c8faa4639fb17d745ce60ff84c867e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4eb74d44776b0fb0782560ea84d986dffec8ddd94947f383eba2284b0f32e35e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f62581d7e884dd01ee1707b7c21148f61f2febb7de092ae2f108743fcbef5985"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6f5dcb658d597410bb7c967c1d24eaf9377b0d621358cbe9d2ff804e5dd12e81"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9bf9acce44e967a5103fcd820fc7580c7b0ab8583eec4e2051aec560f7b31a63"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "240687b5be0f91fbde4936a329c9b7589d9259742766f74de575e1b2046575e4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25740fb56e8bd37692ed380e15ec734be44d7c71974d8993f452b4527814601e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a54917b7e9cd3a67e429a630e237a90b096e0ba18897bfb99ee8bd1068a5fea0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b92aafcfab3d41580d54aca35a8057341f1cfc7c9af9e8bdfc652f83a20ced31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win32.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cd316dbcc74c76266ba94eb021b0cc090b97cca122f50bd7a845f587ff4bf03f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win_amd64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0853da3d5e9bc6a07b2486054a410b7b03f34046c123c6561b535bb48cc509e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cb41ad20064e18a900dd427d7cf41cfaec83bcd1184001f3d91a1f76b3fcea4e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b710bf7e7ae61957d5c4026b486be593ed3ec3dca3e5be15e0f6d8cf5d0a4990"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a952ae3eb460c6712388ac2ec706d24b0e651b9396d90c9a9e0a69eb27737fdc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0bedd91ae1dd142a4dc15970ed2c729ff6c73f33a40fa84ed0cdbf55de87c777"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "761531076df51309075133a6bc1db02d98ec7f66e22b064b1d513bc909f29743"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a2baa6be130e8a00b6cbb9f18a33611ec150b4537f8563bddadb54c1b74b8193"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f05450fa1cd7c525c0b9d1a7916e595d3041ac0afbed2ff6926e5afb6a781b7f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "81c4d1a3a564775c44732b94135d06e33417e829ff25226c164664f4a1046213"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e888be685fa42d8b8a3d3911d5604d14db87538aa7d0b29b1a7ea80d354c732d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6f8d7fe73d1816eeb5378409adc658f9525ecbfaf9e1ede1e2d67a338b0c7348"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0831d3ecdea22e4559cc1793f22e77067c9d8c451d55ae6a75bf1d116a8e7f42"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "513ccbf7420c30e283c25c82d5a8f439d625a838d3ba69e79a110c260c46813f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "301bd744a1adaa2f6a5e06c98f1ac2b6f8dc31a5c23b838f862d65e32fca0d4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f8832a4f83d4782a8f5a7b831c47e8ffe164e43c2c148c8160ed9a6d630bc02a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b2416ed743ec5debcf61e1242e012652a4348de14ecc7df3512da072b074440"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "35585a8cb5917161f42c2104567bb83a1d96194095fc54a543113ed5df9fa436"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d389ff1e95b6e46ebedccf7fd1fadd10559add595ac6a7c2ea730268325f832c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9b007c2444705a2dc4a525964fd4dd28c3320b19b3410da6517cab28716f27d3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "188912b22b6c8225f4c4ffa020a2baa6ad8fabb3c141a12dbe6edbb34e7f1425"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b4cf9ab9a0ae0cb122685209806d3f1dcb63b9fccdf1424fb42a129dc8c2faa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2d34a5450a402b00d20aeb7632489ffa2556ca7b26f4a63c35f6fccae1977427"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "466030a42724780794dea71eb32db83cc51214d66ab3fb3156edd88b9c8f0d78"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "68172622a5a57deb079a2c78511c40f91193548e8ab342c31e8cb0764d362459"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54cdfcda59251b9c2f87a05d038c2ae02121219a04d4a1e6fc345794295bdc07"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6b75b912a0baa033350367a8a07a8b2d44fd5b90c890bfbd063a8a5f945f644b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "47aeceb4363851d17f63069318ba5721ae695d9da55d599b4d6fb31508595278"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0525847f83f506aa1e28eb2057b696fe38217e12931c8b1b02198cfe6975e142"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "efbe0b5e0fd078ed7b005faa0170da4f72666360f66f0bb2d7f73526ecfd99f9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0fadfdda275c838cba5102c7f90a20f2abd7727bf8f4a2b654a5b617529c5c18"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "56dd500411d03c5e9927a1eb55621e906837a83b02350a9dc401247d0353717c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6915fc9fa6b3ec3569566832e1bb03bd801c12cea030200e68663b9a87974e76"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5f1519b080d8ce0a814f17ad9fb49fb3a1d4d7ce5891f5c85fc38631ca3a8dc4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7036316cc26b93e401cedd781a579be606dad174829e6ad9e9c5a0da6e036f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/rpds-py/#rpds_py-0.12.0.tar.gz"
+        }
+      ],
+      "name": "rpds-py",
+      "purl": "pkg:pypi/rpds-py@0.12.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "0.12.0"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "sortedcontainers@2.4.0",
+      "description": "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/sortedcontainers/#sortedcontainers-2.4.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/sortedcontainers/#sortedcontainers-2.4.0.tar.gz"
+        }
+      ],
+      "name": "sortedcontainers",
+      "purl": "pkg:pypi/sortedcontainers@2.4.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.4.0"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "scope": "optional",
+      "type": "library",
+      "version": "2.8.19.14"
+    },
+    {
+      "bom-ref": "uri-template@1.3.0",
+      "description": "RFC 6570 URI Template Processor",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uri-template/#uri-template-1.3.0.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/uri-template/#uri_template-1.3.0-py3-none-any.whl"
+        }
+      ],
+      "name": "uri-template",
+      "purl": "pkg:pypi/uri-template@1.3.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "webcolors@1.13",
+      "description": "A library for working with the color formats defined by HTML and CSS.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/webcolors/#webcolors-1.13-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/webcolors/#webcolors-1.13.tar.gz"
+        }
+      ],
+      "name": "webcolors",
+      "purl": "pkg:pypi/webcolors@1.13",
+      "scope": "optional",
+      "type": "library",
+      "version": "1.13"
+    },
+    {
+      "bom-ref": "zipp@3.17.0",
+      "description": "Backport of pathlib-compatible object wrapper for zip files",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/zipp/#zipp-3.17.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/zipp/#zipp-3.17.0.tar.gz"
+        }
+      ],
+      "name": "zipp",
+      "purl": "pkg:pypi/zipp@3.17.0",
+      "scope": "optional",
+      "type": "library",
+      "version": "3.17.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "attrs@23.1.0"
+    },
+    {
+      "ref": "boolean-py@4.0"
+    },
+    {
+      "dependsOn": [
+        "jsonschema@4.19.2",
+        "license-expression@30.1.1",
+        "lxml@4.9.3",
+        "packageurl-python@0.11.2",
+        "py-serializable@0.15.0",
+        "sortedcontainers@2.4.0"
+      ],
+      "ref": "cyclonedx-python-lib@5.1.1"
+    },
+    {
+      "ref": "defusedxml@0.7.1"
+    },
+    {
+      "ref": "fqdn@1.5.1"
+    },
+    {
+      "ref": "idna@3.4"
+    },
+    {
+      "dependsOn": [
+        "zipp@3.17.0"
+      ],
+      "ref": "importlib-resources@6.1.1"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "ref": "jsonpointer@2.4"
+    },
+    {
+      "dependsOn": [
+        "importlib-resources@6.1.1",
+        "referencing@0.30.2"
+      ],
+      "ref": "jsonschema-specifications@2023.7.1"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.1.0",
+        "fqdn@1.5.1",
+        "idna@3.4",
+        "importlib-resources@6.1.1",
+        "isoduration@20.11.0",
+        "jsonpointer@2.4",
+        "jsonschema-specifications@2023.7.1",
+        "pkgutil-resolve-name@1.3.10",
+        "referencing@0.30.2",
+        "rfc3339-validator@0.1.4",
+        "rfc3987@1.3.8",
+        "rpds-py@0.12.0",
+        "uri-template@1.3.0",
+        "webcolors@1.13"
+      ],
+      "ref": "jsonschema@4.19.2"
+    },
+    {
+      "dependsOn": [
+        "boolean-py@4.0"
+      ],
+      "ref": "license-expression@30.1.1"
+    },
+    {
+      "ref": "lxml@4.9.3"
+    },
+    {
+      "ref": "packageurl-python@0.11.2"
+    },
+    {
+      "ref": "pkgutil-resolve-name@1.3.10"
+    },
+    {
+      "dependsOn": [
+        "defusedxml@0.7.1"
+      ],
+      "ref": "py-serializable@0.15.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "dependsOn": [
+        "attrs@23.1.0",
+        "rpds-py@0.12.0"
+      ],
+      "ref": "referencing@0.30.2"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "rfc3339-validator@0.1.4"
+    },
+    {
+      "ref": "rfc3987@1.3.8"
+    },
+    {
+      "ref": "rpds-py@0.12.0"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "sortedcontainers@2.4.0"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    },
+    {
+      "ref": "uri-template@1.3.0"
+    },
+    {
+      "ref": "webcolors@1.13"
+    },
+    {
+      "dependsOn": [
+        "cyclonedx-python-lib@5.1.1"
+      ],
+      "ref": "with-extras"
+    },
+    {
+      "ref": "zipp@3.17.0"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "with-extras",
+      "description": "depenndencies with extras",
+      "name": "with-extras",
+      "properties": [
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "my-extra"
+        }
+      ],
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/some-extras_with-extras_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/some-extras_with-extras_lock20_1.6.xml.bin
@@ -1,0 +1,2094 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="with-extras">
+      <name>with-extras</name>
+      <version>0.1.0</version>
+      <description>depenndencies with extras</description>
+      <properties>
+        <property name="cdx:python:package:required-extra">my-extra</property>
+      </properties>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="attrs@23.1.0">
+      <name>attrs</name>
+      <version>23.1.0</version>
+      <description>Classes Without Boilerplate</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/attrs@23.1.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/#attrs-23.1.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/attrs/#attrs-23.1.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="boolean-py@4.0">
+      <name>boolean-py</name>
+      <version>4.0</version>
+      <description>Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/boolean-py@4.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/boolean-py/#boolean.py-4.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2876f2051d7d6394a531d82dc6eb407faa0b01a0a0b3083817ccd7323b8d96bd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/boolean-py/#boolean.py-4.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">17b9a181630e43dde1851d42bef546d616d5d9b4480357514597e78b203d06e4</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="cyclonedx-python-lib@5.1.1">
+      <name>cyclonedx-python-lib</name>
+      <version>5.1.1</version>
+      <description>Python library for CycloneDX</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/cyclonedx-python-lib@5.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/cyclonedx-python-lib/#cyclonedx_python_lib-5.1.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2989db0cd8bb4c0c442423d71ed7a84ae059e16a2d0f932cc4bf92da7385cdb3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/cyclonedx-python-lib/#cyclonedx_python_lib-5.1.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">215a636a4e77385d2cf4c6c9801c9bad4791849634f2c6daa45ab2c6cb0a85f6</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:required-extra">json-validation</property>
+        <property name="cdx:python:package:required-extra">xml-validation</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="defusedxml@0.7.1">
+      <name>defusedxml</name>
+      <version>0.7.1</version>
+      <description>XML bomb protection for Python stdlib modules</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/defusedxml@0.7.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/defusedxml/#defusedxml-0.7.1-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/defusedxml/#defusedxml-0.7.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="fqdn@1.5.1">
+      <name>fqdn</name>
+      <version>1.5.1</version>
+      <description>Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/fqdn@1.5.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fqdn/#fqdn-1.5.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/fqdn/#fqdn-1.5.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="idna@3.4">
+      <name>idna</name>
+      <version>3.4</version>
+      <description>Internationalized Domain Names in Applications (IDNA)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/idna@3.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/#idna-3.4-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/#idna-3.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="importlib-resources@6.1.1">
+      <name>importlib-resources</name>
+      <version>6.1.1</version>
+      <description>Read resources from Python packages</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/importlib-resources@6.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e8bf90d8213b486f428c9c39714b920041cb02c184686a3dee24905aaa8105d6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/importlib-resources/#importlib_resources-6.1.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="jsonpointer@2.4">
+      <name>jsonpointer</name>
+      <version>2.4</version>
+      <description>Identify specific nodes in a JSON document (RFC 6901)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonpointer@2.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonpointer/#jsonpointer-2.4-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonpointer/#jsonpointer-2.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="jsonschema@4.19.2">
+      <name>jsonschema</name>
+      <version>4.19.2</version>
+      <description>An implementation of JSON Schema validation for Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonschema@4.19.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema/#jsonschema-4.19.2-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eee9e502c788e89cb166d4d37f43084e3b64ab405c795c03d343a4dbc2c810fc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema/#jsonschema-4.19.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c9ff4d7447eed9592c23a12ccee508baf0dd0d59650615e847feb6cdca74f392</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:python:package:required-extra">format</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="jsonschema-specifications@2023.7.1">
+      <name>jsonschema-specifications</name>
+      <version>2023.7.1</version>
+      <description>The JSON Schema meta-schemas and vocabularies, exposed as a Registry</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/jsonschema-specifications@2023.7.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">05adf340b659828a004220a9613be00fa3f223f2b82002e273dee62fd50524b1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/jsonschema-specifications/#jsonschema_specifications-2023.7.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c91a50404e88a1f6ba40636778e2ee08f6e24c5613fe4c53ac24578a5a7f72bb</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="license-expression@30.1.1">
+      <name>license-expression</name>
+      <version>30.1.1</version>
+      <description>license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/license-expression@30.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/license-expression/#license-expression-30.1.1.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">42375df653ad85e6f5b4b0385138b2dbea1f5d66360783d8625c3e4f97f11f0c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/license-expression/#license_expression-30.1.1-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8d7e5e2de0d04fc104a4f952c440e8f08a5ba63480a0dad015b294770b7e58ec</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="lxml@4.9.3">
+      <name>lxml</name>
+      <version>4.9.3</version>
+      <description>Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/lxml@4.9.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b0a545b46b526d418eb91754565ba5b63b1c0b12f9bd2f808c852d9b4b2f9b5c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">075b731ddd9e7f68ad24c635374211376aa05a281673ede86cbe1d1b3455279d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e224d5755dba2f4a9498e150c43792392ac9b5380aa1b845f98a1618c94eeef</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2c74524e179f2ad6d2a4f7caf70e2d96639c0954c943ad601a9e146c76408ed7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1026bc732b6a7f96369f7bfe1a4f2290fb34dce00d8644bc3036fb351a4ca1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c0781a98ff5e6586926293e59480b64ddd46282953203c76ae15dbbbf302e8bb</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cef2502e7e8a96fe5ad686d60b49e1ab03e438bd9123987994528febd569868e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b86164d2cff4d3aaa1f04a14685cbc072efd0b4f99ca5708b2ad1b9b5988a991</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">42871176e7896d5d45138f6d28751053c711ed4d48d8e30b498da155af39aebd</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ae8b9c6deb1e634ba4f1930eb67ef6e6bf6a44b6eb5ad605642b2d6d5ed9ce3c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_28_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">411007c0d88188d9f621b11d252cce90c4a2d1a49db6c068e3c16422f306eab8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd47b4a0d41d2afa3e58e5bf1f62069255aa2fd6ff5ee41604418ca925911d76</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e2cb47860da1f7e9a5256254b74ae331687b9672dfa780eed355c4c9c3dbd23</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1247694b26342a7bf47c02e513d32225ededd18045264d40758abeb3c838a51f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cdb650fc86227eba20de1a29d4b2c1bfe139dc75a0669270033cb2ea3d391b85</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp310-cp310-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">97047f0d25cd4bcae81f9ec9dc290ca3e15927c192df17331b53bebe0e3ff96d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-macosx_11_0_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f447ea5429b54f9582d4b955f5f1985f278ce5cf169f72eea8afd9502973dd5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">57d6ba0ca2b0c462f339640d22882acc711de224d769edf29962b09f77129cbf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9767e79108424fb6c3edf8f81e6730666a50feb01a328f4a016464a5893f835a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_28_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">71c52db65e4b56b8ddc5bb89fb2e66c558ed9d1a74a45ceb7dcb20c191c3df2f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d73d8ecf8ecf10a3bd007f2192725a34bd62898e8da27eb9d32a58084f93962b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0a3d3487f07c1d7f150894c238299934a2a074ef590b583103a45002035be120</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9e28c51fa0ce5674be9f560c6761c1b441631901993f76700b1b30ca6c8378d6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0bfd0767c5c1de2551a120673b72e5d4b628737cb05414f03c3277bf9bed3305</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp311-cp311-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">25f32acefac14ef7bd53e4218fe93b804ef6f6b92ffdb4322bb6d49d94cad2bc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-macosx_11_0_universal2.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d3ff32724f98fbbbfa9f49d82852b159e9784d6094983d9a8b7f2ddaebb063d4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-manylinux_2_28_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48d6ed886b343d11493129e019da91d4039826794a3e3027321c56d9e71505be</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9a92d3faef50658dd2c5470af249985782bf754c4e18e15afb67d3ab06233f13</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b4e4bc18382088514ebde9328da057775055940a1f2e18f6ad2d78aa0f3ec5b9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fc9b106a1bf918db68619fdcd6d5ad4f972fdd19c01d19bdb6bf63f3589a9ec5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp312-cp312-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d37017287a7adb6ab77e1c5bee9bcf9660f90ff445042b790402a654d2ad81d8</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">56dc1f1ebccc656d1b3ed288f11e27172a01503fc016bcabdcbc0978b19352b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">578695735c5a3f51569810dfebd05dd6f888147a34f0f98d4bb27e92b76e05c2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">704f61ba8c1283c71b16135caf697557f5ecf3e74d9e453233e4771d68a1f42d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp35-cp35m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c41bfca0bd3532d53d16fd34d20806d5c2b1ace22a2f2e4c0008570bf2c58833</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">64f479d719dc9f4c813ad9bb6b28f8390360660b73b2e4beb4cb0ae7104f1c12</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dd708cf4ee4408cf46a48b108fb9427bfa00b9b85812a9262b5c668af2533ea5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5c31c7462abdf8f2ac0577d9f05279727e698f97ecbb02f17939ea99ae8daa98</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e3cd95e10c2610c360154afdc2f1480aea394f4a4f1ea0a5eacce49640c9b190</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4930be26af26ac545c3dffb662521d4e6268352866956672231887d18f0eaab2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4aec80cde9197340bc353d2768e2a75f5f60bacda2bab72ab1dc499589b3878c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">14e019fd83b831b2e61baed40cab76222139926b1fb5ed0e79225bc0cae14584</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0c0850c8b02c298d3c7006b23e98249515ac57430e16a166873fc47a5d549287</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aca086dc5f9ef98c512bac8efea4483eb84abbf926eaeedf7b91479feb092458</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">50baa9c1c47efcaef189f31e3d00d697c6d4afda5c3cde0302d063492ff9b477</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp36-cp36m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bef4e656f7d98aaa3486d2627e7d2df1157d7e88e7efd43a65aa5dd4714916cf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">46f409a2d60f634fe550f7133ed30ad5321ae2e6630f13657fb9479506b00601</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4c28a9144688aef80d6ea666c809b4b0e50010a2aca784c97f5e6bf143d9f129</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">141f1d1a9b663c679dc524af3ea1773e618907e96075262726c7612c02b149a4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">53ace1c1fd5a74ef662f844a0413446c0629d151055340e9893da958a374f70d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">17a753023436a18e27dd7769e798ce302963c236bc4114ceee5b25c18c52c693</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7d298a1bd60c067ea75d9f684f5f3992c9d6766fadbc0bcedd39750bf344c2f4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">081d32421db5df44c41b7f08a334a090a545c54ba977e47fd7cc2deece78809a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">23eed6d7b1a3336ad92d8e39d4bfe09073c31bfe502f20ca5116b2a334f8ec02</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1509dd12b773c02acd154582088820893109f6ca27ef7291b003d0e81666109f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp37-cp37m-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">120fa9349a24c7043854c53cae8cec227e1f79195a7493e09e0c12e29f918e52</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d2d1edbca80b510443f51afd8496be95529db04a509bc8faee49c7b0fb6d2cc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8d7e43bd40f65f7d97ad8ef5c9b1778943d02f04febef12def25f7583d19baac</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">71d66ee82e7417828af6ecd7db817913cb0cf9d4e61aa0ac1fde0583d84358db</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6fc3c450eaa0b56f815c7b62f2b7fba7266c4779adcf1cece9e6deb1de7305ce</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">65299ea57d82fb91c7f019300d24050c4ddeb7c5a190e076b5f48a2b43d19c42</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eadfbbbfb41b44034a4c757fd5d70baccd43296fb894dba0295606a7cf3124aa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3e9bdd30efde2b9ccfa9cb5768ba04fe71b018a25ea093379c857c9dad262c40</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fcdd00edfd0a3001e0181eab3e63bd5c74ad3e67152c84f93f13769a40e073a7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">57aba1bbdf450b726d58b2aea5fe47c7875f5afb2c4a23784ed78f19a0462574</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp38-cp38-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">92af161ecbdb2883c4593d5ed4815ea71b31fafd7fd05789b23100d081ecac96</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9bb6ad405121241e99a86efff22d3ef469024ce22875a7ae045896ad23ba2340</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8ed74706b26ad100433da4b9d807eae371efaa266ffc3e9191ea436087a9d6a7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fbf521479bcac1e25a663df882c46a641a9bff6b56dc8b0fafaebd2f66fb231b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_28_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">303bf1edce6ced16bf67a18a1cf8339d0db79577eec5d9a6d4a80f0fb10aa2da</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5515edd2a6d1a5a70bfcdee23b42ec33425e405c5b351478ab7dc9347228f96e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">690dafd0b187ed38583a648076865d8c229661ed20e48f2335d68e2cf7dc829d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b6420a005548ad52154c8ceab4a1290ff78d757f9e5cbc68f8c77089acd3c432</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-musllinux_1_1_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bb3bb49c7a6ad9d981d734ef7c7193bc349ac338776a0360cc671eaee89bcf69</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-musllinux_1_1_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d27be7405547d1f958b60837dc4c1007da90b8b23f54ba1f8b728c78fdb19d50</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8df133a2ea5e74eef5e8fc6f19b9e085f758768a16e9877a60aec455ed2609b2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-cp39-cp39-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4dd9a263e845a72eacb60d12401e37c616438ea2e5442885f65082c276dfb2b2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6689a3d7fd13dc687e9102a27e98ef33730ac4fe37795d5036d18b4d527abd35</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f6bdac493b949141b733c5345b6ba8f87a226029cbabc7e9e121a413e49441e0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">05186a0f1346ae12553d66df1cfce6f251589fea3ad3da4f3ef4e34b2d58c6a3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c2006f5c8d28dee289f7020f721354362fa304acbaaf9745751ac4006650254b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5c245b783db29c4e4fbbbfc9c5a78be496c9fea25517f90606aa1f6b2b3d5f7b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4fb960a632a49f2f089d522f70496640fdf1218f1243889da3822e0a9f5f3ba7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">50670615eaf97227d5dc60de2dc99fb134a7130d310d783314e7724bf163f75d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9719fe17307a9e814580af1f5c6e05ca593b12fb7e44fe62450a5384dbf61b4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp38-pypy38_pp73-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3331bece23c9ee066e0fb3f96c61322b9e0f54d775fccefff4c38ca488de283a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-macosx_11_0_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ed667f49b11360951e201453fc3967344d0d0263aa415e1619e85ae7fd17b4e0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8b77946fd508cbf0fccd8e400a7f71d4ac0e1595812e66025bac475a8e811694</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e4da8ca0c0c0aea88fd46be8e44bd49716772358d648cce45fe387f7b92374a7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fe4bda6bd4340caa6e5cf95e73f8fea5c4bfc55763dd42f1b50a94c1b4a2fbd4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3-pp39-pypy39_pp73-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f3df3db1d336b9356dd3112eae5f5c2b8b377f3bc826848567f10bfddfee77e9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/lxml/#lxml-4.9.3.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48628bd53a426c9eb9bc066a923acaa0878d1e86129fd5359aee99285f4eed9c</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="packageurl-python@0.11.2">
+      <name>packageurl-python</name>
+      <version>0.11.2</version>
+      <description>A purl aka. Package URL parser and builder</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/packageurl-python@0.11.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/packageurl-python/#packageurl-python-0.11.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">01fbf74a41ef85cf413f1ede529a1411f658bda66ed22d45d27280ad9ceba471</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/packageurl-python/#packageurl_python-0.11.2-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">799acfe8d9e6e3534bbc19660be97d5b66754bc033e62c39f1e2f16323fcfa84</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkgutil-resolve-name@1.3.10">
+      <name>pkgutil-resolve-name</name>
+      <version>1.3.10</version>
+      <description>Resolve a name to an object.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/pkgutil-resolve-name@1.3.10</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/pkgutil-resolve-name/#pkgutil_resolve_name-1.3.10.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="py-serializable@0.15.0">
+      <name>py-serializable</name>
+      <version>0.15.0</version>
+      <description>Library for serializing and deserializing Python Objects to and from JSON and XML.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/py-serializable@0.15.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-serializable/#py-serializable-0.15.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8fc41457d8ee5f5c5a12f41fd87bf1a4f2ecf9da39fee92059b728e78f320771</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/py-serializable/#py_serializable-0.15.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d3f1201b33420c481aa83f7860c7bf2c2f036ba3ea82b6e15a96696457c36cd2</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="referencing@0.30.2">
+      <name>referencing</name>
+      <version>0.30.2</version>
+      <description>JSON Referencing + Python</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/referencing@0.30.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/#referencing-0.30.2-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">449b6669b6121a9e96a7f9e410b245d471e8d48964c67113ce9afe50c8dd7bdf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/referencing/#referencing-0.30.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">794ad8003c65938edcdbc027f1933215e0d0ccc0291e3ce20a4d87432b59efc0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="rfc3339-validator@0.1.4">
+      <name>rfc3339-validator</name>
+      <version>0.1.4</version>
+      <description>A pure python RFC3339 validator</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rfc3339-validator@0.1.4</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3339-validator/#rfc3339_validator-0.1.4.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="rfc3987@1.3.8">
+      <name>rfc3987</name>
+      <version>1.3.8</version>
+      <description>Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rfc3987@1.3.8</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3987/#rfc3987-1.3.8-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rfc3987/#rfc3987-1.3.8.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="rpds-py@0.12.0">
+      <name>rpds-py</name>
+      <version>0.12.0</version>
+      <description>Python bindings to Rust's persistent data structures (rpds)</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/rpds-py@0.12.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c694bee70ece3b232df4678448fdda245fd3b1bb4ba481fb6cd20e13bb784c46</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">30e5ce9f501fb1f970e4a59098028cf20676dee64fc496d55c33e04bbbee097d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d72a4315514e5a0b9837a086cb433b004eea630afb0cc129de76d77654a9606f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">eebaf8c76c39604d52852366249ab807fe6f7a3ffb0dd5484b9944917244cdbe</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a239303acb0315091d54c7ff36712dba24554993b9a93941cf301391d8a997ee</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ced40cdbb6dd47a032725a038896cceae9ce267d340f59508b23537f05455431</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3c8c0226c71bd0ce9892eaf6afa77ae8f43a3d9313124a03df0b389c01f832de</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b8e11715178f3608874508f08e990d3771e0b8c66c73eb4e183038d600a9b274</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5210a0018c7e09c75fa788648617ebba861ae242944111d3079034e14498223f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">171d9a159f1b2f42a42a64a985e4ba46fc7268c78299272ceba970743a67ee50</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">57ec6baec231bb19bb5fd5fc7bae21231860a1605174b11585660236627e390e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7188ddc1a8887194f984fa4110d5a3d5b9b5cd35f6bafdff1b649049cbc0ce29</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp310-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e04581c6117ad9479b6cfae313e212fe0dfa226ac727755f0d539cd54792963</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0a38612d07a36138507d69646c470aedbfe2b75b43a4643f7bd8e51e52779624</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f12d69d568f5647ec503b64932874dade5a20255736c89936bf690951a5e79f5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f8a1d990dc198a6c68ec3d9a637ba1ce489b38cbfb65440a27901afbc5df575</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8c567c664fc2f44130a20edac73e0a867f8e012bf7370276f15c6adc3586c37c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e9e976e0dbed4f51c56db10831c9623d0fd67aac02853fe5476262e5a22acb7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efddca2d02254a52078c35cadad34762adbae3ff01c6b0c7787b59d038b63e0d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d9e7f29c00577aff6b318681e730a519b235af292732a149337f6aaa4d1c5e31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">389c0e38358fdc4e38e9995e7291269a3aead7acfcf8942010ee7bc5baee091c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">33ab498f9ac30598b6406e2be1b45fd231195b83d948ebd4bd77f337cb6a2bff</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d56b1cd606ba4cedd64bb43479d56580e147c6ef3f5d1c5e64203a1adab784a2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1fa73ed22c40a1bec98d7c93b5659cd35abcfa5a0a95ce876b91adbda170537c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">dbc25baa6abb205766fb8606f8263b02c3503a55957fcb4576a6bb0a59d37d10</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp311-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c6b52b7028b547866c2413f614ee306c2d4eafdd444b1ff656bf3295bf1484aa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9620650c364c01ed5b497dcae7c3d4b948daeae6e1883ae185fef1c927b6b534</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2124f9e645a94ab7c853bc0a3644e0ca8ffbe5bb2d72db49aef8f9ec1c285733</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">281c8b219d4f4b3581b918b816764098d04964915b2f272d1476654143801aa2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">27ccc93c7457ef890b0dd31564d2a05e1aca330623c942b7e818e9e7c2669ee4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d1c562a9bb72244fa767d1c1ab55ca1d92dd5f7c4d77878fee5483a22ffac808</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e57919c32ee295a2fca458bb73e4b20b05c115627f96f95a10f9f5acbd61172d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">fa35ad36440aaf1ac8332b4a4a433d4acd28f1613f0d480995f5cfd3580e90b7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e6aea5c0eb5b0faf52c7b5c4a47c8bb64437173be97227c819ffa31801fa4e34</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">81cf9d306c04df1b45971c13167dc3bad625808aa01281d55f3cf852dde0e206</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08e6e7ff286254016b945e1ab632ee843e43d45e40683b66dd12b73791366dd1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4d0a675a7acbbc16179188d8c6d0afb8628604fc1241faf41007255957335a0b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2287c09482949e0ca0c0eb68b2aca6cf57f8af8c6dfd29dcd3bc45f17b57978</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp312-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8015835494b21aa7abd3b43fdea0614ee35ef6b03db7ecba9beb58eadf01c24f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6174d6ad6b58a6bcf67afbbf1723420a53d06c4b89f4c50763d6fa0a6ac9afd2</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a689e1ded7137552bea36305a7a16ad2b40be511740b80748d3140614993db98</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f45321224144c25a62052035ce96cbcf264667bcb0d81823b1bbc22c4addd194</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">aa32205358a76bf578854bf31698a86dc8b2cb591fd1d79a833283f4a403f04b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">91bd2b7cf0f4d252eec8b7046fa6a43cee17e8acdfc00eaa8b3dbf2f9a59d061</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3acadbab8b59f63b87b518e09c4c64b142e7286b9ca7a208107d6f9f4c393c5c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">429349a510da82c85431f0f3e66212d83efe9fd2850f50f339341b6532c62fe4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">05942656cb2cb4989cd50ced52df16be94d344eae5097e8583966a1d27da73a5</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0c5441b7626c29dbd54a3f6f3713ec8e956b009f419ffdaaa3c80eaf98ddb523</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b6b0e17d39d21698185097652c611f9cf30f7c56ccec189789920e3e7f1cee56</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-cp38-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">3b7a64d43e2a1fa2dd46b678e00cabd9a49ebb123b339ce799204c44a593ae1c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e5bbe011a2cea9060fef1bb3d668a2fd8432b8888e6d92e74c9c794d3c101595</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp38-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">bec29b801b4adbf388314c0d050e851d53762ab424af22657021ce4b6eb41543</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1096ca0bf2d3426cbe79d4ccc91dc5aaa73629b08ea2d8467375fad8447ce11a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">48aa98987d54a46e13e6954880056c204700c65616af4395d1f0639eba11764b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7979d90ee2190d000129598c2b0c82f13053dba432b94e45e68253b09bb1f0f6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">88857060b690a57d2ea8569bca58758143c8faa4639fb17d745ce60ff84c867e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4eb74d44776b0fb0782560ea84d986dffec8ddd94947f383eba2284b0f32e35e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f62581d7e884dd01ee1707b7c21148f61f2febb7de092ae2f108743fcbef5985</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6f5dcb658d597410bb7c967c1d24eaf9377b0d621358cbe9d2ff804e5dd12e81</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9bf9acce44e967a5103fcd820fc7580c7b0ab8583eec4e2051aec560f7b31a63</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">240687b5be0f91fbde4936a329c9b7589d9259742766f74de575e1b2046575e4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">25740fb56e8bd37692ed380e15ec734be44d7c71974d8993f452b4527814601e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-cp39-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a54917b7e9cd3a67e429a630e237a90b096e0ba18897bfb99ee8bd1068a5fea0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win32.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b92aafcfab3d41580d54aca35a8057341f1cfc7c9af9e8bdfc652f83a20ced31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-cp39-none-win_amd64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cd316dbcc74c76266ba94eb021b0cc090b97cca122f50bd7a845f587ff4bf03f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0853da3d5e9bc6a07b2486054a410b7b03f34046c123c6561b535bb48cc509e1</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">cb41ad20064e18a900dd427d7cf41cfaec83bcd1184001f3d91a1f76b3fcea4e</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b710bf7e7ae61957d5c4026b486be593ed3ec3dca3e5be15e0f6d8cf5d0a4990</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a952ae3eb460c6712388ac2ec706d24b0e651b9396d90c9a9e0a69eb27737fdc</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0bedd91ae1dd142a4dc15970ed2c729ff6c73f33a40fa84ed0cdbf55de87c777</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">761531076df51309075133a6bc1db02d98ec7f66e22b064b1d513bc909f29743</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a2baa6be130e8a00b6cbb9f18a33611ec150b4537f8563bddadb54c1b74b8193</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f05450fa1cd7c525c0b9d1a7916e595d3041ac0afbed2ff6926e5afb6a781b7f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">81c4d1a3a564775c44732b94135d06e33417e829ff25226c164664f4a1046213</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">e888be685fa42d8b8a3d3911d5604d14db87538aa7d0b29b1a7ea80d354c732d</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6f8d7fe73d1816eeb5378409adc658f9525ecbfaf9e1ede1e2d67a338b0c7348</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0831d3ecdea22e4559cc1793f22e77067c9d8c451d55ae6a75bf1d116a8e7f42</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">513ccbf7420c30e283c25c82d5a8f439d625a838d3ba69e79a110c260c46813f</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">301bd744a1adaa2f6a5e06c98f1ac2b6f8dc31a5c23b838f862d65e32fca0d4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f8832a4f83d4782a8f5a7b831c47e8ffe164e43c2c148c8160ed9a6d630bc02a</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4b2416ed743ec5debcf61e1242e012652a4348de14ecc7df3512da072b074440</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">35585a8cb5917161f42c2104567bb83a1d96194095fc54a543113ed5df9fa436</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d389ff1e95b6e46ebedccf7fd1fadd10559add595ac6a7c2ea730268325f832c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">9b007c2444705a2dc4a525964fd4dd28c3320b19b3410da6517cab28716f27d3</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">188912b22b6c8225f4c4ffa020a2baa6ad8fabb3c141a12dbe6edbb34e7f1425</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1b4cf9ab9a0ae0cb122685209806d3f1dcb63b9fccdf1424fb42a129dc8c2faa</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">2d34a5450a402b00d20aeb7632489ffa2556ca7b26f4a63c35f6fccae1977427</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">466030a42724780794dea71eb32db83cc51214d66ab3fb3156edd88b9c8f0d78</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">68172622a5a57deb079a2c78511c40f91193548e8ab342c31e8cb0764d362459</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">54cdfcda59251b9c2f87a05d038c2ae02121219a04d4a1e6fc345794295bdc07</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6b75b912a0baa033350367a8a07a8b2d44fd5b90c890bfbd063a8a5f945f644b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">47aeceb4363851d17f63069318ba5721ae695d9da55d599b4d6fb31508595278</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0525847f83f506aa1e28eb2057b696fe38217e12931c8b1b02198cfe6975e142</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">efbe0b5e0fd078ed7b005faa0170da4f72666360f66f0bb2d7f73526ecfd99f9</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0fadfdda275c838cba5102c7f90a20f2abd7727bf8f4a2b654a5b617529c5c18</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">56dd500411d03c5e9927a1eb55621e906837a83b02350a9dc401247d0353717c</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">6915fc9fa6b3ec3569566832e1bb03bd801c12cea030200e68663b9a87974e76</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">5f1519b080d8ce0a814f17ad9fb49fb3a1d4d7ce5891f5c85fc38631ca3a8dc4</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/rpds-py/#rpds_py-0.12.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">7036316cc26b93e401cedd781a579be606dad174829e6ad9e9c5a0da6e036f80</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="sortedcontainers@2.4.0">
+      <name>sortedcontainers</name>
+      <version>2.4.0</version>
+      <description>Sorted Containers -- Sorted List, Sorted Dict, Sorted Set</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/sortedcontainers@2.4.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/sortedcontainers/#sortedcontainers-2.4.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/sortedcontainers/#sortedcontainers-2.4.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="uri-template@1.3.0">
+      <name>uri-template</name>
+      <version>1.3.0</version>
+      <description>RFC 6570 URI Template Processor</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/uri-template@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uri-template/#uri-template-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/uri-template/#uri_template-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="webcolors@1.13">
+      <name>webcolors</name>
+      <version>1.13</version>
+      <description>A library for working with the color formats defined by HTML and CSS.</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/webcolors@1.13</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/webcolors/#webcolors-1.13-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/webcolors/#webcolors-1.13.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="zipp@3.17.0">
+      <name>zipp</name>
+      <version>3.17.0</version>
+      <description>Backport of pathlib-compatible object wrapper for zip files</description>
+      <scope>optional</scope>
+      <purl>pkg:pypi/zipp@3.17.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/zipp/#zipp-3.17.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/zipp/#zipp-3.17.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="attrs@23.1.0"/>
+    <dependency ref="boolean-py@4.0"/>
+    <dependency ref="cyclonedx-python-lib@5.1.1">
+      <dependency ref="jsonschema@4.19.2"/>
+      <dependency ref="license-expression@30.1.1"/>
+      <dependency ref="lxml@4.9.3"/>
+      <dependency ref="packageurl-python@0.11.2"/>
+      <dependency ref="py-serializable@0.15.0"/>
+      <dependency ref="sortedcontainers@2.4.0"/>
+    </dependency>
+    <dependency ref="defusedxml@0.7.1"/>
+    <dependency ref="fqdn@1.5.1"/>
+    <dependency ref="idna@3.4"/>
+    <dependency ref="importlib-resources@6.1.1">
+      <dependency ref="zipp@3.17.0"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="jsonpointer@2.4"/>
+    <dependency ref="jsonschema-specifications@2023.7.1">
+      <dependency ref="importlib-resources@6.1.1"/>
+      <dependency ref="referencing@0.30.2"/>
+    </dependency>
+    <dependency ref="jsonschema@4.19.2">
+      <dependency ref="attrs@23.1.0"/>
+      <dependency ref="fqdn@1.5.1"/>
+      <dependency ref="idna@3.4"/>
+      <dependency ref="importlib-resources@6.1.1"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="jsonpointer@2.4"/>
+      <dependency ref="jsonschema-specifications@2023.7.1"/>
+      <dependency ref="pkgutil-resolve-name@1.3.10"/>
+      <dependency ref="referencing@0.30.2"/>
+      <dependency ref="rfc3339-validator@0.1.4"/>
+      <dependency ref="rfc3987@1.3.8"/>
+      <dependency ref="rpds-py@0.12.0"/>
+      <dependency ref="uri-template@1.3.0"/>
+      <dependency ref="webcolors@1.13"/>
+    </dependency>
+    <dependency ref="license-expression@30.1.1">
+      <dependency ref="boolean-py@4.0"/>
+    </dependency>
+    <dependency ref="lxml@4.9.3"/>
+    <dependency ref="packageurl-python@0.11.2"/>
+    <dependency ref="pkgutil-resolve-name@1.3.10"/>
+    <dependency ref="py-serializable@0.15.0">
+      <dependency ref="defusedxml@0.7.1"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="referencing@0.30.2">
+      <dependency ref="attrs@23.1.0"/>
+      <dependency ref="rpds-py@0.12.0"/>
+    </dependency>
+    <dependency ref="rfc3339-validator@0.1.4">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="rfc3987@1.3.8"/>
+    <dependency ref="rpds-py@0.12.0"/>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="sortedcontainers@2.4.0"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+    <dependency ref="uri-template@1.3.0"/>
+    <dependency ref="webcolors@1.13"/>
+    <dependency ref="with-extras">
+      <dependency ref="cyclonedx-python-lib@5.1.1"/>
+    </dependency>
+    <dependency ref="zipp@3.17.0"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/some-groups_group-deps_lock11_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/some-groups_group-deps_lock11_1.6.json.bin
@@ -1,0 +1,346 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        },
+        {
+          "name": "cdx:poetry:group",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        },
+        {
+          "name": "cdx:poetry:group",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "dev"
+        }
+      ],
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6",
+        "isoduration@20.11.0",
+        "toml@0.10.2"
+      ],
+      "ref": "group-deps"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "group-deps",
+      "description": "dependencies organized in groups",
+      "name": "group-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/some-groups_group-deps_lock11_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/some-groups_group-deps_lock11_1.6.xml.bin
@@ -1,0 +1,252 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="group-deps">
+      <name>group-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+        <property name="cdx:poetry:group">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+        <property name="cdx:poetry:group">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">dev</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="group-deps">
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/poetry/some-groups_group-deps_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/some-groups_group-deps_lock20_1.6.json.bin
@@ -1,0 +1,314 @@
+{
+  "components": [
+    {
+      "bom-ref": "arrow@1.3.0",
+      "description": "Better dates & times for Python",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz"
+        }
+      ],
+      "name": "arrow",
+      "purl": "pkg:pypi/arrow@1.3.0",
+      "type": "library",
+      "version": "1.3.0"
+    },
+    {
+      "bom-ref": "colorama@0.4.6",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "bom-ref": "isoduration@20.11.0",
+      "description": "Operations with ISO 8601 durations",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz"
+        }
+      ],
+      "name": "isoduration",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "groupA"
+        }
+      ],
+      "purl": "pkg:pypi/isoduration@20.11.0",
+      "type": "library",
+      "version": "20.11.0"
+    },
+    {
+      "bom-ref": "python-dateutil@2.8.2",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl"
+        }
+      ],
+      "name": "python-dateutil",
+      "purl": "pkg:pypi/python-dateutil@2.8.2",
+      "type": "library",
+      "version": "2.8.2"
+    },
+    {
+      "bom-ref": "six@1.16.0",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/six/#six-1.16.0.tar.gz"
+        }
+      ],
+      "name": "six",
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "bom-ref": "toml@0.10.2",
+      "description": "Python Library for Tom's Obvious, Minimal Language",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/toml/#toml-0.10.2.tar.gz"
+        }
+      ],
+      "name": "toml",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2",
+      "type": "library",
+      "version": "0.10.2"
+    },
+    {
+      "bom-ref": "types-python-dateutil@2.8.19.14",
+      "description": "Typing stubs for python-dateutil",
+      "externalReferences": [
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz"
+        },
+        {
+          "comment": "from legacy-api",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl"
+        }
+      ],
+      "name": "types-python-dateutil",
+      "purl": "pkg:pypi/types-python-dateutil@2.8.19.14",
+      "type": "library",
+      "version": "2.8.19.14"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependsOn": [
+        "python-dateutil@2.8.2",
+        "types-python-dateutil@2.8.19.14"
+      ],
+      "ref": "arrow@1.3.0"
+    },
+    {
+      "ref": "colorama@0.4.6"
+    },
+    {
+      "dependsOn": [
+        "colorama@0.4.6",
+        "isoduration@20.11.0",
+        "toml@0.10.2"
+      ],
+      "ref": "group-deps"
+    },
+    {
+      "dependsOn": [
+        "arrow@1.3.0"
+      ],
+      "ref": "isoduration@20.11.0"
+    },
+    {
+      "dependsOn": [
+        "six@1.16.0"
+      ],
+      "ref": "python-dateutil@2.8.2"
+    },
+    {
+      "ref": "six@1.16.0"
+    },
+    {
+      "ref": "toml@0.10.2"
+    },
+    {
+      "ref": "types-python-dateutil@2.8.19.14"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "group-deps",
+      "description": "dependencies organized in groups",
+      "name": "group-deps",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/poetry/some-groups_group-deps_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/some-groups_group-deps_lock20_1.6.xml.bin
@@ -1,0 +1,238 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="group-deps">
+      <name>group-deps</name>
+      <version>0.1.0</version>
+      <description>dependencies organized in groups</description>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="arrow@1.3.0">
+      <name>arrow</name>
+      <version>1.3.0</version>
+      <description>Better dates &amp; times for Python</description>
+      <purl>pkg:pypi/arrow@1.3.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/arrow/#arrow-1.3.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="colorama@0.4.6">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>Cross-platform colored terminal text.</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/#colorama-0.4.6.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="isoduration@20.11.0">
+      <name>isoduration</name>
+      <version>20.11.0</version>
+      <description>Operations with ISO 8601 durations</description>
+      <purl>pkg:pypi/isoduration@20.11.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/isoduration/#isoduration-20.11.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">groupA</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="python-dateutil@2.8.2">
+      <name>python-dateutil</name>
+      <version>2.8.2</version>
+      <description>Extensions to the standard Python datetime module</description>
+      <purl>pkg:pypi/python-dateutil@2.8.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python-dateutil-2.8.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/python-dateutil/#python_dateutil-2.8.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="six@1.16.0">
+      <name>six</name>
+      <version>1.16.0</version>
+      <description>Python 2 and 3 compatibility utilities</description>
+      <purl>pkg:pypi/six@1.16.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/six/#six-1.16.0.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="toml@0.10.2">
+      <name>toml</name>
+      <version>0.10.2</version>
+      <description>Python Library for Tom's Obvious, Minimal Language</description>
+      <purl>pkg:pypi/toml@0.10.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2-py2.py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/toml/#toml-0.10.2.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="types-python-dateutil@2.8.19.14">
+      <name>types-python-dateutil</name>
+      <version>2.8.19.14</version>
+      <description>Typing stubs for python-dateutil</description>
+      <purl>pkg:pypi/types-python-dateutil@2.8.19.14</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types-python-dateutil-2.8.19.14.tar.gz</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">1f4f10ac98bb8b16ade9dbee3518d9ace017821d94b057a425b069f834737f4b</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/types-python-dateutil/#types_python_dateutil-2.8.19.14-py3-none-any.whl</url>
+          <comment>from legacy-api</comment>
+          <hashes>
+            <hash alg="SHA-256">f977b8de27787639986b4e28963263fd0e5158942b3ecef91b9335c130cb1ce9</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="arrow@1.3.0">
+      <dependency ref="python-dateutil@2.8.2"/>
+      <dependency ref="types-python-dateutil@2.8.19.14"/>
+    </dependency>
+    <dependency ref="colorama@0.4.6"/>
+    <dependency ref="group-deps">
+      <dependency ref="colorama@0.4.6"/>
+      <dependency ref="isoduration@20.11.0"/>
+      <dependency ref="toml@0.10.2"/>
+    </dependency>
+    <dependency ref="isoduration@20.11.0">
+      <dependency ref="arrow@1.3.0"/>
+    </dependency>
+    <dependency ref="python-dateutil@2.8.2">
+      <dependency ref="six@1.16.0"/>
+    </dependency>
+    <dependency ref="six@1.16.0"/>
+    <dependency ref="toml@0.10.2"/>
+    <dependency ref="types-python-dateutil@2.8.19.14"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/file_frozen_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/file_frozen_1.6.json.bin
@@ -1,0 +1,119 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/FooProject/"
+        }
+      ],
+      "name": "FooProject",
+      "purl": "pkg:pypi/fooproject@1.2",
+      "type": "library",
+      "version": "1.2"
+    },
+    {
+      "bom-ref": "requirements-L4",
+      "description": "requirements line 4: colorama==0.4.6",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/"
+        }
+      ],
+      "name": "colorama",
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L4"
+    },
+    {
+      "ref": "requirements-L7"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "externalReferences": [
+        {
+          "comment": "from pyproject urls: documentation",
+          "type": "documentation",
+          "url": "https://oss.acme.org/my-project/docs/"
+        },
+        {
+          "comment": "from pyproject urls: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://oss.acme.org/my-project/bugs/"
+        },
+        {
+          "comment": "from pyproject urls: Funding",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/funding/"
+        },
+        {
+          "comment": "from pyproject urls: Change log",
+          "type": "release-notes",
+          "url": "https://oss.acme.org/my-project/changelog/"
+        },
+        {
+          "comment": "from pyproject urls: repository",
+          "type": "vcs",
+          "url": "https://oss.acme.org/my-project.git"
+        },
+        {
+          "comment": "from pyproject urls: homepage",
+          "type": "website",
+          "url": "https://oss.acme.org/my-project/"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/file_frozen_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/file_frozen_1.6.xml.bin
@@ -1,0 +1,116 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://oss.acme.org/my-project/docs/</url>
+          <comment>from pyproject urls: documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://oss.acme.org/my-project/bugs/</url>
+          <comment>from pyproject urls: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/funding/</url>
+          <comment>from pyproject urls: Funding</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://oss.acme.org/my-project/changelog/</url>
+          <comment>from pyproject urls: Change log</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://oss.acme.org/my-project.git</url>
+          <comment>from pyproject urls: repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://oss.acme.org/my-project/</url>
+          <comment>from pyproject urls: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L7">
+      <name>FooProject</name>
+      <version>1.2</version>
+      <description>requirements line 7: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</description>
+      <purl>pkg:pypi/fooproject@1.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/FooProject/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824</hash>
+            <hash alg="SHA-256">486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L4">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>requirements line 4: colorama==0.4.6</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L4"/>
+    <dependency ref="requirements-L7"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/file_local_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/file_local_1.6.json.bin
@@ -1,0 +1,176 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L11",
+      "description": "requirements line 11: foo @ file://../foo",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "file://../foo"
+        }
+      ],
+      "name": "foo",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L14",
+      "description": "requirements line 14: ./downloads/numpy-1.9.2-cp34-none-win32.whl",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "./downloads/numpy-1.9.2-cp34-none-win32.whl"
+        }
+      ],
+      "name": "numpy",
+      "type": "library",
+      "version": "1.9.2"
+    },
+    {
+      "bom-ref": "requirements-L2",
+      "description": "requirements line 2: ./myproject/chardet",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "./myproject/chardet"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L5",
+      "description": "requirements line 5: ./myproject/requests --hash=sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"
+            }
+          ],
+          "type": "other",
+          "url": "./myproject/requests"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L8",
+      "description": "requirements line 8: -e ./myproject/idna.whl",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "./myproject/idna.whl"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L17",
+      "description": "requirements line 17: ./downloads/numpy-1.26.1.tar.gz",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "./downloads/numpy-1.26.1.tar.gz"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L11"
+    },
+    {
+      "ref": "requirements-L14"
+    },
+    {
+      "ref": "requirements-L17"
+    },
+    {
+      "ref": "requirements-L2"
+    },
+    {
+      "ref": "requirements-L5"
+    },
+    {
+      "ref": "requirements-L8"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "externalReferences": [
+        {
+          "comment": "from pyproject urls: documentation",
+          "type": "documentation",
+          "url": "https://oss.acme.org/my-project/docs/"
+        },
+        {
+          "comment": "from pyproject urls: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://oss.acme.org/my-project/bugs/"
+        },
+        {
+          "comment": "from pyproject urls: Funding",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/funding/"
+        },
+        {
+          "comment": "from pyproject urls: Change log",
+          "type": "release-notes",
+          "url": "https://oss.acme.org/my-project/changelog/"
+        },
+        {
+          "comment": "from pyproject urls: repository",
+          "type": "vcs",
+          "url": "https://oss.acme.org/my-project.git"
+        },
+        {
+          "comment": "from pyproject urls: homepage",
+          "type": "website",
+          "url": "https://oss.acme.org/my-project/"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/file_local_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/file_local_1.6.xml.bin
@@ -1,0 +1,156 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://oss.acme.org/my-project/docs/</url>
+          <comment>from pyproject urls: documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://oss.acme.org/my-project/bugs/</url>
+          <comment>from pyproject urls: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/funding/</url>
+          <comment>from pyproject urls: Funding</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://oss.acme.org/my-project/changelog/</url>
+          <comment>from pyproject urls: Change log</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://oss.acme.org/my-project.git</url>
+          <comment>from pyproject urls: repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://oss.acme.org/my-project/</url>
+          <comment>from pyproject urls: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L11">
+      <name>foo</name>
+      <description>requirements line 11: foo @ file://../foo</description>
+      <externalReferences>
+        <reference type="other">
+          <url>file://../foo</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L14">
+      <name>numpy</name>
+      <version>1.9.2</version>
+      <description>requirements line 14: ./downloads/numpy-1.9.2-cp34-none-win32.whl</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./downloads/numpy-1.9.2-cp34-none-win32.whl</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L2">
+      <name>unknown</name>
+      <description>requirements line 2: ./myproject/chardet</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./myproject/chardet</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L5">
+      <name>unknown</name>
+      <description>requirements line 5: ./myproject/requests --hash=sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./myproject/requests</url>
+          <comment>explicit local path</comment>
+          <hashes>
+            <hash alg="SHA-256">27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L8">
+      <name>unknown</name>
+      <description>requirements line 8: -e ./myproject/idna.whl</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./myproject/idna.whl</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L17">
+      <name>unknown</name>
+      <description>requirements line 17: ./downloads/numpy-1.26.1.tar.gz</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./downloads/numpy-1.26.1.tar.gz</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L11"/>
+    <dependency ref="requirements-L14"/>
+    <dependency ref="requirements-L17"/>
+    <dependency ref="requirements-L2"/>
+    <dependency ref="requirements-L5"/>
+    <dependency ref="requirements-L8"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/file_nested_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/file_nested_1.6.json.bin
@@ -1,0 +1,119 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/FooProject/"
+        }
+      ],
+      "name": "FooProject",
+      "purl": "pkg:pypi/fooproject@1.2",
+      "type": "library",
+      "version": "1.2"
+    },
+    {
+      "bom-ref": "requirements-L4",
+      "description": "requirements line 4: colorama==0.4.6",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/"
+        }
+      ],
+      "name": "colorama",
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L4"
+    },
+    {
+      "ref": "requirements-L7"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "externalReferences": [
+        {
+          "comment": "from pyproject urls: documentation",
+          "type": "documentation",
+          "url": "https://oss.acme.org/my-project/docs/"
+        },
+        {
+          "comment": "from pyproject urls: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://oss.acme.org/my-project/bugs/"
+        },
+        {
+          "comment": "from pyproject urls: Funding",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/funding/"
+        },
+        {
+          "comment": "from pyproject urls: Change log",
+          "type": "release-notes",
+          "url": "https://oss.acme.org/my-project/changelog/"
+        },
+        {
+          "comment": "from pyproject urls: repository",
+          "type": "vcs",
+          "url": "https://oss.acme.org/my-project.git"
+        },
+        {
+          "comment": "from pyproject urls: homepage",
+          "type": "website",
+          "url": "https://oss.acme.org/my-project/"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/file_nested_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/file_nested_1.6.xml.bin
@@ -1,0 +1,116 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://oss.acme.org/my-project/docs/</url>
+          <comment>from pyproject urls: documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://oss.acme.org/my-project/bugs/</url>
+          <comment>from pyproject urls: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/funding/</url>
+          <comment>from pyproject urls: Funding</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://oss.acme.org/my-project/changelog/</url>
+          <comment>from pyproject urls: Change log</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://oss.acme.org/my-project.git</url>
+          <comment>from pyproject urls: repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://oss.acme.org/my-project/</url>
+          <comment>from pyproject urls: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L7">
+      <name>FooProject</name>
+      <version>1.2</version>
+      <description>requirements line 7: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</description>
+      <purl>pkg:pypi/fooproject@1.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/FooProject/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824</hash>
+            <hash alg="SHA-256">486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L4">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>requirements line 4: colorama==0.4.6</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L4"/>
+    <dependency ref="requirements-L7"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/file_private-packages_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/file_private-packages_1.6.json.bin
@@ -1,0 +1,118 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L9",
+      "description": "requirements line 9: my-other-package @ https://pypackages.acme.org/my-other-package-1.2.3.tar.gz",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "distribution",
+          "url": "https://pypackages.acme.org/my-other-package-1.2.3.tar.gz"
+        }
+      ],
+      "name": "my-other-package",
+      "purl": "pkg:pypi/my-other-package?download_url=https://pypackages.acme.org/my-other-package-1.2.3.tar.gz",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: my-package==1.2.3",
+      "externalReferences": [
+        {
+          "comment": "implicit dist extra-url",
+          "type": "distribution",
+          "url": "https://legacy1.pypackages.acme.org/simple/my-package/"
+        },
+        {
+          "comment": "implicit dist extra-url",
+          "type": "distribution",
+          "url": "https://legacy2.pypackages.acme.org/simple/my-package/"
+        },
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypackages.acme.org/simple/my-package/"
+        }
+      ],
+      "name": "my-package",
+      "purl": "pkg:pypi/my-package@1.2.3",
+      "type": "library",
+      "version": "1.2.3"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L7"
+    },
+    {
+      "ref": "requirements-L9"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "externalReferences": [
+        {
+          "comment": "from pyproject urls: documentation",
+          "type": "documentation",
+          "url": "https://oss.acme.org/my-project/docs/"
+        },
+        {
+          "comment": "from pyproject urls: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://oss.acme.org/my-project/bugs/"
+        },
+        {
+          "comment": "from pyproject urls: Funding",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/funding/"
+        },
+        {
+          "comment": "from pyproject urls: Change log",
+          "type": "release-notes",
+          "url": "https://oss.acme.org/my-project/changelog/"
+        },
+        {
+          "comment": "from pyproject urls: repository",
+          "type": "vcs",
+          "url": "https://oss.acme.org/my-project.git"
+        },
+        {
+          "comment": "from pyproject urls: homepage",
+          "type": "website",
+          "url": "https://oss.acme.org/my-project/"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/file_private-packages_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/file_private-packages_1.6.xml.bin
@@ -1,0 +1,119 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://oss.acme.org/my-project/docs/</url>
+          <comment>from pyproject urls: documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://oss.acme.org/my-project/bugs/</url>
+          <comment>from pyproject urls: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/funding/</url>
+          <comment>from pyproject urls: Funding</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://oss.acme.org/my-project/changelog/</url>
+          <comment>from pyproject urls: Change log</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://oss.acme.org/my-project.git</url>
+          <comment>from pyproject urls: repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://oss.acme.org/my-project/</url>
+          <comment>from pyproject urls: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L9">
+      <name>my-other-package</name>
+      <description>requirements line 9: my-other-package @ https://pypackages.acme.org/my-other-package-1.2.3.tar.gz</description>
+      <purl>pkg:pypi/my-other-package?download_url=https://pypackages.acme.org/my-other-package-1.2.3.tar.gz</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypackages.acme.org/my-other-package-1.2.3.tar.gz</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L7">
+      <name>my-package</name>
+      <version>1.2.3</version>
+      <description>requirements line 7: my-package==1.2.3</description>
+      <purl>pkg:pypi/my-package@1.2.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://legacy1.pypackages.acme.org/simple/my-package/</url>
+          <comment>implicit dist extra-url</comment>
+        </reference>
+        <reference type="distribution">
+          <url>https://legacy2.pypackages.acme.org/simple/my-package/</url>
+          <comment>implicit dist extra-url</comment>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypackages.acme.org/simple/my-package/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L7"/>
+    <dependency ref="requirements-L9"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/file_regression-issue448.cp1252.txt_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/file_regression-issue448.cp1252.txt_1.6.json.bin
@@ -1,0 +1,124 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L6",
+      "description": "requirements line 6: packageurl-python>=0.9.4",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/packageurl-python/"
+        }
+      ],
+      "name": "packageurl-python",
+      "purl": "pkg:pypi/packageurl-python",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: requirements_parser>=0.2.0",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/requirements_parser/"
+        }
+      ],
+      "name": "requirements_parser",
+      "purl": "pkg:pypi/requirements-parser",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L8",
+      "description": "requirements line 8: setuptools>=50.3.2",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/setuptools/"
+        }
+      ],
+      "name": "setuptools",
+      "purl": "pkg:pypi/setuptools",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L6"
+    },
+    {
+      "ref": "requirements-L7"
+    },
+    {
+      "ref": "requirements-L8"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "externalReferences": [
+        {
+          "comment": "from pyproject urls: documentation",
+          "type": "documentation",
+          "url": "https://oss.acme.org/my-project/docs/"
+        },
+        {
+          "comment": "from pyproject urls: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://oss.acme.org/my-project/bugs/"
+        },
+        {
+          "comment": "from pyproject urls: Funding",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/funding/"
+        },
+        {
+          "comment": "from pyproject urls: Change log",
+          "type": "release-notes",
+          "url": "https://oss.acme.org/my-project/changelog/"
+        },
+        {
+          "comment": "from pyproject urls: repository",
+          "type": "vcs",
+          "url": "https://oss.acme.org/my-project.git"
+        },
+        {
+          "comment": "from pyproject urls: homepage",
+          "type": "website",
+          "url": "https://oss.acme.org/my-project/"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/file_regression-issue448.cp1252.txt_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/file_regression-issue448.cp1252.txt_1.6.xml.bin
@@ -1,0 +1,122 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://oss.acme.org/my-project/docs/</url>
+          <comment>from pyproject urls: documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://oss.acme.org/my-project/bugs/</url>
+          <comment>from pyproject urls: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/funding/</url>
+          <comment>from pyproject urls: Funding</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://oss.acme.org/my-project/changelog/</url>
+          <comment>from pyproject urls: Change log</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://oss.acme.org/my-project.git</url>
+          <comment>from pyproject urls: repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://oss.acme.org/my-project/</url>
+          <comment>from pyproject urls: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L6">
+      <name>packageurl-python</name>
+      <description>requirements line 6: packageurl-python&gt;=0.9.4</description>
+      <purl>pkg:pypi/packageurl-python</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/packageurl-python/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L7">
+      <name>requirements_parser</name>
+      <description>requirements line 7: requirements_parser&gt;=0.2.0</description>
+      <purl>pkg:pypi/requirements-parser</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/requirements_parser/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L8">
+      <name>setuptools</name>
+      <description>requirements line 8: setuptools&gt;=50.3.2</description>
+      <purl>pkg:pypi/setuptools</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/setuptools/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L6"/>
+    <dependency ref="requirements-L7"/>
+    <dependency ref="requirements-L8"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/file_with-comments_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/file_with-comments_1.6.json.bin
@@ -1,0 +1,163 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L1",
+      "description": "requirements line 1: certifi==2023.11.17",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/"
+        }
+      ],
+      "name": "certifi",
+      "purl": "pkg:pypi/certifi@2023.11.17",
+      "type": "library",
+      "version": "2023.11.17"
+    },
+    {
+      "bom-ref": "requirements-L2",
+      "description": "requirements line 2: chardet==4.0.0",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/chardet/"
+        }
+      ],
+      "name": "chardet",
+      "purl": "pkg:pypi/chardet@4.0.0",
+      "type": "library",
+      "version": "4.0.0"
+    },
+    {
+      "bom-ref": "requirements-L3",
+      "description": "requirements line 3: idna==2.10",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/"
+        }
+      ],
+      "name": "idna",
+      "purl": "pkg:pypi/idna@2.10",
+      "type": "library",
+      "version": "2.10"
+    },
+    {
+      "bom-ref": "requirements-L4",
+      "description": "requirements line 4: requests==2.31.0",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/requests/"
+        }
+      ],
+      "name": "requests",
+      "purl": "pkg:pypi/requests@2.31.0",
+      "type": "library",
+      "version": "2.31.0"
+    },
+    {
+      "bom-ref": "requirements-L5",
+      "description": "requirements line 5: urllib3==2.2.0",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/urllib3/"
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3@2.2.0",
+      "type": "library",
+      "version": "2.2.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L1"
+    },
+    {
+      "ref": "requirements-L2"
+    },
+    {
+      "ref": "requirements-L3"
+    },
+    {
+      "ref": "requirements-L4"
+    },
+    {
+      "ref": "requirements-L5"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "externalReferences": [
+        {
+          "comment": "from pyproject urls: documentation",
+          "type": "documentation",
+          "url": "https://oss.acme.org/my-project/docs/"
+        },
+        {
+          "comment": "from pyproject urls: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://oss.acme.org/my-project/bugs/"
+        },
+        {
+          "comment": "from pyproject urls: Funding",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/funding/"
+        },
+        {
+          "comment": "from pyproject urls: Change log",
+          "type": "release-notes",
+          "url": "https://oss.acme.org/my-project/changelog/"
+        },
+        {
+          "comment": "from pyproject urls: repository",
+          "type": "vcs",
+          "url": "https://oss.acme.org/my-project.git"
+        },
+        {
+          "comment": "from pyproject urls: homepage",
+          "type": "website",
+          "url": "https://oss.acme.org/my-project/"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/file_with-comments_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-comments_1.6.xml.bin
@@ -1,0 +1,151 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://oss.acme.org/my-project/docs/</url>
+          <comment>from pyproject urls: documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://oss.acme.org/my-project/bugs/</url>
+          <comment>from pyproject urls: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/funding/</url>
+          <comment>from pyproject urls: Funding</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://oss.acme.org/my-project/changelog/</url>
+          <comment>from pyproject urls: Change log</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://oss.acme.org/my-project.git</url>
+          <comment>from pyproject urls: repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://oss.acme.org/my-project/</url>
+          <comment>from pyproject urls: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L1">
+      <name>certifi</name>
+      <version>2023.11.17</version>
+      <description>requirements line 1: certifi==2023.11.17</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L2">
+      <name>chardet</name>
+      <version>4.0.0</version>
+      <description>requirements line 2: chardet==4.0.0</description>
+      <purl>pkg:pypi/chardet@4.0.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/chardet/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L3">
+      <name>idna</name>
+      <version>2.10</version>
+      <description>requirements line 3: idna==2.10</description>
+      <purl>pkg:pypi/idna@2.10</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L4">
+      <name>requests</name>
+      <version>2.31.0</version>
+      <description>requirements line 4: requests==2.31.0</description>
+      <purl>pkg:pypi/requests@2.31.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/requests/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L5">
+      <name>urllib3</name>
+      <version>2.2.0</version>
+      <description>requirements line 5: urllib3==2.2.0</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/urllib3/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L1"/>
+    <dependency ref="requirements-L2"/>
+    <dependency ref="requirements-L3"/>
+    <dependency ref="requirements-L4"/>
+    <dependency ref="requirements-L5"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/file_with-extras_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/file_with-extras_1.6.json.bin
@@ -1,0 +1,101 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L4",
+      "description": "requirements line 4: cyclonedx-python-lib[JSON-validation,xml-Validation] == 5.1.1",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/cyclonedx-python-lib/"
+        }
+      ],
+      "name": "cyclonedx-python-lib",
+      "properties": [
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "json-validation"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "xml-validation"
+        }
+      ],
+      "purl": "pkg:pypi/cyclonedx-python-lib@5.1.1",
+      "type": "library",
+      "version": "5.1.1"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L4"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "externalReferences": [
+        {
+          "comment": "from pyproject urls: documentation",
+          "type": "documentation",
+          "url": "https://oss.acme.org/my-project/docs/"
+        },
+        {
+          "comment": "from pyproject urls: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://oss.acme.org/my-project/bugs/"
+        },
+        {
+          "comment": "from pyproject urls: Funding",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/funding/"
+        },
+        {
+          "comment": "from pyproject urls: Change log",
+          "type": "release-notes",
+          "url": "https://oss.acme.org/my-project/changelog/"
+        },
+        {
+          "comment": "from pyproject urls: repository",
+          "type": "vcs",
+          "url": "https://oss.acme.org/my-project.git"
+        },
+        {
+          "comment": "from pyproject urls: homepage",
+          "type": "website",
+          "url": "https://oss.acme.org/my-project/"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/file_with-extras_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-extras_1.6.xml.bin
@@ -1,0 +1,103 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://oss.acme.org/my-project/docs/</url>
+          <comment>from pyproject urls: documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://oss.acme.org/my-project/bugs/</url>
+          <comment>from pyproject urls: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/funding/</url>
+          <comment>from pyproject urls: Funding</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://oss.acme.org/my-project/changelog/</url>
+          <comment>from pyproject urls: Change log</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://oss.acme.org/my-project.git</url>
+          <comment>from pyproject urls: repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://oss.acme.org/my-project/</url>
+          <comment>from pyproject urls: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L4">
+      <name>cyclonedx-python-lib</name>
+      <version>5.1.1</version>
+      <description>requirements line 4: cyclonedx-python-lib[JSON-validation,xml-Validation] == 5.1.1</description>
+      <purl>pkg:pypi/cyclonedx-python-lib@5.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/cyclonedx-python-lib/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:python:package:required-extra">json-validation</property>
+        <property name="cdx:python:package:required-extra">xml-validation</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L4"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/file_with-hashes_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/file_with-hashes_1.6.json.bin
@@ -1,0 +1,202 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L11",
+      "description": "requirements line 11: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/FooProject/"
+        }
+      ],
+      "name": "FooProject",
+      "purl": "pkg:pypi/fooproject@1.2",
+      "type": "library",
+      "version": "1.2"
+    },
+    {
+      "bom-ref": "requirements-L4",
+      "description": "requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/"
+        }
+      ],
+      "name": "certifi",
+      "purl": "pkg:pypi/certifi@2023.11.17",
+      "type": "library",
+      "version": "2023.11.17"
+    },
+    {
+      "bom-ref": "requirements-L16",
+      "description": "requirements line 16: colorama @ https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz     --hash=md5:9854316552d41419b678d39af443a75f     --hash=sha1:aa1fc7722b9128a3c945048de03f5b4e55157c6a",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "hashes": [
+            {
+              "alg": "MD5",
+              "content": "9854316552d41419b678d39af443a75f"
+            },
+            {
+              "alg": "SHA-1",
+              "content": "aa1fc7722b9128a3c945048de03f5b4e55157c6a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "purl": "pkg:pypi/colorama?download_url=https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L21",
+      "description": "requirements line 21: something == 1.33.7 --hash=foo:something-invalid",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/something/"
+        }
+      ],
+      "name": "something",
+      "purl": "pkg:pypi/something@1.33.7",
+      "type": "library",
+      "version": "1.33.7"
+    },
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/urllib3/"
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3@2.2.0",
+      "type": "library",
+      "version": "2.2.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L11"
+    },
+    {
+      "ref": "requirements-L16"
+    },
+    {
+      "ref": "requirements-L21"
+    },
+    {
+      "ref": "requirements-L4"
+    },
+    {
+      "ref": "requirements-L7"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "externalReferences": [
+        {
+          "comment": "from pyproject urls: documentation",
+          "type": "documentation",
+          "url": "https://oss.acme.org/my-project/docs/"
+        },
+        {
+          "comment": "from pyproject urls: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://oss.acme.org/my-project/bugs/"
+        },
+        {
+          "comment": "from pyproject urls: Funding",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/funding/"
+        },
+        {
+          "comment": "from pyproject urls: Change log",
+          "type": "release-notes",
+          "url": "https://oss.acme.org/my-project/changelog/"
+        },
+        {
+          "comment": "from pyproject urls: repository",
+          "type": "vcs",
+          "url": "https://oss.acme.org/my-project.git"
+        },
+        {
+          "comment": "from pyproject urls: homepage",
+          "type": "website",
+          "url": "https://oss.acme.org/my-project/"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/file_with-hashes_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-hashes_1.6.xml.bin
@@ -1,0 +1,166 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://oss.acme.org/my-project/docs/</url>
+          <comment>from pyproject urls: documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://oss.acme.org/my-project/bugs/</url>
+          <comment>from pyproject urls: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/funding/</url>
+          <comment>from pyproject urls: Funding</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://oss.acme.org/my-project/changelog/</url>
+          <comment>from pyproject urls: Change log</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://oss.acme.org/my-project.git</url>
+          <comment>from pyproject urls: repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://oss.acme.org/my-project/</url>
+          <comment>from pyproject urls: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L11">
+      <name>FooProject</name>
+      <version>1.2</version>
+      <description>requirements line 11: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</description>
+      <purl>pkg:pypi/fooproject@1.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/FooProject/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824</hash>
+            <hash alg="SHA-256">486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L4">
+      <name>certifi</name>
+      <version>2023.11.17</version>
+      <description>requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</hash>
+            <hash alg="SHA-256">e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L16">
+      <name>colorama</name>
+      <description>requirements line 16: colorama @ https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz     --hash=md5:9854316552d41419b678d39af443a75f     --hash=sha1:aa1fc7722b9128a3c945048de03f5b4e55157c6a</description>
+      <purl>pkg:pypi/colorama?download_url=https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz</url>
+          <comment>explicit dist url</comment>
+          <hashes>
+            <hash alg="MD5">9854316552d41419b678d39af443a75f</hash>
+            <hash alg="SHA-1">aa1fc7722b9128a3c945048de03f5b4e55157c6a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L21">
+      <name>something</name>
+      <version>1.33.7</version>
+      <description>requirements line 21: something == 1.33.7 --hash=foo:something-invalid</description>
+      <purl>pkg:pypi/something@1.33.7</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/something/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L7">
+      <name>urllib3</name>
+      <version>2.2.0</version>
+      <description>requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/urllib3/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20</hash>
+            <hash alg="SHA-256">ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L11"/>
+    <dependency ref="requirements-L16"/>
+    <dependency ref="requirements-L21"/>
+    <dependency ref="requirements-L4"/>
+    <dependency ref="requirements-L7"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/file_with-urls_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/file_with-urls_1.6.json.bin
@@ -1,0 +1,192 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L11",
+      "description": "requirements line 11: git+https://github.com/path/to/package-four@releases/tag/v3.7.1#egg=package-four",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "vcs",
+          "url": "git+https://github.com/path/to/package-four@releases/tag/v3.7.1#egg=package-four"
+        }
+      ],
+      "name": "package-four",
+      "purl": "pkg:pypi/package-four?vcs_url=git%2Bhttps://github.com/path/to/package-four%40releases/tag/v3.7.1%23egg%3Dpackage-four",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L5",
+      "description": "requirements line 5: git+https://github.com/path/to/package-one@41b95ec#egg=package-one",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "vcs",
+          "url": "git+https://github.com/path/to/package-one@41b95ec#egg=package-one"
+        }
+      ],
+      "name": "package-one",
+      "purl": "pkg:pypi/package-one?vcs_url=git%2Bhttps://github.com/path/to/package-one%4041b95ec%23egg%3Dpackage-one",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L9",
+      "description": "requirements line 9: git+https://github.com/path/to/package-three@0.1#egg=package-three",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "vcs",
+          "url": "git+https://github.com/path/to/package-three@0.1#egg=package-three"
+        }
+      ],
+      "name": "package-three",
+      "purl": "pkg:pypi/package-three?vcs_url=git%2Bhttps://github.com/path/to/package-three%400.1%23egg%3Dpackage-three",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: git+https://github.com/path/to/package-two@master#egg=package-two",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "vcs",
+          "url": "git+https://github.com/path/to/package-two@master#egg=package-two"
+        }
+      ],
+      "name": "package-two",
+      "purl": "pkg:pypi/package-two?vcs_url=git%2Bhttps://github.com/path/to/package-two%40master%23egg%3Dpackage-two",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L19",
+      "description": "requirements line 19: https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L23",
+      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "distribution",
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L15",
+      "description": "requirements line 15: http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "distribution",
+          "url": "http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl"
+        }
+      ],
+      "name": "wxPython-Phoenix",
+      "purl": "pkg:pypi/wxpython-phoenix@3.0.3.dev1820%2B49a8884?download_url=http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820%2B49a8884-cp34-none-win_amd64.whl",
+      "type": "library",
+      "version": "3.0.3.dev1820+49a8884"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L11"
+    },
+    {
+      "ref": "requirements-L15"
+    },
+    {
+      "ref": "requirements-L19"
+    },
+    {
+      "ref": "requirements-L23"
+    },
+    {
+      "ref": "requirements-L5"
+    },
+    {
+      "ref": "requirements-L7"
+    },
+    {
+      "ref": "requirements-L9"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "externalReferences": [
+        {
+          "comment": "from pyproject urls: documentation",
+          "type": "documentation",
+          "url": "https://oss.acme.org/my-project/docs/"
+        },
+        {
+          "comment": "from pyproject urls: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://oss.acme.org/my-project/bugs/"
+        },
+        {
+          "comment": "from pyproject urls: Funding",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/funding/"
+        },
+        {
+          "comment": "from pyproject urls: Change log",
+          "type": "release-notes",
+          "url": "https://oss.acme.org/my-project/changelog/"
+        },
+        {
+          "comment": "from pyproject urls: repository",
+          "type": "vcs",
+          "url": "https://oss.acme.org/my-project.git"
+        },
+        {
+          "comment": "from pyproject urls: homepage",
+          "type": "website",
+          "url": "https://oss.acme.org/my-project/"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/file_with-urls_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/file_with-urls_1.6.xml.bin
@@ -1,0 +1,170 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://oss.acme.org/my-project/docs/</url>
+          <comment>from pyproject urls: documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://oss.acme.org/my-project/bugs/</url>
+          <comment>from pyproject urls: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/funding/</url>
+          <comment>from pyproject urls: Funding</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://oss.acme.org/my-project/changelog/</url>
+          <comment>from pyproject urls: Change log</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://oss.acme.org/my-project.git</url>
+          <comment>from pyproject urls: repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://oss.acme.org/my-project/</url>
+          <comment>from pyproject urls: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L11">
+      <name>package-four</name>
+      <description>requirements line 11: git+https://github.com/path/to/package-four@releases/tag/v3.7.1#egg=package-four</description>
+      <purl>pkg:pypi/package-four?vcs_url=git%2Bhttps://github.com/path/to/package-four%40releases/tag/v3.7.1%23egg%3Dpackage-four</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/path/to/package-four@releases/tag/v3.7.1#egg=package-four</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L5">
+      <name>package-one</name>
+      <description>requirements line 5: git+https://github.com/path/to/package-one@41b95ec#egg=package-one</description>
+      <purl>pkg:pypi/package-one?vcs_url=git%2Bhttps://github.com/path/to/package-one%4041b95ec%23egg%3Dpackage-one</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/path/to/package-one@41b95ec#egg=package-one</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L9">
+      <name>package-three</name>
+      <description>requirements line 9: git+https://github.com/path/to/package-three@0.1#egg=package-three</description>
+      <purl>pkg:pypi/package-three?vcs_url=git%2Bhttps://github.com/path/to/package-three%400.1%23egg%3Dpackage-three</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/path/to/package-three@0.1#egg=package-three</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L7">
+      <name>package-two</name>
+      <description>requirements line 7: git+https://github.com/path/to/package-two@master#egg=package-two</description>
+      <purl>pkg:pypi/package-two?vcs_url=git%2Bhttps://github.com/path/to/package-two%40master%23egg%3Dpackage-two</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/path/to/package-two@master#egg=package-two</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L19">
+      <name>unknown</name>
+      <description>requirements line 19: https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L23">
+      <name>urllib3</name>
+      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</description>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L15">
+      <name>wxPython-Phoenix</name>
+      <version>3.0.3.dev1820+49a8884</version>
+      <description>requirements line 15: http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl</description>
+      <purl>pkg:pypi/wxpython-phoenix@3.0.3.dev1820%2B49a8884?download_url=http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820%2B49a8884-cp34-none-win_amd64.whl</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L11"/>
+    <dependency ref="requirements-L15"/>
+    <dependency ref="requirements-L19"/>
+    <dependency ref="requirements-L23"/>
+    <dependency ref="requirements-L5"/>
+    <dependency ref="requirements-L7"/>
+    <dependency ref="requirements-L9"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/file_without-pinned-versions_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/file_without-pinned-versions_1.6.json.bin
@@ -1,0 +1,124 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L1",
+      "description": "requirements line 1: certifi>=2023.11.17",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/"
+        }
+      ],
+      "name": "certifi",
+      "purl": "pkg:pypi/certifi",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L2",
+      "description": "requirements line 2: chardet >= 4.0.0 , < 5",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/chardet/"
+        }
+      ],
+      "name": "chardet",
+      "purl": "pkg:pypi/chardet",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L3",
+      "description": "requirements line 3: urllib3",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/urllib3/"
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L1"
+    },
+    {
+      "ref": "requirements-L2"
+    },
+    {
+      "ref": "requirements-L3"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "externalReferences": [
+        {
+          "comment": "from pyproject urls: documentation",
+          "type": "documentation",
+          "url": "https://oss.acme.org/my-project/docs/"
+        },
+        {
+          "comment": "from pyproject urls: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://oss.acme.org/my-project/bugs/"
+        },
+        {
+          "comment": "from pyproject urls: Funding",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/funding/"
+        },
+        {
+          "comment": "from pyproject urls: Change log",
+          "type": "release-notes",
+          "url": "https://oss.acme.org/my-project/changelog/"
+        },
+        {
+          "comment": "from pyproject urls: repository",
+          "type": "vcs",
+          "url": "https://oss.acme.org/my-project.git"
+        },
+        {
+          "comment": "from pyproject urls: homepage",
+          "type": "website",
+          "url": "https://oss.acme.org/my-project/"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/file_without-pinned-versions_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/file_without-pinned-versions_1.6.xml.bin
@@ -1,0 +1,122 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://oss.acme.org/my-project/docs/</url>
+          <comment>from pyproject urls: documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://oss.acme.org/my-project/bugs/</url>
+          <comment>from pyproject urls: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/funding/</url>
+          <comment>from pyproject urls: Funding</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://oss.acme.org/my-project/changelog/</url>
+          <comment>from pyproject urls: Change log</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://oss.acme.org/my-project.git</url>
+          <comment>from pyproject urls: repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://oss.acme.org/my-project/</url>
+          <comment>from pyproject urls: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L1">
+      <name>certifi</name>
+      <description>requirements line 1: certifi&gt;=2023.11.17</description>
+      <purl>pkg:pypi/certifi</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L2">
+      <name>chardet</name>
+      <description>requirements line 2: chardet &gt;= 4.0.0 , &lt; 5</description>
+      <purl>pkg:pypi/chardet</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/chardet/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L3">
+      <name>urllib3</name>
+      <description>requirements line 3: urllib3</description>
+      <purl>pkg:pypi/urllib3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/urllib3/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L1"/>
+    <dependency ref="requirements-L2"/>
+    <dependency ref="requirements-L3"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/index_auth_frozen_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/index_auth_frozen_1.6.json.bin
@@ -1,0 +1,159 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7",
+      "externalReferences": [
+        {
+          "comment": "implicit dist extra-url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://legacy1.pypackages.acme.org/simple/FooProject/"
+        },
+        {
+          "comment": "implicit dist extra-url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://legacy2.pypackages.acme.org/simple/FooProject/"
+        },
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypackages.acme.org/simple/FooProject/"
+        }
+      ],
+      "name": "FooProject",
+      "purl": "pkg:pypi/fooproject@1.2",
+      "type": "library",
+      "version": "1.2"
+    },
+    {
+      "bom-ref": "requirements-L4",
+      "description": "requirements line 4: colorama==0.4.6",
+      "externalReferences": [
+        {
+          "comment": "implicit dist extra-url",
+          "type": "distribution",
+          "url": "https://legacy1.pypackages.acme.org/simple/colorama/"
+        },
+        {
+          "comment": "implicit dist extra-url",
+          "type": "distribution",
+          "url": "https://legacy2.pypackages.acme.org/simple/colorama/"
+        },
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypackages.acme.org/simple/colorama/"
+        }
+      ],
+      "name": "colorama",
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L4"
+    },
+    {
+      "ref": "requirements-L7"
+    },
+    {
+      "ref": "root-component"
+    }
+  ],
+  "metadata": {
+    "component": {
+      "bom-ref": "root-component",
+      "description": "some `reuqirements.txt` a root-component with all metadata",
+      "externalReferences": [
+        {
+          "comment": "from pyproject urls: documentation",
+          "type": "documentation",
+          "url": "https://oss.acme.org/my-project/docs/"
+        },
+        {
+          "comment": "from pyproject urls: Bug Tracker",
+          "type": "issue-tracker",
+          "url": "https://oss.acme.org/my-project/bugs/"
+        },
+        {
+          "comment": "from pyproject urls: Funding",
+          "type": "other",
+          "url": "https://oss.acme.org/my-project/funding/"
+        },
+        {
+          "comment": "from pyproject urls: Change log",
+          "type": "release-notes",
+          "url": "https://oss.acme.org/my-project/changelog/"
+        },
+        {
+          "comment": "from pyproject urls: repository",
+          "type": "vcs",
+          "url": "https://oss.acme.org/my-project.git"
+        },
+        {
+          "comment": "from pyproject urls: homepage",
+          "type": "website",
+          "url": "https://oss.acme.org/my-project/"
+        }
+      ],
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR MIT"
+        }
+      ],
+      "name": "testing-requirements-txt",
+      "type": "application",
+      "version": "0.1.0"
+    },
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/index_auth_frozen_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/index_auth_frozen_1.6.xml.bin
@@ -1,0 +1,140 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="root-component">
+      <name>testing-requirements-txt</name>
+      <version>0.1.0</version>
+      <description>some `reuqirements.txt` a root-component with all metadata</description>
+      <licenses>
+        <expression>Apache-2.0 OR MIT</expression>
+      </licenses>
+      <externalReferences>
+        <reference type="documentation">
+          <url>https://oss.acme.org/my-project/docs/</url>
+          <comment>from pyproject urls: documentation</comment>
+        </reference>
+        <reference type="issue-tracker">
+          <url>https://oss.acme.org/my-project/bugs/</url>
+          <comment>from pyproject urls: Bug Tracker</comment>
+        </reference>
+        <reference type="other">
+          <url>https://oss.acme.org/my-project/funding/</url>
+          <comment>from pyproject urls: Funding</comment>
+        </reference>
+        <reference type="release-notes">
+          <url>https://oss.acme.org/my-project/changelog/</url>
+          <comment>from pyproject urls: Change log</comment>
+        </reference>
+        <reference type="vcs">
+          <url>https://oss.acme.org/my-project.git</url>
+          <comment>from pyproject urls: repository</comment>
+        </reference>
+        <reference type="website">
+          <url>https://oss.acme.org/my-project/</url>
+          <comment>from pyproject urls: homepage</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L7">
+      <name>FooProject</name>
+      <version>1.2</version>
+      <description>requirements line 7: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</description>
+      <purl>pkg:pypi/fooproject@1.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://legacy1.pypackages.acme.org/simple/FooProject/</url>
+          <comment>implicit dist extra-url</comment>
+          <hashes>
+            <hash alg="SHA-256">2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824</hash>
+            <hash alg="SHA-256">486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://legacy2.pypackages.acme.org/simple/FooProject/</url>
+          <comment>implicit dist extra-url</comment>
+          <hashes>
+            <hash alg="SHA-256">2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824</hash>
+            <hash alg="SHA-256">486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</hash>
+          </hashes>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypackages.acme.org/simple/FooProject/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824</hash>
+            <hash alg="SHA-256">486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L4">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>requirements line 4: colorama==0.4.6</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://legacy1.pypackages.acme.org/simple/colorama/</url>
+          <comment>implicit dist extra-url</comment>
+        </reference>
+        <reference type="distribution">
+          <url>https://legacy2.pypackages.acme.org/simple/colorama/</url>
+          <comment>implicit dist extra-url</comment>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypackages.acme.org/simple/colorama/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L4"/>
+    <dependency ref="requirements-L7"/>
+    <dependency ref="root-component"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/stream_frozen_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/stream_frozen_1.6.json.bin
@@ -1,0 +1,72 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/FooProject/"
+        }
+      ],
+      "name": "FooProject",
+      "purl": "pkg:pypi/fooproject@1.2",
+      "type": "library",
+      "version": "1.2"
+    },
+    {
+      "bom-ref": "requirements-L4",
+      "description": "requirements line 4: colorama==0.4.6",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/colorama/"
+        }
+      ],
+      "name": "colorama",
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "type": "library",
+      "version": "0.4.6"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L4"
+    },
+    {
+      "ref": "requirements-L7"
+    }
+  ],
+  "metadata": {
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/stream_frozen_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_frozen_1.6.xml.bin
@@ -1,0 +1,81 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L7">
+      <name>FooProject</name>
+      <version>1.2</version>
+      <description>requirements line 7: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</description>
+      <purl>pkg:pypi/fooproject@1.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/FooProject/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824</hash>
+            <hash alg="SHA-256">486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L4">
+      <name>colorama</name>
+      <version>0.4.6</version>
+      <description>requirements line 4: colorama==0.4.6</description>
+      <purl>pkg:pypi/colorama@0.4.6</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/colorama/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L4"/>
+    <dependency ref="requirements-L7"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/stream_local_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/stream_local_1.6.json.bin
@@ -1,0 +1,129 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L11",
+      "description": "requirements line 11: foo @ file://../foo",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "file://../foo"
+        }
+      ],
+      "name": "foo",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L14",
+      "description": "requirements line 14: ./downloads/numpy-1.9.2-cp34-none-win32.whl",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "./downloads/numpy-1.9.2-cp34-none-win32.whl"
+        }
+      ],
+      "name": "numpy",
+      "type": "library",
+      "version": "1.9.2"
+    },
+    {
+      "bom-ref": "requirements-L2",
+      "description": "requirements line 2: ./myproject/chardet",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "./myproject/chardet"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L5",
+      "description": "requirements line 5: ./myproject/requests --hash=sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"
+            }
+          ],
+          "type": "other",
+          "url": "./myproject/requests"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L8",
+      "description": "requirements line 8: -e ./myproject/idna.whl",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "./myproject/idna.whl"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L17",
+      "description": "requirements line 17: ./downloads/numpy-1.26.1.tar.gz",
+      "externalReferences": [
+        {
+          "comment": "explicit local path",
+          "type": "other",
+          "url": "./downloads/numpy-1.26.1.tar.gz"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L11"
+    },
+    {
+      "ref": "requirements-L14"
+    },
+    {
+      "ref": "requirements-L17"
+    },
+    {
+      "ref": "requirements-L2"
+    },
+    {
+      "ref": "requirements-L5"
+    },
+    {
+      "ref": "requirements-L8"
+    }
+  ],
+  "metadata": {
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/stream_local_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_local_1.6.xml.bin
@@ -1,0 +1,121 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L11">
+      <name>foo</name>
+      <description>requirements line 11: foo @ file://../foo</description>
+      <externalReferences>
+        <reference type="other">
+          <url>file://../foo</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L14">
+      <name>numpy</name>
+      <version>1.9.2</version>
+      <description>requirements line 14: ./downloads/numpy-1.9.2-cp34-none-win32.whl</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./downloads/numpy-1.9.2-cp34-none-win32.whl</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L2">
+      <name>unknown</name>
+      <description>requirements line 2: ./myproject/chardet</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./myproject/chardet</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L5">
+      <name>unknown</name>
+      <description>requirements line 5: ./myproject/requests --hash=sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./myproject/requests</url>
+          <comment>explicit local path</comment>
+          <hashes>
+            <hash alg="SHA-256">27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L8">
+      <name>unknown</name>
+      <description>requirements line 8: -e ./myproject/idna.whl</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./myproject/idna.whl</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L17">
+      <name>unknown</name>
+      <description>requirements line 17: ./downloads/numpy-1.26.1.tar.gz</description>
+      <externalReferences>
+        <reference type="other">
+          <url>./downloads/numpy-1.26.1.tar.gz</url>
+          <comment>explicit local path</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L11"/>
+    <dependency ref="requirements-L14"/>
+    <dependency ref="requirements-L17"/>
+    <dependency ref="requirements-L2"/>
+    <dependency ref="requirements-L5"/>
+    <dependency ref="requirements-L8"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/stream_nested_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/stream_nested_1.6.json.bin
@@ -1,0 +1,22 @@
+{
+  "metadata": {
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/stream_nested_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_nested_1.6.xml.bin
@@ -1,0 +1,47 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+</bom>

--- a/tests/_data/snapshots/requirements/stream_private-packages_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/stream_private-packages_1.6.json.bin
@@ -1,0 +1,71 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L9",
+      "description": "requirements line 9: my-other-package @ https://pypackages.acme.org/my-other-package-1.2.3.tar.gz",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "distribution",
+          "url": "https://pypackages.acme.org/my-other-package-1.2.3.tar.gz"
+        }
+      ],
+      "name": "my-other-package",
+      "purl": "pkg:pypi/my-other-package?download_url=https://pypackages.acme.org/my-other-package-1.2.3.tar.gz",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: my-package==1.2.3",
+      "externalReferences": [
+        {
+          "comment": "implicit dist extra-url",
+          "type": "distribution",
+          "url": "https://legacy1.pypackages.acme.org/simple/my-package/"
+        },
+        {
+          "comment": "implicit dist extra-url",
+          "type": "distribution",
+          "url": "https://legacy2.pypackages.acme.org/simple/my-package/"
+        },
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypackages.acme.org/simple/my-package/"
+        }
+      ],
+      "name": "my-package",
+      "purl": "pkg:pypi/my-package@1.2.3",
+      "type": "library",
+      "version": "1.2.3"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L7"
+    },
+    {
+      "ref": "requirements-L9"
+    }
+  ],
+  "metadata": {
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/stream_private-packages_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_private-packages_1.6.xml.bin
@@ -1,0 +1,84 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L9">
+      <name>my-other-package</name>
+      <description>requirements line 9: my-other-package @ https://pypackages.acme.org/my-other-package-1.2.3.tar.gz</description>
+      <purl>pkg:pypi/my-other-package?download_url=https://pypackages.acme.org/my-other-package-1.2.3.tar.gz</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypackages.acme.org/my-other-package-1.2.3.tar.gz</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L7">
+      <name>my-package</name>
+      <version>1.2.3</version>
+      <description>requirements line 7: my-package==1.2.3</description>
+      <purl>pkg:pypi/my-package@1.2.3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://legacy1.pypackages.acme.org/simple/my-package/</url>
+          <comment>implicit dist extra-url</comment>
+        </reference>
+        <reference type="distribution">
+          <url>https://legacy2.pypackages.acme.org/simple/my-package/</url>
+          <comment>implicit dist extra-url</comment>
+        </reference>
+        <reference type="distribution">
+          <url>https://pypackages.acme.org/simple/my-package/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L7"/>
+    <dependency ref="requirements-L9"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/stream_regression-issue448.cp1252.txt_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/stream_regression-issue448.cp1252.txt_1.6.json.bin
@@ -1,0 +1,77 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L6",
+      "description": "requirements line 6: packageurl-python>=0.9.4",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/packageurl-python/"
+        }
+      ],
+      "name": "packageurl-python",
+      "purl": "pkg:pypi/packageurl-python",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: requirements_parser>=0.2.0",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/requirements_parser/"
+        }
+      ],
+      "name": "requirements_parser",
+      "purl": "pkg:pypi/requirements-parser",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L8",
+      "description": "requirements line 8: setuptools>=50.3.2",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/setuptools/"
+        }
+      ],
+      "name": "setuptools",
+      "purl": "pkg:pypi/setuptools",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L6"
+    },
+    {
+      "ref": "requirements-L7"
+    },
+    {
+      "ref": "requirements-L8"
+    }
+  ],
+  "metadata": {
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/stream_regression-issue448.cp1252.txt_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_regression-issue448.cp1252.txt_1.6.xml.bin
@@ -1,0 +1,87 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L6">
+      <name>packageurl-python</name>
+      <description>requirements line 6: packageurl-python&gt;=0.9.4</description>
+      <purl>pkg:pypi/packageurl-python</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/packageurl-python/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L7">
+      <name>requirements_parser</name>
+      <description>requirements line 7: requirements_parser&gt;=0.2.0</description>
+      <purl>pkg:pypi/requirements-parser</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/requirements_parser/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L8">
+      <name>setuptools</name>
+      <description>requirements line 8: setuptools&gt;=50.3.2</description>
+      <purl>pkg:pypi/setuptools</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/setuptools/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L6"/>
+    <dependency ref="requirements-L7"/>
+    <dependency ref="requirements-L8"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/stream_with-comments_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/stream_with-comments_1.6.json.bin
@@ -1,0 +1,116 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L1",
+      "description": "requirements line 1: certifi==2023.11.17",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/"
+        }
+      ],
+      "name": "certifi",
+      "purl": "pkg:pypi/certifi@2023.11.17",
+      "type": "library",
+      "version": "2023.11.17"
+    },
+    {
+      "bom-ref": "requirements-L2",
+      "description": "requirements line 2: chardet==4.0.0",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/chardet/"
+        }
+      ],
+      "name": "chardet",
+      "purl": "pkg:pypi/chardet@4.0.0",
+      "type": "library",
+      "version": "4.0.0"
+    },
+    {
+      "bom-ref": "requirements-L3",
+      "description": "requirements line 3: idna==2.10",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/idna/"
+        }
+      ],
+      "name": "idna",
+      "purl": "pkg:pypi/idna@2.10",
+      "type": "library",
+      "version": "2.10"
+    },
+    {
+      "bom-ref": "requirements-L4",
+      "description": "requirements line 4: requests==2.31.0",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/requests/"
+        }
+      ],
+      "name": "requests",
+      "purl": "pkg:pypi/requests@2.31.0",
+      "type": "library",
+      "version": "2.31.0"
+    },
+    {
+      "bom-ref": "requirements-L5",
+      "description": "requirements line 5: urllib3==2.2.0",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/urllib3/"
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3@2.2.0",
+      "type": "library",
+      "version": "2.2.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L1"
+    },
+    {
+      "ref": "requirements-L2"
+    },
+    {
+      "ref": "requirements-L3"
+    },
+    {
+      "ref": "requirements-L4"
+    },
+    {
+      "ref": "requirements-L5"
+    }
+  ],
+  "metadata": {
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/stream_with-comments_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-comments_1.6.xml.bin
@@ -1,0 +1,116 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L1">
+      <name>certifi</name>
+      <version>2023.11.17</version>
+      <description>requirements line 1: certifi==2023.11.17</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L2">
+      <name>chardet</name>
+      <version>4.0.0</version>
+      <description>requirements line 2: chardet==4.0.0</description>
+      <purl>pkg:pypi/chardet@4.0.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/chardet/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L3">
+      <name>idna</name>
+      <version>2.10</version>
+      <description>requirements line 3: idna==2.10</description>
+      <purl>pkg:pypi/idna@2.10</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/idna/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L4">
+      <name>requests</name>
+      <version>2.31.0</version>
+      <description>requirements line 4: requests==2.31.0</description>
+      <purl>pkg:pypi/requests@2.31.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/requests/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L5">
+      <name>urllib3</name>
+      <version>2.2.0</version>
+      <description>requirements line 5: urllib3==2.2.0</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/urllib3/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L1"/>
+    <dependency ref="requirements-L2"/>
+    <dependency ref="requirements-L3"/>
+    <dependency ref="requirements-L4"/>
+    <dependency ref="requirements-L5"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/stream_with-extras_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/stream_with-extras_1.6.json.bin
@@ -1,0 +1,54 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L4",
+      "description": "requirements line 4: cyclonedx-python-lib[JSON-validation,xml-Validation] == 5.1.1",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/cyclonedx-python-lib/"
+        }
+      ],
+      "name": "cyclonedx-python-lib",
+      "properties": [
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "json-validation"
+        },
+        {
+          "name": "cdx:python:package:required-extra",
+          "value": "xml-validation"
+        }
+      ],
+      "purl": "pkg:pypi/cyclonedx-python-lib@5.1.1",
+      "type": "library",
+      "version": "5.1.1"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L4"
+    }
+  ],
+  "metadata": {
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/stream_with-extras_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-extras_1.6.xml.bin
@@ -1,0 +1,68 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L4">
+      <name>cyclonedx-python-lib</name>
+      <version>5.1.1</version>
+      <description>requirements line 4: cyclonedx-python-lib[JSON-validation,xml-Validation] == 5.1.1</description>
+      <purl>pkg:pypi/cyclonedx-python-lib@5.1.1</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/cyclonedx-python-lib/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:python:package:required-extra">json-validation</property>
+        <property name="cdx:python:package:required-extra">xml-validation</property>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L4"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/stream_with-hashes_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/stream_with-hashes_1.6.json.bin
@@ -1,0 +1,155 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L11",
+      "description": "requirements line 11: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/FooProject/"
+        }
+      ],
+      "name": "FooProject",
+      "purl": "pkg:pypi/fooproject@1.2",
+      "type": "library",
+      "version": "1.2"
+    },
+    {
+      "bom-ref": "requirements-L4",
+      "description": "requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/"
+        }
+      ],
+      "name": "certifi",
+      "purl": "pkg:pypi/certifi@2023.11.17",
+      "type": "library",
+      "version": "2023.11.17"
+    },
+    {
+      "bom-ref": "requirements-L16",
+      "description": "requirements line 16: colorama @ https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz     --hash=md5:9854316552d41419b678d39af443a75f     --hash=sha1:aa1fc7722b9128a3c945048de03f5b4e55157c6a",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "hashes": [
+            {
+              "alg": "MD5",
+              "content": "9854316552d41419b678d39af443a75f"
+            },
+            {
+              "alg": "SHA-1",
+              "content": "aa1fc7722b9128a3c945048de03f5b4e55157c6a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz"
+        }
+      ],
+      "name": "colorama",
+      "purl": "pkg:pypi/colorama?download_url=https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L21",
+      "description": "requirements line 21: something == 1.33.7 --hash=foo:something-invalid",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/something/"
+        }
+      ],
+      "name": "something",
+      "purl": "pkg:pypi/something@1.33.7",
+      "type": "library",
+      "version": "1.33.7"
+    },
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://pypi.org/simple/urllib3/"
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3@2.2.0",
+      "type": "library",
+      "version": "2.2.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L11"
+    },
+    {
+      "ref": "requirements-L16"
+    },
+    {
+      "ref": "requirements-L21"
+    },
+    {
+      "ref": "requirements-L4"
+    },
+    {
+      "ref": "requirements-L7"
+    }
+  ],
+  "metadata": {
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/stream_with-hashes_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-hashes_1.6.xml.bin
@@ -1,0 +1,131 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L11">
+      <name>FooProject</name>
+      <version>1.2</version>
+      <description>requirements line 11: FooProject == 1.2   --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824   --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</description>
+      <purl>pkg:pypi/fooproject@1.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/FooProject/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824</hash>
+            <hash alg="SHA-256">486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L4">
+      <name>certifi</name>
+      <version>2023.11.17</version>
+      <description>requirements line 4: certifi==2023.11.17 --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474 --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</description>
+      <purl>pkg:pypi/certifi@2023.11.17</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1</hash>
+            <hash alg="SHA-256">e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L16">
+      <name>colorama</name>
+      <description>requirements line 16: colorama @ https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz     --hash=md5:9854316552d41419b678d39af443a75f     --hash=sha1:aa1fc7722b9128a3c945048de03f5b4e55157c6a</description>
+      <purl>pkg:pypi/colorama?download_url=https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://github.com/tartley/colorama/archive/refs/tags/0.4.6.tar.gz</url>
+          <comment>explicit dist url</comment>
+          <hashes>
+            <hash alg="MD5">9854316552d41419b678d39af443a75f</hash>
+            <hash alg="SHA-1">aa1fc7722b9128a3c945048de03f5b4e55157c6a</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L21">
+      <name>something</name>
+      <version>1.33.7</version>
+      <description>requirements line 21: something == 1.33.7 --hash=foo:something-invalid</description>
+      <purl>pkg:pypi/something@1.33.7</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/something/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L7">
+      <name>urllib3</name>
+      <version>2.2.0</version>
+      <description>requirements line 7: urllib3==2.2.0 --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20  --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</description>
+      <purl>pkg:pypi/urllib3@2.2.0</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/urllib3/</url>
+          <comment>implicit dist url</comment>
+          <hashes>
+            <hash alg="SHA-256">051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20</hash>
+            <hash alg="SHA-256">ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L11"/>
+    <dependency ref="requirements-L16"/>
+    <dependency ref="requirements-L21"/>
+    <dependency ref="requirements-L4"/>
+    <dependency ref="requirements-L7"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/stream_with-urls_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/stream_with-urls_1.6.json.bin
@@ -1,0 +1,145 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L11",
+      "description": "requirements line 11: git+https://github.com/path/to/package-four@releases/tag/v3.7.1#egg=package-four",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "vcs",
+          "url": "git+https://github.com/path/to/package-four@releases/tag/v3.7.1#egg=package-four"
+        }
+      ],
+      "name": "package-four",
+      "purl": "pkg:pypi/package-four?vcs_url=git%2Bhttps://github.com/path/to/package-four%40releases/tag/v3.7.1%23egg%3Dpackage-four",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L5",
+      "description": "requirements line 5: git+https://github.com/path/to/package-one@41b95ec#egg=package-one",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "vcs",
+          "url": "git+https://github.com/path/to/package-one@41b95ec#egg=package-one"
+        }
+      ],
+      "name": "package-one",
+      "purl": "pkg:pypi/package-one?vcs_url=git%2Bhttps://github.com/path/to/package-one%4041b95ec%23egg%3Dpackage-one",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L9",
+      "description": "requirements line 9: git+https://github.com/path/to/package-three@0.1#egg=package-three",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "vcs",
+          "url": "git+https://github.com/path/to/package-three@0.1#egg=package-three"
+        }
+      ],
+      "name": "package-three",
+      "purl": "pkg:pypi/package-three?vcs_url=git%2Bhttps://github.com/path/to/package-three%400.1%23egg%3Dpackage-three",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L7",
+      "description": "requirements line 7: git+https://github.com/path/to/package-two@master#egg=package-two",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "vcs",
+          "url": "git+https://github.com/path/to/package-two@master#egg=package-two"
+        }
+      ],
+      "name": "package-two",
+      "purl": "pkg:pypi/package-two?vcs_url=git%2Bhttps://github.com/path/to/package-two%40master%23egg%3Dpackage-two",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L19",
+      "description": "requirements line 19: https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz"
+        }
+      ],
+      "name": "unknown",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L23",
+      "description": "requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "distribution",
+          "url": "https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip"
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L15",
+      "description": "requirements line 15: http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl",
+      "externalReferences": [
+        {
+          "comment": "explicit dist url",
+          "type": "distribution",
+          "url": "http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl"
+        }
+      ],
+      "name": "wxPython-Phoenix",
+      "purl": "pkg:pypi/wxpython-phoenix@3.0.3.dev1820%2B49a8884?download_url=http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820%2B49a8884-cp34-none-win_amd64.whl",
+      "type": "library",
+      "version": "3.0.3.dev1820+49a8884"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L11"
+    },
+    {
+      "ref": "requirements-L15"
+    },
+    {
+      "ref": "requirements-L19"
+    },
+    {
+      "ref": "requirements-L23"
+    },
+    {
+      "ref": "requirements-L5"
+    },
+    {
+      "ref": "requirements-L7"
+    },
+    {
+      "ref": "requirements-L9"
+    }
+  ],
+  "metadata": {
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/stream_with-urls_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_with-urls_1.6.xml.bin
@@ -1,0 +1,135 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L11">
+      <name>package-four</name>
+      <description>requirements line 11: git+https://github.com/path/to/package-four@releases/tag/v3.7.1#egg=package-four</description>
+      <purl>pkg:pypi/package-four?vcs_url=git%2Bhttps://github.com/path/to/package-four%40releases/tag/v3.7.1%23egg%3Dpackage-four</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/path/to/package-four@releases/tag/v3.7.1#egg=package-four</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L5">
+      <name>package-one</name>
+      <description>requirements line 5: git+https://github.com/path/to/package-one@41b95ec#egg=package-one</description>
+      <purl>pkg:pypi/package-one?vcs_url=git%2Bhttps://github.com/path/to/package-one%4041b95ec%23egg%3Dpackage-one</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/path/to/package-one@41b95ec#egg=package-one</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L9">
+      <name>package-three</name>
+      <description>requirements line 9: git+https://github.com/path/to/package-three@0.1#egg=package-three</description>
+      <purl>pkg:pypi/package-three?vcs_url=git%2Bhttps://github.com/path/to/package-three%400.1%23egg%3Dpackage-three</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/path/to/package-three@0.1#egg=package-three</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L7">
+      <name>package-two</name>
+      <description>requirements line 7: git+https://github.com/path/to/package-two@master#egg=package-two</description>
+      <purl>pkg:pypi/package-two?vcs_url=git%2Bhttps://github.com/path/to/package-two%40master%23egg%3Dpackage-two</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/path/to/package-two@master#egg=package-two</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L19">
+      <name>unknown</name>
+      <description>requirements line 19: https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz</description>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L23">
+      <name>urllib3</name>
+      <description>requirements line 23: urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</description>
+      <purl>pkg:pypi/urllib3?download_url=https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://github.com/urllib3/urllib3/archive/refs/tags/2.2.0.zip</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L15">
+      <name>wxPython-Phoenix</name>
+      <version>3.0.3.dev1820+49a8884</version>
+      <description>requirements line 15: http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl</description>
+      <purl>pkg:pypi/wxpython-phoenix@3.0.3.dev1820%2B49a8884?download_url=http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820%2B49a8884-cp34-none-win_amd64.whl</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl</url>
+          <comment>explicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L11"/>
+    <dependency ref="requirements-L15"/>
+    <dependency ref="requirements-L19"/>
+    <dependency ref="requirements-L23"/>
+    <dependency ref="requirements-L5"/>
+    <dependency ref="requirements-L7"/>
+    <dependency ref="requirements-L9"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.6.json.bin
+++ b/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.6.json.bin
@@ -1,0 +1,77 @@
+{
+  "components": [
+    {
+      "bom-ref": "requirements-L1",
+      "description": "requirements line 1: certifi>=2023.11.17",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/certifi/"
+        }
+      ],
+      "name": "certifi",
+      "purl": "pkg:pypi/certifi",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L2",
+      "description": "requirements line 2: chardet >= 4.0.0 , < 5",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/chardet/"
+        }
+      ],
+      "name": "chardet",
+      "purl": "pkg:pypi/chardet",
+      "type": "library"
+    },
+    {
+      "bom-ref": "requirements-L3",
+      "description": "requirements line 3: urllib3",
+      "externalReferences": [
+        {
+          "comment": "implicit dist url",
+          "type": "distribution",
+          "url": "https://pypi.org/simple/urllib3/"
+        }
+      ],
+      "name": "urllib3",
+      "purl": "pkg:pypi/urllib3",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "requirements-L1"
+    },
+    {
+      "ref": "requirements-L2"
+    },
+    {
+      "ref": "requirements-L3"
+    }
+  ],
+  "metadata": {
+    "properties": [
+      {
+        "name": "cdx:reproducible",
+        "value": "true"
+      }
+    ],
+    "tools": [
+      {
+        "externalReferences": [   ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "libVersion-testing"
+      }
+    ]
+  },
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.6.xml.bin
+++ b/tests/_data/snapshots/requirements/stream_without-pinned-versions_1.6.xml.bin
@@ -1,0 +1,87 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-bom</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-bom/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-bom-tool.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python/</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>libVersion-testing</version>
+        <externalReferences><!-- stripped --></externalReferences>
+      </tool>
+    </tools>
+    <properties>
+      <property name="cdx:reproducible">true</property>
+    </properties>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="requirements-L1">
+      <name>certifi</name>
+      <description>requirements line 1: certifi&gt;=2023.11.17</description>
+      <purl>pkg:pypi/certifi</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/certifi/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L2">
+      <name>chardet</name>
+      <description>requirements line 2: chardet &gt;= 4.0.0 , &lt; 5</description>
+      <purl>pkg:pypi/chardet</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/chardet/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="requirements-L3">
+      <name>urllib3</name>
+      <description>requirements line 3: urllib3</description>
+      <purl>pkg:pypi/urllib3</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://pypi.org/simple/urllib3/</url>
+          <comment>implicit dist url</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="requirements-L1"/>
+    <dependency ref="requirements-L2"/>
+    <dependency ref="requirements-L3"/>
+  </dependencies>
+</bom>

--- a/tests/integration/test_cli_environment.py
+++ b/tests/integration/test_cli_environment.py
@@ -128,7 +128,7 @@ class TestCliEnvironment(TestCase, SnapshotMixin):
         self.assertIn('Could not open pyproject file: something-that-must-not-exist.testing', err)
 
     def test_with_current_python(self) -> None:
-        sv = SchemaVersion.V1_5
+        sv = SchemaVersion.V1_6
         of = random.choice((OutputFormat.XML, OutputFormat.JSON))  # nosec B311
         with StringIO() as err, StringIO() as out:
             err.name = '<fakeerr>'
@@ -187,12 +187,13 @@ class TestCliEnvironment(TestCase, SnapshotMixin):
         self.assertEqual(0, res, err)
         self.assertEqualSnapshot(out, 'plain', projectdir, sv, of)
 
-    def assertEqualSnapshot(self, actual: str,  # noqa:N802
-                            purpose: str,
-                            projectdir: str,
-                            sv: SchemaVersion,
-                            of: OutputFormat
-                            ) -> None:
+    def assertEqualSnapshot(
+        self, actual: str,  # noqa:N802
+        purpose: str,
+        projectdir: str,
+        sv: SchemaVersion,
+        of: OutputFormat
+    ) -> None:
         super().assertEqualSnapshot(
             make_comparable(actual, of),
             join('environment', f'{purpose}_{basename(projectdir)}_{sv.to_version()}.{of.name.lower()}')

--- a/tests/integration/test_cli_environment.py
+++ b/tests/integration/test_cli_environment.py
@@ -187,8 +187,8 @@ class TestCliEnvironment(TestCase, SnapshotMixin):
         self.assertEqual(0, res, err)
         self.assertEqualSnapshot(out, 'plain', projectdir, sv, of)
 
-    def assertEqualSnapshot(
-        self, actual: str,  # noqa:N802
+    def assertEqualSnapshot(  # noqa:N802
+        self, actual: str,
         purpose: str,
         projectdir: str,
         sv: SchemaVersion,


### PR DESCRIPTION

- support output as CycloneDX 1.6
- bump dependency `cyclonedx-python-lib` from `^6.1.0` to `^7.0.0`

fixes #719
