### PR TITLE
chore: run tox w/o sdist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ minversion = 4.0
 envlist =
     flake8
     mypy-{current,lowest}
-    py{311,310,39,38}
+    py{312,311,310,39,38}
     bandit
 skip_missing_interpreters = True
 usedevelop = False
@@ -17,6 +17,7 @@ download = False
 [testenv]
 # settings in this category apply to all other testenv, if not overwritten
 skip_install = False
+package = wheel
 allowlist_externals = poetry
 ## deps = poetry ## << this one caused https://github.com/python-poetry/poetry/issues/6288
 commands_pre =
@@ -42,5 +43,6 @@ commands =
     poetry run flake8 cyclonedx_py/ tests/
 
 [testenv:bandit]
+skip_install = True
 commands =
     poetry run bandit -c bandit.yml -v -r cyclonedx_py tests


### PR DESCRIPTION
our sdist config ships tests and docs.

when you have a lot of venvs laying around in the `tests` or `docs` flder, then `poetry build -f sdist` crashes ... a known bug of poetry ... 

per default, tox installs in sdist mode .... 
this causes issues locally, ... which is annoying. 

here is a workaround: dont build sdist, build wheel only.