### PR TITLE
feat!: drop deprecated properties `cdx:poetry:...`

### DIFF
--- a/cyclonedx_py/_internal/__init__.py
+++ b/cyclonedx_py/_internal/__init__.py
@@ -71,13 +71,6 @@ class PropertyName(Enum):
     # region poetry
     # see https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/poetry.md
     PoetryGroup = 'cdx:poetry:group'
-    # region poetry-deprecated
-    # the following property names are deprecated
-    PoetryPackageSourceReference_misspelled = 'cdx:poetry:source:package:reference'
-    PoetryPackageSourceResolvedReference = 'cdx:poetry:package:source:resolved_reference'
-    PoetryPackageSourceVcsRequestedRevision = 'cdx:poetry:package:source:vcs:requested_revision'
-    PoetryPackageSourceVcsCommitId = 'cdx:poetry:package:source:vcs:commit_id'
-    # endregion poetry-deprecated
     # endregion poetry
 
     # region pipenv

--- a/cyclonedx_py/_internal/environment.py
+++ b/cyclonedx_py/_internal/environment.py
@@ -245,15 +245,9 @@ class EnvironmentBB(BomBuilder):
                 component.properties.add(Property(
                     name=PropertyName.PythonPackageSourceVcsCommitId.value,
                     value=packagesource.commit_id))
-                component.properties.add(Property(
-                    name=PropertyName.PoetryPackageSourceVcsCommitId.value,  # deprecated
-                    value=packagesource.commit_id))
                 if packagesource.requested_revision:
                     component.properties.add(Property(
                         name=PropertyName.PythonPackageSourceVcsRequestedRevision.value,
-                        value=packagesource.requested_revision))
-                    component.properties.add(Property(
-                        name=PropertyName.PoetryPackageSourceVcsRequestedRevision.value,  # deprecated
                         value=packagesource.requested_revision))
             elif isinstance(packagesource, PackageSourceArchive):
                 if '://files.pythonhosted.org/' not in packagesource.url:

--- a/cyclonedx_py/_internal/poetry.py
+++ b/cyclonedx_py/_internal/poetry.py
@@ -416,16 +416,6 @@ class PoetryBB(BomBuilder):
                     name=PropertyName.PoetryGroup.value,
                     value=package['category']
                 ) if 'category' in package else None,
-                # region deprecated
-                Property(
-                    name=PropertyName.PoetryPackageSourceReference_misspelled.value,  # deprecated
-                    value=source['reference']
-                ) if is_vcs and 'reference' in source else None,
-                Property(
-                    name=PropertyName.PoetryPackageSourceResolvedReference.value,  # deprecated
-                    value=source['resolved_reference']
-                ) if is_vcs and 'resolved_reference' in source else None,
-                # endregion deprecated
             )),
             purl=PackageURL(
                 type=PurlTypePypi,

--- a/tests/_data/snapshots/environment/plain_with-urls_1.3.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.3.json.bin
@@ -35,14 +35,6 @@
       "name": "packaging",
       "properties": [
         {
-          "name": "cdx:poetry:package:source:vcs:commit_id",
-          "value": "b3a5d7d68991c040615d5345bb55f61de53ba176"
-        },
-        {
-          "name": "cdx:poetry:package:source:vcs:requested_revision",
-          "value": "23.2"
-        },
-        {
           "name": "cdx:python:package:source:vcs:commit_id",
           "value": "b3a5d7d68991c040615d5345bb55f61de53ba176"
         },

--- a/tests/_data/snapshots/environment/plain_with-urls_1.3.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.3.xml.bin
@@ -51,8 +51,6 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:poetry:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
-        <property name="cdx:poetry:package:source:vcs:requested_revision">23.2</property>
         <property name="cdx:python:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
         <property name="cdx:python:package:source:vcs:requested_revision">23.2</property>
       </properties>

--- a/tests/_data/snapshots/environment/plain_with-urls_1.4.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.4.json.bin
@@ -35,14 +35,6 @@
       "name": "packaging",
       "properties": [
         {
-          "name": "cdx:poetry:package:source:vcs:commit_id",
-          "value": "b3a5d7d68991c040615d5345bb55f61de53ba176"
-        },
-        {
-          "name": "cdx:poetry:package:source:vcs:requested_revision",
-          "value": "23.2"
-        },
-        {
           "name": "cdx:python:package:source:vcs:commit_id",
           "value": "b3a5d7d68991c040615d5345bb55f61de53ba176"
         },

--- a/tests/_data/snapshots/environment/plain_with-urls_1.4.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.4.xml.bin
@@ -78,8 +78,6 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:poetry:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
-        <property name="cdx:poetry:package:source:vcs:requested_revision">23.2</property>
         <property name="cdx:python:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
         <property name="cdx:python:package:source:vcs:requested_revision">23.2</property>
       </properties>

--- a/tests/_data/snapshots/environment/plain_with-urls_1.5.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.5.json.bin
@@ -35,14 +35,6 @@
       "name": "packaging",
       "properties": [
         {
-          "name": "cdx:poetry:package:source:vcs:commit_id",
-          "value": "b3a5d7d68991c040615d5345bb55f61de53ba176"
-        },
-        {
-          "name": "cdx:poetry:package:source:vcs:requested_revision",
-          "value": "23.2"
-        },
-        {
           "name": "cdx:python:package:source:vcs:commit_id",
           "value": "b3a5d7d68991c040615d5345bb55f61de53ba176"
         },

--- a/tests/_data/snapshots/environment/plain_with-urls_1.5.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.5.xml.bin
@@ -78,8 +78,6 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:poetry:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
-        <property name="cdx:poetry:package:source:vcs:requested_revision">23.2</property>
         <property name="cdx:python:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
         <property name="cdx:python:package:source:vcs:requested_revision">23.2</property>
       </properties>

--- a/tests/_data/snapshots/environment/plain_with-urls_1.6.json.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.6.json.bin
@@ -37,14 +37,6 @@
       "name": "packaging",
       "properties": [
         {
-          "name": "cdx:poetry:package:source:vcs:commit_id",
-          "value": "b3a5d7d68991c040615d5345bb55f61de53ba176"
-        },
-        {
-          "name": "cdx:poetry:package:source:vcs:requested_revision",
-          "value": "23.2"
-        },
-        {
           "name": "cdx:python:package:source:vcs:commit_id",
           "value": "b3a5d7d68991c040615d5345bb55f61de53ba176"
         },

--- a/tests/_data/snapshots/environment/plain_with-urls_1.6.xml.bin
+++ b/tests/_data/snapshots/environment/plain_with-urls_1.6.xml.bin
@@ -78,8 +78,6 @@
         </reference>
       </externalReferences>
       <properties>
-        <property name="cdx:poetry:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
-        <property name="cdx:poetry:package:source:vcs:requested_revision">23.2</property>
         <property name="cdx:python:package:source:vcs:commit_id">b3a5d7d68991c040615d5345bb55f61de53ba176</property>
         <property name="cdx:python:package:source:vcs:requested_revision">23.2</property>
       </properties>

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.3.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.3.json.bin
@@ -17,14 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "2.3.5"
-        },
-        {
           "name": "cdx:python:package:source:vcs:commit_id",
           "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
         },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.3.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.3.xml.bin
@@ -36,8 +36,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
-        <property name="cdx:poetry:source:package:reference">2.3.5</property>
         <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
         <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
       </properties>

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.4.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.4.json.bin
@@ -17,14 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "2.3.5"
-        },
-        {
           "name": "cdx:python:package:source:vcs:commit_id",
           "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
         },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.4.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.4.xml.bin
@@ -63,8 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
-        <property name="cdx:poetry:source:package:reference">2.3.5</property>
         <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
         <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
       </properties>

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.5.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.5.json.bin
@@ -17,14 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "2.3.5"
-        },
-        {
           "name": "cdx:python:package:source:vcs:commit_id",
           "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
         },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.5.xml.bin
@@ -63,8 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
-        <property name="cdx:poetry:source:package:reference">2.3.5</property>
         <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
         <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
       </properties>

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.json.bin
@@ -17,14 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "2.3.5"
-        },
-        {
           "name": "cdx:python:package:source:vcs:commit_id",
           "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
         },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.xml.bin
@@ -63,8 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
-        <property name="cdx:poetry:source:package:reference">2.3.5</property>
         <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
         <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
       </properties>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.3.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.3.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
-        },
-        {
           "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         }
@@ -65,10 +61,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         },
         {
           "name": "cdx:python:package:source:vcs:requested_revision",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.3.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.3.xml.bin
@@ -36,7 +36,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:source:package:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:python:package:source:vcs:requested_revision">da59ad000d1405eaecd557175e29083a87d19f7c</property>
       </properties>
     </component>
@@ -68,7 +67,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:source:package:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:python:package:source:vcs:requested_revision">65486e4383f9f411da95937451205d3c7b61b9e1</property>
       </properties>
     </component>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.4.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.4.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
-        },
-        {
           "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         }
@@ -65,10 +61,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         },
         {
           "name": "cdx:python:package:source:vcs:requested_revision",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.4.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.4.xml.bin
@@ -63,7 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:source:package:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:python:package:source:vcs:requested_revision">da59ad000d1405eaecd557175e29083a87d19f7c</property>
       </properties>
     </component>
@@ -95,7 +94,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:source:package:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:python:package:source:vcs:requested_revision">65486e4383f9f411da95937451205d3c7b61b9e1</property>
       </properties>
     </component>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.5.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.5.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
-        },
-        {
           "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         }
@@ -65,10 +61,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         },
         {
           "name": "cdx:python:package:source:vcs:requested_revision",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.5.xml.bin
@@ -63,7 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:source:package:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:python:package:source:vcs:requested_revision">da59ad000d1405eaecd557175e29083a87d19f7c</property>
       </properties>
     </component>
@@ -95,7 +94,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:source:package:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:python:package:source:vcs:requested_revision">65486e4383f9f411da95937451205d3c7b61b9e1</property>
       </properties>
     </component>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.6.json.bin
@@ -17,10 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
-        },
-        {
           "name": "cdx:python:package:source:vcs:requested_revision",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         }
@@ -65,10 +61,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
         },
         {
           "name": "cdx:python:package:source:vcs:requested_revision",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock10_1.6.xml.bin
@@ -63,7 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:source:package:reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:python:package:source:vcs:requested_revision">da59ad000d1405eaecd557175e29083a87d19f7c</property>
       </properties>
     </component>
@@ -95,7 +94,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:source:package:reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:python:package:source:vcs:requested_revision">65486e4383f9f411da95937451205d3c7b61b9e1</property>
       </properties>
     </component>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.3.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.3.json.bin
@@ -17,14 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "10.1.0"
-        },
-        {
           "name": "cdx:python:package:source:vcs:commit_id",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -73,14 +65,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "1.16.0"
         },
         {
           "name": "cdx:python:package:source:vcs:commit_id",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.3.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.3.xml.bin
@@ -36,8 +36,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
-        <property name="cdx:poetry:source:package:reference">10.1.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:python:package:source:vcs:requested_revision">10.1.0</property>
       </properties>
@@ -70,8 +68,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
-        <property name="cdx:poetry:source:package:reference">1.16.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:python:package:source:vcs:requested_revision">1.16.0</property>
       </properties>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.4.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.4.json.bin
@@ -17,14 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "10.1.0"
-        },
-        {
           "name": "cdx:python:package:source:vcs:commit_id",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -73,14 +65,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "1.16.0"
         },
         {
           "name": "cdx:python:package:source:vcs:commit_id",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.4.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.4.xml.bin
@@ -63,8 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
-        <property name="cdx:poetry:source:package:reference">10.1.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:python:package:source:vcs:requested_revision">10.1.0</property>
       </properties>
@@ -97,8 +95,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
-        <property name="cdx:poetry:source:package:reference">1.16.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:python:package:source:vcs:requested_revision">1.16.0</property>
       </properties>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.5.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.5.json.bin
@@ -17,14 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "10.1.0"
-        },
-        {
           "name": "cdx:python:package:source:vcs:commit_id",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -73,14 +65,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "1.16.0"
         },
         {
           "name": "cdx:python:package:source:vcs:commit_id",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.5.xml.bin
@@ -63,8 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
-        <property name="cdx:poetry:source:package:reference">10.1.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:python:package:source:vcs:requested_revision">10.1.0</property>
       </properties>
@@ -97,8 +95,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
-        <property name="cdx:poetry:source:package:reference">1.16.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:python:package:source:vcs:requested_revision">1.16.0</property>
       </properties>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.6.json.bin
@@ -17,14 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "10.1.0"
-        },
-        {
           "name": "cdx:python:package:source:vcs:commit_id",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -73,14 +65,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "1.16.0"
         },
         {
           "name": "cdx:python:package:source:vcs:commit_id",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock11_1.6.xml.bin
@@ -63,8 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
-        <property name="cdx:poetry:source:package:reference">10.1.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:python:package:source:vcs:requested_revision">10.1.0</property>
       </properties>
@@ -97,8 +95,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
-        <property name="cdx:poetry:source:package:reference">1.16.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:python:package:source:vcs:requested_revision">1.16.0</property>
       </properties>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.3.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.3.json.bin
@@ -17,14 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "10.1.0"
-        },
-        {
           "name": "cdx:python:package:source:vcs:commit_id",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -79,14 +71,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "1.16.0"
         },
         {
           "name": "cdx:python:package:source:vcs:commit_id",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.3.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.3.xml.bin
@@ -36,8 +36,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
-        <property name="cdx:poetry:source:package:reference">10.1.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:python:package:source:vcs:requested_revision">10.1.0</property>
       </properties>
@@ -73,8 +71,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
-        <property name="cdx:poetry:source:package:reference">1.16.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:python:package:source:vcs:requested_revision">1.16.0</property>
       </properties>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.4.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.4.json.bin
@@ -17,14 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "10.1.0"
-        },
-        {
           "name": "cdx:python:package:source:vcs:commit_id",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -79,14 +71,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "1.16.0"
         },
         {
           "name": "cdx:python:package:source:vcs:commit_id",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.4.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.4.xml.bin
@@ -63,8 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
-        <property name="cdx:poetry:source:package:reference">10.1.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:python:package:source:vcs:requested_revision">10.1.0</property>
       </properties>
@@ -100,8 +98,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
-        <property name="cdx:poetry:source:package:reference">1.16.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:python:package:source:vcs:requested_revision">1.16.0</property>
       </properties>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.5.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.5.json.bin
@@ -17,14 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "10.1.0"
-        },
-        {
           "name": "cdx:python:package:source:vcs:commit_id",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -79,14 +71,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "1.16.0"
         },
         {
           "name": "cdx:python:package:source:vcs:commit_id",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.5.xml.bin
@@ -63,8 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
-        <property name="cdx:poetry:source:package:reference">10.1.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:python:package:source:vcs:requested_revision">10.1.0</property>
       </properties>
@@ -100,8 +98,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
-        <property name="cdx:poetry:source:package:reference">1.16.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:python:package:source:vcs:requested_revision">1.16.0</property>
       </properties>

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.6.json.bin
@@ -17,14 +17,6 @@
           "value": "main"
         },
         {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "10.1.0"
-        },
-        {
           "name": "cdx:python:package:source:vcs:commit_id",
           "value": "da59ad000d1405eaecd557175e29083a87d19f7c"
         },
@@ -79,14 +71,6 @@
         {
           "name": "cdx:poetry:group",
           "value": "main"
-        },
-        {
-          "name": "cdx:poetry:package:source:resolved_reference",
-          "value": "65486e4383f9f411da95937451205d3c7b61b9e1"
-        },
-        {
-          "name": "cdx:poetry:source:package:reference",
-          "value": "1.16.0"
         },
         {
           "name": "cdx:python:package:source:vcs:commit_id",

--- a/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_with-urls_lock20_1.6.xml.bin
@@ -63,8 +63,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">da59ad000d1405eaecd557175e29083a87d19f7c</property>
-        <property name="cdx:poetry:source:package:reference">10.1.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">da59ad000d1405eaecd557175e29083a87d19f7c</property>
         <property name="cdx:python:package:source:vcs:requested_revision">10.1.0</property>
       </properties>
@@ -100,8 +98,6 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
-        <property name="cdx:poetry:package:source:resolved_reference">65486e4383f9f411da95937451205d3c7b61b9e1</property>
-        <property name="cdx:poetry:source:package:reference">1.16.0</property>
         <property name="cdx:python:package:source:vcs:commit_id">65486e4383f9f411da95937451205d3c7b61b9e1</property>
         <property name="cdx:python:package:source:vcs:requested_revision">1.16.0</property>
       </properties>


### PR DESCRIPTION
some properties in the namespace `cdx:poetry` were deprecated. they are no longer emitted.
- `cdx:poetry:source:package:reference`
- `cdx:poetry:package:source:resolved_reference`
- `cdx:poetry:package:source:vcs:requested_revision`
- `cdx:poetry:package:source:vcs:commit_id`


fixes #792