### PR TITLE
fix!: adjust python VCS related CycloneDX Properties Taxonomy names

### DIFF
--- a/cyclonedx_py/_internal/__init__.py
+++ b/cyclonedx_py/_internal/__init__.py
@@ -58,8 +58,8 @@ class PropertyName(Enum):
     # see https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/python.md
     PackageExtra = 'cdx:python:package:required-extra'
     PackageSourceSubdirectory = 'cdx:python:package:source:subdirectory'
-    PackageSourceVcsRequestedRevision = 'cdx:poetry:package:source:vcs:requested_revision'
-    PackageSourceVcsCommitId = 'cdx:poetry:package:source:vcs:commit_id'
+    PackageSourceVcsRequestedRevision = 'cdx:python:package:source:vcs:requested_revision'
+    PackageSourceVcsCommitId = 'cdx:python:package:source:vcs:commit_id'
     PackageSourceLocalEditable = 'cdx:python:package:source:local:editable'
     # endregion python
 

--- a/tests/_data/snapshots/environment/plain_with-urls_1.3.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.3.json.bin
@@ -35,11 +35,11 @@
       "name": "packaging",
       "properties": [
         {
-          "name": "cdx:poetry:package:source:vcs:commit_id",
+          "name": "cdx:python:package:source:vcs:commit_id",
           "value": "b3a5d7d68991c040615d5345bb55f61de53ba176"
         },
         {
-          "name": "cdx:poetry:package:source:vcs:requested_revision",
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "23.2"
         }
       ],

--- a/tests/_data/snapshots/environment/plain_with-urls_1.3.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.3.xml.bin
@@ -51,8 +51,8 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:poetry:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
-        <property name="cdx:poetry:package:source:vcs:requested_revision">23.2</property>
+        <property name="cdx:python:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">23.2</property>
       </properties>
     </component>
     <component type="library" bom-ref="six==1.16.0">

--- a/tests/_data/snapshots/environment/plain_with-urls_1.4.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.4.json.bin
@@ -35,11 +35,11 @@
       "name": "packaging",
       "properties": [
         {
-          "name": "cdx:poetry:package:source:vcs:commit_id",
+          "name": "cdx:python:package:source:vcs:commit_id",
           "value": "b3a5d7d68991c040615d5345bb55f61de53ba176"
         },
         {
-          "name": "cdx:poetry:package:source:vcs:requested_revision",
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "23.2"
         }
       ],

--- a/tests/_data/snapshots/environment/plain_with-urls_1.4.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.4.xml.bin
@@ -78,8 +78,8 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:poetry:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
-        <property name="cdx:poetry:package:source:vcs:requested_revision">23.2</property>
+        <property name="cdx:python:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">23.2</property>
       </properties>
     </component>
     <component type="library" bom-ref="six==1.16.0">

--- a/tests/_data/snapshots/environment/plain_with-urls_1.5.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.5.json.bin
@@ -35,11 +35,11 @@
       "name": "packaging",
       "properties": [
         {
-          "name": "cdx:poetry:package:source:vcs:commit_id",
+          "name": "cdx:python:package:source:vcs:commit_id",
           "value": "b3a5d7d68991c040615d5345bb55f61de53ba176"
         },
         {
-          "name": "cdx:poetry:package:source:vcs:requested_revision",
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "23.2"
         }
       ],

--- a/tests/_data/snapshots/environment/plain_with-urls_1.5.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.5.xml.bin
@@ -78,8 +78,8 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:poetry:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
-        <property name="cdx:poetry:package:source:vcs:requested_revision">23.2</property>
+        <property name="cdx:python:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">23.2</property>
       </properties>
     </component>
     <component type="library" bom-ref="six==1.16.0">

--- a/tests/_data/snapshots/environment/plain_with-urls_1.6.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.6.json.bin
@@ -37,11 +37,11 @@
       "name": "packaging",
       "properties": [
         {
-          "name": "cdx:poetry:package:source:vcs:commit_id",
+          "name": "cdx:python:package:source:vcs:commit_id",
           "value": "b3a5d7d68991c040615d5345bb55f61de53ba176"
         },
         {
-          "name": "cdx:poetry:package:source:vcs:requested_revision",
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "23.2"
         }
       ],

--- a/tests/_data/snapshots/environment/plain_with-urls_1.6.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.6.xml.bin
@@ -78,8 +78,8 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:poetry:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
-        <property name="cdx:poetry:package:source:vcs:requested_revision">23.2</property>
+        <property name="cdx:python:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">23.2</property>
       </properties>
     </component>
     <component type="library" bom-ref="six==1.16.0">


### PR DESCRIPTION
in accordance with https://github.com/CycloneDX/cyclonedx-property-taxonomy/pull/96