### PR TITLE
feat: populate properties `cdx:python:package:source:vcs:...`

### DIFF
--- a/cyclonedx_py/_internal/__init__.py
+++ b/cyclonedx_py/_internal/__init__.py
@@ -73,8 +73,8 @@ class PropertyName(Enum):
     PoetryGroup = 'cdx:poetry:group'
     # region poetry-deprecated
     # the following property names are deprecated
-    PoetryPackageSourceReference_misspelled = 'cdx:poetry:package:source:reference'
-    PoetryPackageSourceReference = 'cdx:poetry:source:package:reference'
+    PoetryPackageSourceReference_misspelled  = 'cdx:poetry:source:package:reference'
+    PoetryPackageSourceReference = 'cdx:poetry:package:source:reference'
     PoetryPackageSourceResolvedReference = 'cdx:poetry:package:source:resolved_reference'
     PoetryPackageSourceVcsRequestedRevision = 'cdx:poetry:package:source:vcs:requested_revision'
     PoetryPackageSourceVcsCommitId = 'cdx:poetry:package:source:vcs:commit_id'

--- a/cyclonedx_py/_internal/__init__.py
+++ b/cyclonedx_py/_internal/__init__.py
@@ -74,7 +74,6 @@ class PropertyName(Enum):
     # region poetry-deprecated
     # the following property names are deprecated
     PoetryPackageSourceReference_misspelled  = 'cdx:poetry:source:package:reference'
-    PoetryPackageSourceReference = 'cdx:poetry:package:source:reference'
     PoetryPackageSourceResolvedReference = 'cdx:poetry:package:source:resolved_reference'
     PoetryPackageSourceVcsRequestedRevision = 'cdx:poetry:package:source:vcs:requested_revision'
     PoetryPackageSourceVcsCommitId = 'cdx:poetry:package:source:vcs:commit_id'

--- a/cyclonedx_py/_internal/__init__.py
+++ b/cyclonedx_py/_internal/__init__.py
@@ -45,22 +45,27 @@ class BomBuilder(ABC):
         ...
 
 
-class PropertyName(Enum):
+class PropertyValue(Enum):
     # region general
     # see https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx.md
     BooleanTrue = 'true'
     BooleanFalse = 'false'
+    # endregion general
 
+
+class PropertyName(Enum):
+    # region general
+    # see https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx.md
     Reproducible = 'cdx:reproducible'
     # endregion general
 
     # region python
     # see https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/python.md
-    PackageExtra = 'cdx:python:package:required-extra'
-    PackageSourceSubdirectory = 'cdx:python:package:source:subdirectory'
-    PackageSourceVcsRequestedRevision = 'cdx:poetry:package:source:vcs:requested_revision'
-    PackageSourceVcsCommitId = 'cdx:poetry:package:source:vcs:commit_id'
-    PackageSourceLocalEditable = 'cdx:python:package:source:local:editable'
+    PythonPackageExtra = 'cdx:python:package:required-extra'
+    PythonPackageSourceSubdirectory = 'cdx:python:package:source:subdirectory'
+    PythonPackageSourceVcsRequestedRevision = 'cdx:python:package:source:vcs:requested_revision'
+    PythonPackageSourceVcsCommitId = 'cdx:python:package:source:vcs:commit_id'
+    PythonPackageSourceLocalEditable = 'cdx:python:package:source:local:editable'
     # endregion python
 
     # region poetry
@@ -68,6 +73,11 @@ class PropertyName(Enum):
     PoetryGroup = 'cdx:poetry:group'
     PoetryPackageSourceReference = 'cdx:poetry:source:package:reference'
     PoetryPackageSourceResolvedReference = 'cdx:poetry:package:source:resolved_reference'
+    # region poetry-deprecated
+    # the following property names are deprecated
+    PoetryPackageSourceVcsRequestedRevision = 'cdx:poetry:package:source:vcs:requested_revision'
+    PoetryPackageSourceVcsCommitId = 'cdx:poetry:package:source:vcs:commit_id'
+    # endregion poetry-deprecated
     # endregion poetry
 
     # region pipenv

--- a/cyclonedx_py/_internal/__init__.py
+++ b/cyclonedx_py/_internal/__init__.py
@@ -71,10 +71,11 @@ class PropertyName(Enum):
     # region poetry
     # see https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/poetry.md
     PoetryGroup = 'cdx:poetry:group'
-    PoetryPackageSourceReference = 'cdx:poetry:source:package:reference'
-    PoetryPackageSourceResolvedReference = 'cdx:poetry:package:source:resolved_reference'
     # region poetry-deprecated
     # the following property names are deprecated
+    PoetryPackageSourceReference_misspelled = 'cdx:poetry:package:source:reference'
+    PoetryPackageSourceReference = 'cdx:poetry:source:package:reference'
+    PoetryPackageSourceResolvedReference = 'cdx:poetry:package:source:resolved_reference'
     PoetryPackageSourceVcsRequestedRevision = 'cdx:poetry:package:source:vcs:requested_revision'
     PoetryPackageSourceVcsCommitId = 'cdx:poetry:package:source:vcs:commit_id'
     # endregion poetry-deprecated

--- a/cyclonedx_py/_internal/__init__.py
+++ b/cyclonedx_py/_internal/__init__.py
@@ -73,7 +73,7 @@ class PropertyName(Enum):
     PoetryGroup = 'cdx:poetry:group'
     # region poetry-deprecated
     # the following property names are deprecated
-    PoetryPackageSourceReference_misspelled  = 'cdx:poetry:source:package:reference'
+    PoetryPackageSourceReference_misspelled = 'cdx:poetry:source:package:reference'
     PoetryPackageSourceResolvedReference = 'cdx:poetry:package:source:resolved_reference'
     PoetryPackageSourceVcsRequestedRevision = 'cdx:poetry:package:source:vcs:requested_revision'
     PoetryPackageSourceVcsCommitId = 'cdx:poetry:package:source:vcs:commit_id'

--- a/cyclonedx_py/_internal/cli.py
+++ b/cyclonedx_py/_internal/cli.py
@@ -27,7 +27,7 @@ from cyclonedx.schema import OutputFormat, SchemaVersion
 from cyclonedx.validation import make_schemabased_validator
 
 from .. import __version__
-from . import PropertyName
+from . import PropertyName, PropertyValue
 from .environment import EnvironmentBB
 from .pipenv import PipenvBB
 from .poetry import PoetryBB
@@ -230,7 +230,7 @@ class Command:
 
         if self._output_reproducible:
             bom.metadata.properties.add(Property(name=PropertyName.Reproducible.value,
-                                                 value=PropertyName.BooleanTrue.value))
+                                                 value=PropertyValue.BooleanTrue.value))
             # dirty hacks to remove these mandatory properties
             bom.serial_number = None  # type:ignore[assignment]
             bom.metadata.timestamp = None  # type:ignore[assignment]

--- a/cyclonedx_py/_internal/environment.py
+++ b/cyclonedx_py/_internal/environment.py
@@ -236,19 +236,22 @@ class EnvironmentBB(BomBuilder):
         purl_subpath = None
         if packagesource is not None:
             if packagesource.subdirectory:
-                component.properties.add(Property(name=PropertyName.PythonPackageSourceSubdirectory.value,
-                                                  value=packagesource.subdirectory))
+                component.properties.add(Property(
+                    name=PropertyName.PythonPackageSourceSubdirectory.value,
+                    value=packagesource.subdirectory))
                 purl_subpath = packagesource.subdirectory
             if isinstance(packagesource, PackageSourceVcs):
                 purl_qs['vcs_url'] = f'{packagesource.vcs}+{packagesource.url}@{packagesource.commit_id}'
-                component.properties.add(Property(name=PropertyName.PythonPackageSourceVcsCommitId.value,
-                                                  value=packagesource.commit_id))
+                component.properties.add(Property(
+                    name=PropertyName.PythonPackageSourceVcsCommitId.value,
+                    value=packagesource.commit_id))
                 component.properties.add(Property(
                     name=PropertyName.PoetryPackageSourceVcsCommitId.value,  # deprecated
                     value=packagesource.commit_id))
                 if packagesource.requested_revision:
-                    component.properties.add(Property(name=PropertyName.PythonPackageSourceVcsRequestedRevision.value,
-                                                      value=packagesource.requested_revision))
+                    component.properties.add(Property(
+                        name=PropertyName.PythonPackageSourceVcsRequestedRevision.value,
+                        value=packagesource.requested_revision))
                     component.properties.add(Property(
                         name=PropertyName.PoetryPackageSourceVcsRequestedRevision.value,  # deprecated
                         value=packagesource.requested_revision))

--- a/cyclonedx_py/_internal/environment.py
+++ b/cyclonedx_py/_internal/environment.py
@@ -224,7 +224,7 @@ class EnvironmentBB(BomBuilder):
                 component_deps.append(req_component)
                 req_component.properties.update(
                     Property(
-                        name=PropertyName.PackageExtra.value,
+                        name=PropertyName.PythonPackageExtra.value,
                         value=normalize_packagename(extra)
                     ) for extra in req.extras
                 )
@@ -236,16 +236,22 @@ class EnvironmentBB(BomBuilder):
         purl_subpath = None
         if packagesource is not None:
             if packagesource.subdirectory:
-                component.properties.add(Property(name=PropertyName.PackageSourceSubdirectory.value,
+                component.properties.add(Property(name=PropertyName.PythonPackageSourceSubdirectory.value,
                                                   value=packagesource.subdirectory))
                 purl_subpath = packagesource.subdirectory
             if isinstance(packagesource, PackageSourceVcs):
                 purl_qs['vcs_url'] = f'{packagesource.vcs}+{packagesource.url}@{packagesource.commit_id}'
-                component.properties.add(Property(name=PropertyName.PackageSourceVcsCommitId.value,
+                component.properties.add(Property(name=PropertyName.PythonPackageSourceVcsCommitId.value,
                                                   value=packagesource.commit_id))
+                component.properties.add(Property(
+                    name=PropertyName.PoetryPackageSourceVcsCommitId.value,  # deprecated
+                    value=packagesource.commit_id))
                 if packagesource.requested_revision:
-                    component.properties.add(Property(name=PropertyName.PackageSourceVcsRequestedRevision.value,
+                    component.properties.add(Property(name=PropertyName.PythonPackageSourceVcsRequestedRevision.value,
                                                       value=packagesource.requested_revision))
+                    component.properties.add(Property(
+                        name=PropertyName.PoetryPackageSourceVcsRequestedRevision.value,  # deprecated
+                        value=packagesource.requested_revision))
             elif isinstance(packagesource, PackageSourceArchive):
                 if '://files.pythonhosted.org/' not in packagesource.url:
                     # skip PURL bloat, do not add implicit information

--- a/cyclonedx_py/_internal/pipenv.py
+++ b/cyclonedx_py/_internal/pipenv.py
@@ -187,7 +187,7 @@ class PipenvBB(BomBuilder):
                 ))
                 component.properties.update(
                     Property(
-                        name=PropertyName.PackageExtra.value,
+                        name=PropertyName.PythonPackageExtra.value,
                         value=normalize_packagename(package_extra)
                     ) for package_extra in package_data.get('extras', ())
                 )

--- a/cyclonedx_py/_internal/poetry.py
+++ b/cyclonedx_py/_internal/poetry.py
@@ -416,6 +416,7 @@ class PoetryBB(BomBuilder):
                     name=PropertyName.PoetryGroup.value,
                     value=package['category']
                 ) if 'category' in package else None,
+                # region deprecated
                 Property(
                     name=PropertyName.PoetryPackageSourceReference_misspelled.value,  # deprecated
                     value=source['reference']
@@ -428,6 +429,7 @@ class PoetryBB(BomBuilder):
                     name=PropertyName.PoetryPackageSourceResolvedReference.value,  # deprecated
                     value=source['resolved_reference']
                 ) if is_vcs and 'resolved_reference' in source else None,
+                # endregion deprecated
             )),
             purl=PackageURL(
                 type=PurlTypePypi,

--- a/cyclonedx_py/_internal/poetry.py
+++ b/cyclonedx_py/_internal/poetry.py
@@ -422,10 +422,6 @@ class PoetryBB(BomBuilder):
                     value=source['reference']
                 ) if is_vcs and 'reference' in source else None,
                 Property(
-                    name=PropertyName.PoetryPackageSourceReference.value,  # deprecated
-                    value=source['reference']
-                ) if is_vcs and 'reference' in source else None,
-                Property(
                     name=PropertyName.PoetryPackageSourceResolvedReference.value,  # deprecated
                     value=source['resolved_reference']
                 ) if is_vcs and 'resolved_reference' in source else None,

--- a/cyclonedx_py/_internal/poetry.py
+++ b/cyclonedx_py/_internal/poetry.py
@@ -261,7 +261,7 @@ class PoetryBB(BomBuilder):
         root_c.bom_ref.value = root_c.name
         root_c.properties.update(
             Property(
-                name=PropertyName.PackageExtra.value,
+                name=PropertyName.PythonPackageExtra.value,
                 value=extra
             ) for extra in use_extras
         )
@@ -344,7 +344,7 @@ class PoetryBB(BomBuilder):
             use_extras = frozenset(map(normalize_packagename, use_extras))
             lock_entry.component.properties.update(
                 Property(
-                    name=PropertyName.PackageExtra.value,
+                    name=PropertyName.PythonPackageExtra.value,
                     value=extra
                 ) for extra in use_extras
             )

--- a/cyclonedx_py/_internal/poetry.py
+++ b/cyclonedx_py/_internal/poetry.py
@@ -403,20 +403,32 @@ class PoetryBB(BomBuilder):
             description=package.get('description'),
             scope=ComponentScope.OPTIONAL if package.get('optional') else None,
             external_references=self.__extrefs4lock(package),
-            properties=filter(lambda p: p and p.value, [  # type: ignore[arg-type]
+            properties=filter(lambda p: p and p.value, (  # type: ignore[arg-type]
+                Property(
+                    name=PropertyName.PythonPackageSourceVcsRequestedRevision.value,
+                    value=source['reference']
+                ) if is_vcs and 'reference' in source else None,
+                Property(
+                    name=PropertyName.PythonPackageSourceVcsCommitId.value,
+                    value=source['resolved_reference']
+                ) if is_vcs and 'resolved_reference' in source else None,
                 Property(  # for backwards compatibility: category -> group
                     name=PropertyName.PoetryGroup.value,
                     value=package['category']
                 ) if 'category' in package else None,
                 Property(
-                    name=PropertyName.PoetryPackageSourceReference.value,
+                    name=PropertyName.PoetryPackageSourceReference_misspelled.value,  # deprecated
                     value=source['reference']
                 ) if is_vcs and 'reference' in source else None,
                 Property(
-                    name=PropertyName.PoetryPackageSourceResolvedReference.value,
+                    name=PropertyName.PoetryPackageSourceReference.value,  # deprecated
+                    value=source['reference']
+                ) if is_vcs and 'reference' in source else None,
+                Property(
+                    name=PropertyName.PoetryPackageSourceResolvedReference.value,  # deprecated
                     value=source['resolved_reference']
                 ) if is_vcs and 'resolved_reference' in source else None,
-            ]),
+            )),
             purl=PackageURL(
                 type=PurlTypePypi,
                 name=package['name'],

--- a/cyclonedx_py/_internal/requirements.py
+++ b/cyclonedx_py/_internal/requirements.py
@@ -225,7 +225,7 @@ class RequirementsBB(BomBuilder):
             ) if not is_local and name else None,
             external_references=external_references,
             properties=(Property(
-                name=PropertyName.PackageExtra.value,
+                name=PropertyName.PythonPackageExtra.value,
                 value=normalize_packagename(extra)
             ) for extra in req.extras)
         )

--- a/tests/_data/snapshots/environment/plain_with-urls_1.3.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.3.json.bin
@@ -41,6 +41,14 @@
         {
           "name": "cdx:poetry:package:source:vcs:requested_revision",
           "value": "23.2"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "b3a5d7d68991c040615d5345bb55f61de53ba176"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
+          "value": "23.2"
         }
       ],
       "purl": "pkg:pypi/packaging@23.2?vcs_url=git%2Bhttps://github.com/pypa/packaging.git%40b3a5d7d68991c040615d5345bb55f61de53ba176",

--- a/tests/_data/snapshots/environment/plain_with-urls_1.3.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.3.xml.bin
@@ -53,6 +53,8 @@
       <properties>
         <property name="cdx:poetry:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
         <property name="cdx:poetry:package:source:vcs:requested_revision">23.2</property>
+        <property name="cdx:python:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">23.2</property>
       </properties>
     </component>
     <component type="library" bom-ref="six==1.16.0">

--- a/tests/_data/snapshots/environment/plain_with-urls_1.4.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.4.json.bin
@@ -41,6 +41,14 @@
         {
           "name": "cdx:poetry:package:source:vcs:requested_revision",
           "value": "23.2"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "b3a5d7d68991c040615d5345bb55f61de53ba176"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
+          "value": "23.2"
         }
       ],
       "purl": "pkg:pypi/packaging@23.2?vcs_url=git%2Bhttps://github.com/pypa/packaging.git%40b3a5d7d68991c040615d5345bb55f61de53ba176",

--- a/tests/_data/snapshots/environment/plain_with-urls_1.4.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.4.xml.bin
@@ -80,6 +80,8 @@
       <properties>
         <property name="cdx:poetry:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
         <property name="cdx:poetry:package:source:vcs:requested_revision">23.2</property>
+        <property name="cdx:python:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">23.2</property>
       </properties>
     </component>
     <component type="library" bom-ref="six==1.16.0">

--- a/tests/_data/snapshots/environment/plain_with-urls_1.5.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.5.json.bin
@@ -41,6 +41,14 @@
         {
           "name": "cdx:poetry:package:source:vcs:requested_revision",
           "value": "23.2"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "b3a5d7d68991c040615d5345bb55f61de53ba176"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
+          "value": "23.2"
         }
       ],
       "purl": "pkg:pypi/packaging@23.2?vcs_url=git%2Bhttps://github.com/pypa/packaging.git%40b3a5d7d68991c040615d5345bb55f61de53ba176",

--- a/tests/_data/snapshots/environment/plain_with-urls_1.5.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.5.xml.bin
@@ -80,6 +80,8 @@
       <properties>
         <property name="cdx:poetry:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
         <property name="cdx:poetry:package:source:vcs:requested_revision">23.2</property>
+        <property name="cdx:python:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">23.2</property>
       </properties>
     </component>
     <component type="library" bom-ref="six==1.16.0">

--- a/tests/_data/snapshots/environment/plain_with-urls_1.6.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.6.json.bin
@@ -43,6 +43,14 @@
         {
           "name": "cdx:poetry:package:source:vcs:requested_revision",
           "value": "23.2"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "b3a5d7d68991c040615d5345bb55f61de53ba176"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
+          "value": "23.2"
         }
       ],
       "purl": "pkg:pypi/packaging@23.2?vcs_url=git%2Bhttps://github.com/pypa/packaging.git%40b3a5d7d68991c040615d5345bb55f61de53ba176",

--- a/tests/_data/snapshots/environment/plain_with-urls_1.6.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.6.xml.bin
@@ -80,6 +80,8 @@
       <properties>
         <property name="cdx:poetry:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
         <property name="cdx:poetry:package:source:vcs:requested_revision">23.2</property>
+        <property name="cdx:python:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">23.2</property>
       </properties>
     </component>
     <component type="library" bom-ref="six==1.16.0">

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.3.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.3.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "2.3.5"
-        },
-        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
         },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.3.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.3.json.bin
@@ -17,11 +17,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "2.3.5"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "2.3.5"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "2.3.5"
         }
       ],

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.3.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.3.xml.bin
@@ -36,7 +36,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">2.3.5</property>
         <property name="cdx:poetry:package:source:resolved_reference">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
         <property name="cdx:poetry:source:package:reference">2.3.5</property>
         <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.3.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.3.xml.bin
@@ -36,8 +36,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">2.3.5</property>
         <property name="cdx:poetry:package:source:resolved_reference">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
         <property name="cdx:poetry:source:package:reference">2.3.5</property>
+        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
       </properties>
     </component>
     <component type="library" bom-ref="pathlib2@2.3.5">

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.4.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.4.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "2.3.5"
-        },
-        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
         },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.4.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.4.json.bin
@@ -17,11 +17,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "2.3.5"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "2.3.5"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "2.3.5"
         }
       ],

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.4.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.4.xml.bin
@@ -63,8 +63,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">2.3.5</property>
         <property name="cdx:poetry:package:source:resolved_reference">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
         <property name="cdx:poetry:source:package:reference">2.3.5</property>
+        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
       </properties>
     </component>
     <component type="library" bom-ref="pathlib2@2.3.5">

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.4.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.4.xml.bin
@@ -63,7 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">2.3.5</property>
         <property name="cdx:poetry:package:source:resolved_reference">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
         <property name="cdx:poetry:source:package:reference">2.3.5</property>
         <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.5.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.5.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "2.3.5"
-        },
-        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
         },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.5.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.5.json.bin
@@ -17,11 +17,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "2.3.5"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "2.3.5"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "2.3.5"
         }
       ],

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.5.xml.bin
@@ -63,8 +63,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">2.3.5</property>
         <property name="cdx:poetry:package:source:resolved_reference">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
         <property name="cdx:poetry:source:package:reference">2.3.5</property>
+        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
       </properties>
     </component>
     <component type="library" bom-ref="pathlib2@2.3.5">

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.5.xml.bin
@@ -63,7 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">2.3.5</property>
         <property name="cdx:poetry:package:source:resolved_reference">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
         <property name="cdx:poetry:source:package:reference">2.3.5</property>
         <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "2.3.5"
-        },
-        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
         },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.json.bin
@@ -17,11 +17,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "2.3.5"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "2.3.5"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "2.3.5"
         }
       ],

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.xml.bin
@@ -63,8 +63,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">2.3.5</property>
         <property name="cdx:poetry:package:source:resolved_reference">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
         <property name="cdx:poetry:source:package:reference">2.3.5</property>
+        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
       </properties>
     </component>
     <component type="library" bom-ref="pathlib2@2.3.5">

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.xml.bin
@@ -63,7 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">2.3.5</property>
         <property name="cdx:poetry:package:source:resolved_reference">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
         <property name="cdx:poetry:source:package:reference">2.3.5</property>
         <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.3.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.3.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
-        },
-        {
           "name": "cdx:poetry:source:package:reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -69,10 +65,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         },
         {
           "name": "cdx:poetry:source:package:reference",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.3.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.3.json.bin
@@ -17,7 +17,15 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
           "name": "cdx:poetry:source:package:reference",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         }
       ],
@@ -63,7 +71,15 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
           "name": "cdx:poetry:source:package:reference",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         }
       ],

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.3.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.3.xml.bin
@@ -36,7 +36,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:python:package:source:vcs:requested_revision">da59ad000d1405eaecd557175e29083a87d19f7c</property>
       </properties>
@@ -69,7 +68,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:python:package:source:vcs:requested_revision">65486e4383f9f411da95937451205d3c7b61b9e1</property>
       </properties>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.3.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.3.xml.bin
@@ -36,7 +36,9 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">da59ad000d1405eaecd557175e29083a87d19f7c</property>
       </properties>
     </component>
     <component type="library" bom-ref="numpy@1.24.4">
@@ -67,7 +69,9 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">65486e4383f9f411da95937451205d3c7b61b9e1</property>
       </properties>
     </component>
     <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.4.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.4.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
-        },
-        {
           "name": "cdx:poetry:source:package:reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -69,10 +65,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         },
         {
           "name": "cdx:poetry:source:package:reference",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.4.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.4.json.bin
@@ -17,7 +17,15 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
           "name": "cdx:poetry:source:package:reference",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         }
       ],
@@ -63,7 +71,15 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
           "name": "cdx:poetry:source:package:reference",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         }
       ],

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.4.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.4.xml.bin
@@ -63,7 +63,9 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">da59ad000d1405eaecd557175e29083a87d19f7c</property>
       </properties>
     </component>
     <component type="library" bom-ref="numpy@1.24.4">
@@ -94,7 +96,9 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">65486e4383f9f411da95937451205d3c7b61b9e1</property>
       </properties>
     </component>
     <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.4.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.4.xml.bin
@@ -63,7 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:python:package:source:vcs:requested_revision">da59ad000d1405eaecd557175e29083a87d19f7c</property>
       </properties>
@@ -96,7 +95,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:python:package:source:vcs:requested_revision">65486e4383f9f411da95937451205d3c7b61b9e1</property>
       </properties>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.5.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.5.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
-        },
-        {
           "name": "cdx:poetry:source:package:reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -69,10 +65,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         },
         {
           "name": "cdx:poetry:source:package:reference",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.5.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.5.json.bin
@@ -17,7 +17,15 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
           "name": "cdx:poetry:source:package:reference",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         }
       ],
@@ -63,7 +71,15 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
           "name": "cdx:poetry:source:package:reference",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         }
       ],

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.5.xml.bin
@@ -63,7 +63,9 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">da59ad000d1405eaecd557175e29083a87d19f7c</property>
       </properties>
     </component>
     <component type="library" bom-ref="numpy@1.24.4">
@@ -94,7 +96,9 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">65486e4383f9f411da95937451205d3c7b61b9e1</property>
       </properties>
     </component>
     <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.5.xml.bin
@@ -63,7 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:python:package:source:vcs:requested_revision">da59ad000d1405eaecd557175e29083a87d19f7c</property>
       </properties>
@@ -96,7 +95,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:python:package:source:vcs:requested_revision">65486e4383f9f411da95937451205d3c7b61b9e1</property>
       </properties>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.6.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
-        },
-        {
           "name": "cdx:poetry:source:package:reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -69,10 +65,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         },
         {
           "name": "cdx:poetry:source:package:reference",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.6.json.bin
@@ -17,7 +17,15 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
           "name": "cdx:poetry:source:package:reference",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         }
       ],
@@ -63,7 +71,15 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
           "name": "cdx:poetry:source:package:reference",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         }
       ],

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.6.xml.bin
@@ -63,7 +63,9 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">da59ad000d1405eaecd557175e29083a87d19f7c</property>
       </properties>
     </component>
     <component type="library" bom-ref="numpy@1.24.4">
@@ -94,7 +96,9 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">65486e4383f9f411da95937451205d3c7b61b9e1</property>
       </properties>
     </component>
     <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.6.xml.bin
@@ -63,7 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:python:package:source:vcs:requested_revision">da59ad000d1405eaecd557175e29083a87d19f7c</property>
       </properties>
@@ -96,7 +95,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:python:package:source:vcs:requested_revision">65486e4383f9f411da95937451205d3c7b61b9e1</property>
       </properties>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.3.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.3.json.bin
@@ -17,11 +17,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "10.1.0"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "10.1.0"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "10.1.0"
         }
       ],
@@ -67,11 +79,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "1.16.0"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "1.16.0"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "1.16.0"
         }
       ],

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.3.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.3.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "10.1.0"
-        },
-        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -77,10 +73,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "1.16.0"
         },
         {
           "name": "cdx:poetry:package:source:resolved_reference",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.3.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.3.xml.bin
@@ -36,8 +36,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">10.1.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">10.1.0</property>
+        <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">10.1.0</property>
       </properties>
     </component>
     <component type="library" bom-ref="numpy@1.24.4">
@@ -68,8 +71,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">1.16.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">1.16.0</property>
+        <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">1.16.0</property>
       </properties>
     </component>
     <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.3.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.3.xml.bin
@@ -36,7 +36,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">10.1.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">10.1.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
@@ -71,7 +70,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">1.16.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">1.16.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.4.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.4.json.bin
@@ -17,11 +17,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "10.1.0"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "10.1.0"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "10.1.0"
         }
       ],
@@ -67,11 +79,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "1.16.0"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "1.16.0"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "1.16.0"
         }
       ],

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.4.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.4.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "10.1.0"
-        },
-        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -77,10 +73,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "1.16.0"
         },
         {
           "name": "cdx:poetry:package:source:resolved_reference",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.4.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.4.xml.bin
@@ -63,7 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">10.1.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">10.1.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
@@ -98,7 +97,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">1.16.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">1.16.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.4.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.4.xml.bin
@@ -63,8 +63,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">10.1.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">10.1.0</property>
+        <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">10.1.0</property>
       </properties>
     </component>
     <component type="library" bom-ref="numpy@1.24.4">
@@ -95,8 +98,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">1.16.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">1.16.0</property>
+        <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">1.16.0</property>
       </properties>
     </component>
     <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.5.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.5.json.bin
@@ -17,11 +17,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "10.1.0"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "10.1.0"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "10.1.0"
         }
       ],
@@ -67,11 +79,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "1.16.0"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "1.16.0"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "1.16.0"
         }
       ],

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.5.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.5.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "10.1.0"
-        },
-        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -77,10 +73,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "1.16.0"
         },
         {
           "name": "cdx:poetry:package:source:resolved_reference",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.5.xml.bin
@@ -63,7 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">10.1.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">10.1.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
@@ -98,7 +97,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">1.16.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">1.16.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.5.xml.bin
@@ -63,8 +63,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">10.1.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">10.1.0</property>
+        <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">10.1.0</property>
       </properties>
     </component>
     <component type="library" bom-ref="numpy@1.24.4">
@@ -95,8 +98,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">1.16.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">1.16.0</property>
+        <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">1.16.0</property>
       </properties>
     </component>
     <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.6.json.bin
@@ -17,11 +17,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "10.1.0"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "10.1.0"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "10.1.0"
         }
       ],
@@ -67,11 +79,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "1.16.0"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "1.16.0"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "1.16.0"
         }
       ],

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.6.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "10.1.0"
-        },
-        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -77,10 +73,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "1.16.0"
         },
         {
           "name": "cdx:poetry:package:source:resolved_reference",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.6.xml.bin
@@ -63,7 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">10.1.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">10.1.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
@@ -98,7 +97,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">1.16.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">1.16.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.6.xml.bin
@@ -63,8 +63,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">10.1.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">10.1.0</property>
+        <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">10.1.0</property>
       </properties>
     </component>
     <component type="library" bom-ref="numpy@1.24.4">
@@ -95,8 +98,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">1.16.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">1.16.0</property>
+        <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">1.16.0</property>
       </properties>
     </component>
     <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.3.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.3.json.bin
@@ -17,11 +17,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "10.1.0"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "10.1.0"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "10.1.0"
         }
       ],
@@ -73,11 +85,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "1.16.0"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "1.16.0"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "1.16.0"
         }
       ],

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.3.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.3.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "10.1.0"
-        },
-        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -83,10 +79,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "1.16.0"
         },
         {
           "name": "cdx:poetry:package:source:resolved_reference",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.3.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.3.xml.bin
@@ -36,7 +36,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">10.1.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">10.1.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
@@ -74,7 +73,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">1.16.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">1.16.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.3.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.3.xml.bin
@@ -36,8 +36,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">10.1.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">10.1.0</property>
+        <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">10.1.0</property>
       </properties>
     </component>
     <component type="library" bom-ref="numpy@1.24.4">
@@ -71,8 +74,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">1.16.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">1.16.0</property>
+        <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">1.16.0</property>
       </properties>
     </component>
     <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.4.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.4.json.bin
@@ -17,11 +17,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "10.1.0"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "10.1.0"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "10.1.0"
         }
       ],
@@ -73,11 +85,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "1.16.0"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "1.16.0"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "1.16.0"
         }
       ],

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.4.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.4.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "10.1.0"
-        },
-        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -83,10 +79,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "1.16.0"
         },
         {
           "name": "cdx:poetry:package:source:resolved_reference",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.4.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.4.xml.bin
@@ -63,8 +63,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">10.1.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">10.1.0</property>
+        <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">10.1.0</property>
       </properties>
     </component>
     <component type="library" bom-ref="numpy@1.24.4">
@@ -98,8 +101,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">1.16.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">1.16.0</property>
+        <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">1.16.0</property>
       </properties>
     </component>
     <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.4.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.4.xml.bin
@@ -63,7 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">10.1.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">10.1.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
@@ -101,7 +100,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">1.16.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">1.16.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.5.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.5.json.bin
@@ -17,11 +17,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "10.1.0"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "10.1.0"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "10.1.0"
         }
       ],
@@ -73,11 +85,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "1.16.0"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "1.16.0"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "1.16.0"
         }
       ],

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.5.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.5.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "10.1.0"
-        },
-        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -83,10 +79,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "1.16.0"
         },
         {
           "name": "cdx:poetry:package:source:resolved_reference",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.5.xml.bin
@@ -63,8 +63,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">10.1.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">10.1.0</property>
+        <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">10.1.0</property>
       </properties>
     </component>
     <component type="library" bom-ref="numpy@1.24.4">
@@ -98,8 +101,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">1.16.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">1.16.0</property>
+        <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">1.16.0</property>
       </properties>
     </component>
     <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.5.xml.bin
@@ -63,7 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">10.1.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">10.1.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
@@ -101,7 +100,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">1.16.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">1.16.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.6.json.bin
@@ -17,11 +17,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "10.1.0"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "10.1.0"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "10.1.0"
         }
       ],
@@ -73,11 +85,23 @@
           "value": "main"
         },
         {
+          "name": "cdx:poetry:package:source:reference",
+          "value": "1.16.0"
+        },
+        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         },
         {
           "name": "cdx:poetry:source:package:reference",
+          "value": "1.16.0"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "1.16.0"
         }
       ],

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.6.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "10.1.0"
-        },
-        {
           "name": "cdx:poetry:package:source:resolved_reference",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -83,10 +79,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:reference",
-          "value": "1.16.0"
         },
         {
           "name": "cdx:poetry:package:source:resolved_reference",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.6.xml.bin
@@ -63,8 +63,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">10.1.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">10.1.0</property>
+        <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">10.1.0</property>
       </properties>
     </component>
     <component type="library" bom-ref="numpy@1.24.4">
@@ -98,8 +101,11 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+        <property name="cdx:poetry:package:source:reference">1.16.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">1.16.0</property>
+        <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">1.16.0</property>
       </properties>
     </component>
     <component type="library" bom-ref="wxPython@4.2.2a1.dev5618+1f82021f">

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.6.xml.bin
@@ -63,7 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">10.1.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:poetry:source:package:reference">10.1.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
@@ -101,7 +100,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:reference">1.16.0</property>
         <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:poetry:source:package:reference">1.16.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>


### PR DESCRIPTION
populate the newly added/fixed CycloneDX properties `cdx:python:package:source:vcs:...` in accordance with <https://github.com/CycloneDX/cyclonedx-property-taxonomy/pull/96> and <https://github.com/CycloneDX/cyclonedx-property-taxonomy/pull/98>.

the deprecated properties are still used, so no breaking changes exist.

fixes #789 