### PR TITLE
feat: add support for `cyclonedx-python-lib>=9.0<10`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ cyclonedx-py = "cyclonedx_py._internal.cli:run"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-cyclonedx-python-lib = { version = "^8.0", extras = ["validation"] }
+cyclonedx-python-lib = { version = "^8.0 || ^9.0", extras = ["validation"] }
 packageurl-python = ">=0.11, <2"  # keep in sync with same dep in `cyclonedx-python-lib`
 pip-requirements-parser = "^32.0"
 packaging = "^22 || ^23 || ^24"

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.0.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.0.xml.bin
@@ -5,14 +5,14 @@
       <name>pathlib2</name>
       <version>2.3.5</version>
       <description>Object-oriented filesystem paths</description>
-      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
+      <purl>pkg:pypi/pathlib2@2.3.5</purl>
       <modified>false</modified>
     </component>
     <component type="library">
       <name>pathlib2</name>
       <version>2.3.5</version>
       <description>Object-oriented filesystem paths</description>
-      <purl>pkg:pypi/pathlib2@2.3.5</purl>
+      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
       <modified>false</modified>
     </component>
     <component type="library">

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.1.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.1.xml.bin
@@ -1,18 +1,6 @@
 <?xml version="1.0" ?>
 <bom xmlns="http://cyclonedx.org/schema/bom/1.1" version="1">
   <components>
-    <component type="library" bom-ref="pathlib2@2.3.5#1">
-      <name>pathlib2</name>
-      <version>2.3.5</version>
-      <description>Object-oriented filesystem paths</description>
-      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
-          <comment>from VCS</comment>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="pathlib2@2.3.5">
       <name>pathlib2</name>
       <version>2.3.5</version>
@@ -26,6 +14,18 @@
         <reference type="distribution">
           <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.5.tar.gz</url>
           <comment>from legacy-api</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pathlib2@2.3.5#1">
+      <name>pathlib2</name>
+      <version>2.3.5</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
+          <comment>from VCS</comment>
         </reference>
       </externalReferences>
     </component>

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.2.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.2.json.bin
@@ -1,21 +1,6 @@
 {
   "components": [
     {
-      "bom-ref": "pathlib2@2.3.5#1",
-      "description": "Object-oriented filesystem paths",
-      "externalReferences": [
-        {
-          "comment": "from VCS",
-          "type": "vcs",
-          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        }
-      ],
-      "name": "pathlib2",
-      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
-      "type": "library",
-      "version": "2.3.5"
-    },
-    {
       "bom-ref": "pathlib2@2.3.5",
       "description": "Object-oriented filesystem paths",
       "externalReferences": [
@@ -32,6 +17,21 @@
       ],
       "name": "pathlib2",
       "purl": "pkg:pypi/pathlib2@2.3.5",
+      "type": "library",
+      "version": "2.3.5"
+    },
+    {
+      "bom-ref": "pathlib2@2.3.5#1",
+      "description": "Object-oriented filesystem paths",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        }
+      ],
+      "name": "pathlib2",
+      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
       "type": "library",
       "version": "2.3.5"
     },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.2.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.2.xml.bin
@@ -20,18 +20,6 @@
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="pathlib2@2.3.5#1">
-      <name>pathlib2</name>
-      <version>2.3.5</version>
-      <description>Object-oriented filesystem paths</description>
-      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
-          <comment>from VCS</comment>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="pathlib2@2.3.5">
       <name>pathlib2</name>
       <version>2.3.5</version>
@@ -45,6 +33,18 @@
         <reference type="distribution">
           <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.5.tar.gz</url>
           <comment>from legacy-api</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pathlib2@2.3.5#1">
+      <name>pathlib2</name>
+      <version>2.3.5</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
+          <comment>from VCS</comment>
         </reference>
       </externalReferences>
     </component>

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.3.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.3.json.bin
@@ -1,35 +1,6 @@
 {
   "components": [
     {
-      "bom-ref": "pathlib2@2.3.5#1",
-      "description": "Object-oriented filesystem paths",
-      "externalReferences": [
-        {
-          "comment": "from VCS",
-          "type": "vcs",
-          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        }
-      ],
-      "name": "pathlib2",
-      "properties": [
-        {
-          "name": "cdx:poetry:group",
-          "value": "main"
-        },
-        {
-          "name": "cdx:python:package:source:vcs:commit_id",
-          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        },
-        {
-          "name": "cdx:python:package:source:vcs:requested_revision",
-          "value": "2.3.5"
-        }
-      ],
-      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
-      "type": "library",
-      "version": "2.3.5"
-    },
-    {
       "bom-ref": "pathlib2@2.3.5",
       "description": "Object-oriented filesystem paths",
       "externalReferences": [
@@ -64,6 +35,35 @@
         }
       ],
       "purl": "pkg:pypi/pathlib2@2.3.5",
+      "type": "library",
+      "version": "2.3.5"
+    },
+    {
+      "bom-ref": "pathlib2@2.3.5#1",
+      "description": "Object-oriented filesystem paths",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        }
+      ],
+      "name": "pathlib2",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
+          "value": "2.3.5"
+        }
+      ],
+      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
       "type": "library",
       "version": "2.3.5"
     },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.3.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.3.xml.bin
@@ -23,23 +23,6 @@
     </properties>
   </metadata>
   <components>
-    <component type="library" bom-ref="pathlib2@2.3.5#1">
-      <name>pathlib2</name>
-      <version>2.3.5</version>
-      <description>Object-oriented filesystem paths</description>
-      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
-          <comment>from VCS</comment>
-        </reference>
-      </externalReferences>
-      <properties>
-        <property name="cdx:poetry:group">main</property>
-        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
-        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
-      </properties>
-    </component>
     <component type="library" bom-ref="pathlib2@2.3.5">
       <name>pathlib2</name>
       <version>2.3.5</version>
@@ -63,6 +46,23 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pathlib2@2.3.5#1">
+      <name>pathlib2</name>
+      <version>2.3.5</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
       </properties>
     </component>
     <component type="library" bom-ref="pathlib2@2.3.6#2">

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.4.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.4.json.bin
@@ -1,35 +1,6 @@
 {
   "components": [
     {
-      "bom-ref": "pathlib2@2.3.5#1",
-      "description": "Object-oriented filesystem paths",
-      "externalReferences": [
-        {
-          "comment": "from VCS",
-          "type": "vcs",
-          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        }
-      ],
-      "name": "pathlib2",
-      "properties": [
-        {
-          "name": "cdx:poetry:group",
-          "value": "main"
-        },
-        {
-          "name": "cdx:python:package:source:vcs:commit_id",
-          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        },
-        {
-          "name": "cdx:python:package:source:vcs:requested_revision",
-          "value": "2.3.5"
-        }
-      ],
-      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
-      "type": "library",
-      "version": "2.3.5"
-    },
-    {
       "bom-ref": "pathlib2@2.3.5",
       "description": "Object-oriented filesystem paths",
       "externalReferences": [
@@ -64,6 +35,35 @@
         }
       ],
       "purl": "pkg:pypi/pathlib2@2.3.5",
+      "type": "library",
+      "version": "2.3.5"
+    },
+    {
+      "bom-ref": "pathlib2@2.3.5#1",
+      "description": "Object-oriented filesystem paths",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        }
+      ],
+      "name": "pathlib2",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
+          "value": "2.3.5"
+        }
+      ],
+      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
       "type": "library",
       "version": "2.3.5"
     },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.4.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.4.xml.bin
@@ -50,23 +50,6 @@
     </properties>
   </metadata>
   <components>
-    <component type="library" bom-ref="pathlib2@2.3.5#1">
-      <name>pathlib2</name>
-      <version>2.3.5</version>
-      <description>Object-oriented filesystem paths</description>
-      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
-          <comment>from VCS</comment>
-        </reference>
-      </externalReferences>
-      <properties>
-        <property name="cdx:poetry:group">main</property>
-        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
-        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
-      </properties>
-    </component>
     <component type="library" bom-ref="pathlib2@2.3.5">
       <name>pathlib2</name>
       <version>2.3.5</version>
@@ -90,6 +73,23 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pathlib2@2.3.5#1">
+      <name>pathlib2</name>
+      <version>2.3.5</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
       </properties>
     </component>
     <component type="library" bom-ref="pathlib2@2.3.6#2">

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.5.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.5.json.bin
@@ -1,35 +1,6 @@
 {
   "components": [
     {
-      "bom-ref": "pathlib2@2.3.5#1",
-      "description": "Object-oriented filesystem paths",
-      "externalReferences": [
-        {
-          "comment": "from VCS",
-          "type": "vcs",
-          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        }
-      ],
-      "name": "pathlib2",
-      "properties": [
-        {
-          "name": "cdx:poetry:group",
-          "value": "main"
-        },
-        {
-          "name": "cdx:python:package:source:vcs:commit_id",
-          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        },
-        {
-          "name": "cdx:python:package:source:vcs:requested_revision",
-          "value": "2.3.5"
-        }
-      ],
-      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
-      "type": "library",
-      "version": "2.3.5"
-    },
-    {
       "bom-ref": "pathlib2@2.3.5",
       "description": "Object-oriented filesystem paths",
       "externalReferences": [
@@ -64,6 +35,35 @@
         }
       ],
       "purl": "pkg:pypi/pathlib2@2.3.5",
+      "type": "library",
+      "version": "2.3.5"
+    },
+    {
+      "bom-ref": "pathlib2@2.3.5#1",
+      "description": "Object-oriented filesystem paths",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        }
+      ],
+      "name": "pathlib2",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
+          "value": "2.3.5"
+        }
+      ],
+      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
       "type": "library",
       "version": "2.3.5"
     },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.5.xml.bin
@@ -60,23 +60,6 @@
     </properties>
   </metadata>
   <components>
-    <component type="library" bom-ref="pathlib2@2.3.5#1">
-      <name>pathlib2</name>
-      <version>2.3.5</version>
-      <description>Object-oriented filesystem paths</description>
-      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
-          <comment>from VCS</comment>
-        </reference>
-      </externalReferences>
-      <properties>
-        <property name="cdx:poetry:group">main</property>
-        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
-        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
-      </properties>
-    </component>
     <component type="library" bom-ref="pathlib2@2.3.5">
       <name>pathlib2</name>
       <version>2.3.5</version>
@@ -100,6 +83,23 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pathlib2@2.3.5#1">
+      <name>pathlib2</name>
+      <version>2.3.5</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
       </properties>
     </component>
     <component type="library" bom-ref="pathlib2@2.3.6#2">

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.json.bin
@@ -1,35 +1,6 @@
 {
   "components": [
     {
-      "bom-ref": "pathlib2@2.3.5#1",
-      "description": "Object-oriented filesystem paths",
-      "externalReferences": [
-        {
-          "comment": "from VCS",
-          "type": "vcs",
-          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        }
-      ],
-      "name": "pathlib2",
-      "properties": [
-        {
-          "name": "cdx:poetry:group",
-          "value": "main"
-        },
-        {
-          "name": "cdx:python:package:source:vcs:commit_id",
-          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        },
-        {
-          "name": "cdx:python:package:source:vcs:requested_revision",
-          "value": "2.3.5"
-        }
-      ],
-      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
-      "type": "library",
-      "version": "2.3.5"
-    },
-    {
       "bom-ref": "pathlib2@2.3.5",
       "description": "Object-oriented filesystem paths",
       "externalReferences": [
@@ -64,6 +35,35 @@
         }
       ],
       "purl": "pkg:pypi/pathlib2@2.3.5",
+      "type": "library",
+      "version": "2.3.5"
+    },
+    {
+      "bom-ref": "pathlib2@2.3.5#1",
+      "description": "Object-oriented filesystem paths",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        }
+      ],
+      "name": "pathlib2",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
+          "value": "2.3.5"
+        }
+      ],
+      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
       "type": "library",
       "version": "2.3.5"
     },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock20_1.6.xml.bin
@@ -60,23 +60,6 @@
     </properties>
   </metadata>
   <components>
-    <component type="library" bom-ref="pathlib2@2.3.5#1">
-      <name>pathlib2</name>
-      <version>2.3.5</version>
-      <description>Object-oriented filesystem paths</description>
-      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
-          <comment>from VCS</comment>
-        </reference>
-      </externalReferences>
-      <properties>
-        <property name="cdx:poetry:group">main</property>
-        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
-        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
-      </properties>
-    </component>
     <component type="library" bom-ref="pathlib2@2.3.5">
       <name>pathlib2</name>
       <version>2.3.5</version>
@@ -100,6 +83,23 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pathlib2@2.3.5#1">
+      <name>pathlib2</name>
+      <version>2.3.5</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
       </properties>
     </component>
     <component type="library" bom-ref="pathlib2@2.3.6#2">

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.0.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.0.xml.bin
@@ -5,14 +5,14 @@
       <name>pathlib2</name>
       <version>2.3.5</version>
       <description>Object-oriented filesystem paths</description>
-      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
+      <purl>pkg:pypi/pathlib2@2.3.5</purl>
       <modified>false</modified>
     </component>
     <component type="library">
       <name>pathlib2</name>
       <version>2.3.5</version>
       <description>Object-oriented filesystem paths</description>
-      <purl>pkg:pypi/pathlib2@2.3.5</purl>
+      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
       <modified>false</modified>
     </component>
     <component type="library">

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.1.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.1.xml.bin
@@ -1,18 +1,6 @@
 <?xml version="1.0" ?>
 <bom xmlns="http://cyclonedx.org/schema/bom/1.1" version="1">
   <components>
-    <component type="library" bom-ref="pathlib2@2.3.5#1">
-      <name>pathlib2</name>
-      <version>2.3.5</version>
-      <description>Object-oriented filesystem paths</description>
-      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
-          <comment>from VCS</comment>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="pathlib2@2.3.5">
       <name>pathlib2</name>
       <version>2.3.5</version>
@@ -26,6 +14,18 @@
         <reference type="distribution">
           <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.5.tar.gz</url>
           <comment>from legacy-api</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pathlib2@2.3.5#1">
+      <name>pathlib2</name>
+      <version>2.3.5</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
+          <comment>from VCS</comment>
         </reference>
       </externalReferences>
     </component>

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.2.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.2.json.bin
@@ -1,21 +1,6 @@
 {
   "components": [
     {
-      "bom-ref": "pathlib2@2.3.5#1",
-      "description": "Object-oriented filesystem paths",
-      "externalReferences": [
-        {
-          "comment": "from VCS",
-          "type": "vcs",
-          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        }
-      ],
-      "name": "pathlib2",
-      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
-      "type": "library",
-      "version": "2.3.5"
-    },
-    {
       "bom-ref": "pathlib2@2.3.5",
       "description": "Object-oriented filesystem paths",
       "externalReferences": [
@@ -32,6 +17,21 @@
       ],
       "name": "pathlib2",
       "purl": "pkg:pypi/pathlib2@2.3.5",
+      "type": "library",
+      "version": "2.3.5"
+    },
+    {
+      "bom-ref": "pathlib2@2.3.5#1",
+      "description": "Object-oriented filesystem paths",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        }
+      ],
+      "name": "pathlib2",
+      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
       "type": "library",
       "version": "2.3.5"
     },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.2.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.2.xml.bin
@@ -20,18 +20,6 @@
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="pathlib2@2.3.5#1">
-      <name>pathlib2</name>
-      <version>2.3.5</version>
-      <description>Object-oriented filesystem paths</description>
-      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
-          <comment>from VCS</comment>
-        </reference>
-      </externalReferences>
-    </component>
     <component type="library" bom-ref="pathlib2@2.3.5">
       <name>pathlib2</name>
       <version>2.3.5</version>
@@ -45,6 +33,18 @@
         <reference type="distribution">
           <url>https://pypi.org/simple/pathlib2/#pathlib2-2.3.5.tar.gz</url>
           <comment>from legacy-api</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pathlib2@2.3.5#1">
+      <name>pathlib2</name>
+      <version>2.3.5</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
+          <comment>from VCS</comment>
         </reference>
       </externalReferences>
     </component>

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.3.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.3.json.bin
@@ -1,35 +1,6 @@
 {
   "components": [
     {
-      "bom-ref": "pathlib2@2.3.5#1",
-      "description": "Object-oriented filesystem paths",
-      "externalReferences": [
-        {
-          "comment": "from VCS",
-          "type": "vcs",
-          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        }
-      ],
-      "name": "pathlib2",
-      "properties": [
-        {
-          "name": "cdx:poetry:group",
-          "value": "main"
-        },
-        {
-          "name": "cdx:python:package:source:vcs:commit_id",
-          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        },
-        {
-          "name": "cdx:python:package:source:vcs:requested_revision",
-          "value": "2.3.5"
-        }
-      ],
-      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
-      "type": "library",
-      "version": "2.3.5"
-    },
-    {
       "bom-ref": "pathlib2@2.3.5",
       "description": "Object-oriented filesystem paths",
       "externalReferences": [
@@ -64,6 +35,35 @@
         }
       ],
       "purl": "pkg:pypi/pathlib2@2.3.5",
+      "type": "library",
+      "version": "2.3.5"
+    },
+    {
+      "bom-ref": "pathlib2@2.3.5#1",
+      "description": "Object-oriented filesystem paths",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        }
+      ],
+      "name": "pathlib2",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
+          "value": "2.3.5"
+        }
+      ],
+      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
       "type": "library",
       "version": "2.3.5"
     },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.3.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.3.xml.bin
@@ -23,23 +23,6 @@
     </properties>
   </metadata>
   <components>
-    <component type="library" bom-ref="pathlib2@2.3.5#1">
-      <name>pathlib2</name>
-      <version>2.3.5</version>
-      <description>Object-oriented filesystem paths</description>
-      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
-          <comment>from VCS</comment>
-        </reference>
-      </externalReferences>
-      <properties>
-        <property name="cdx:poetry:group">main</property>
-        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
-        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
-      </properties>
-    </component>
     <component type="library" bom-ref="pathlib2@2.3.5">
       <name>pathlib2</name>
       <version>2.3.5</version>
@@ -63,6 +46,23 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pathlib2@2.3.5#1">
+      <name>pathlib2</name>
+      <version>2.3.5</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
       </properties>
     </component>
     <component type="library" bom-ref="pathlib2@2.3.6#2">

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.4.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.4.json.bin
@@ -1,35 +1,6 @@
 {
   "components": [
     {
-      "bom-ref": "pathlib2@2.3.5#1",
-      "description": "Object-oriented filesystem paths",
-      "externalReferences": [
-        {
-          "comment": "from VCS",
-          "type": "vcs",
-          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        }
-      ],
-      "name": "pathlib2",
-      "properties": [
-        {
-          "name": "cdx:poetry:group",
-          "value": "main"
-        },
-        {
-          "name": "cdx:python:package:source:vcs:commit_id",
-          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        },
-        {
-          "name": "cdx:python:package:source:vcs:requested_revision",
-          "value": "2.3.5"
-        }
-      ],
-      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
-      "type": "library",
-      "version": "2.3.5"
-    },
-    {
       "bom-ref": "pathlib2@2.3.5",
       "description": "Object-oriented filesystem paths",
       "externalReferences": [
@@ -64,6 +35,35 @@
         }
       ],
       "purl": "pkg:pypi/pathlib2@2.3.5",
+      "type": "library",
+      "version": "2.3.5"
+    },
+    {
+      "bom-ref": "pathlib2@2.3.5#1",
+      "description": "Object-oriented filesystem paths",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        }
+      ],
+      "name": "pathlib2",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
+          "value": "2.3.5"
+        }
+      ],
+      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
       "type": "library",
       "version": "2.3.5"
     },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.4.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.4.xml.bin
@@ -50,23 +50,6 @@
     </properties>
   </metadata>
   <components>
-    <component type="library" bom-ref="pathlib2@2.3.5#1">
-      <name>pathlib2</name>
-      <version>2.3.5</version>
-      <description>Object-oriented filesystem paths</description>
-      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
-          <comment>from VCS</comment>
-        </reference>
-      </externalReferences>
-      <properties>
-        <property name="cdx:poetry:group">main</property>
-        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
-        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
-      </properties>
-    </component>
     <component type="library" bom-ref="pathlib2@2.3.5">
       <name>pathlib2</name>
       <version>2.3.5</version>
@@ -90,6 +73,23 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pathlib2@2.3.5#1">
+      <name>pathlib2</name>
+      <version>2.3.5</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
       </properties>
     </component>
     <component type="library" bom-ref="pathlib2@2.3.6#2">

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.5.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.5.json.bin
@@ -1,35 +1,6 @@
 {
   "components": [
     {
-      "bom-ref": "pathlib2@2.3.5#1",
-      "description": "Object-oriented filesystem paths",
-      "externalReferences": [
-        {
-          "comment": "from VCS",
-          "type": "vcs",
-          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        }
-      ],
-      "name": "pathlib2",
-      "properties": [
-        {
-          "name": "cdx:poetry:group",
-          "value": "main"
-        },
-        {
-          "name": "cdx:python:package:source:vcs:commit_id",
-          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        },
-        {
-          "name": "cdx:python:package:source:vcs:requested_revision",
-          "value": "2.3.5"
-        }
-      ],
-      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
-      "type": "library",
-      "version": "2.3.5"
-    },
-    {
       "bom-ref": "pathlib2@2.3.5",
       "description": "Object-oriented filesystem paths",
       "externalReferences": [
@@ -64,6 +35,35 @@
         }
       ],
       "purl": "pkg:pypi/pathlib2@2.3.5",
+      "type": "library",
+      "version": "2.3.5"
+    },
+    {
+      "bom-ref": "pathlib2@2.3.5#1",
+      "description": "Object-oriented filesystem paths",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        }
+      ],
+      "name": "pathlib2",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
+          "value": "2.3.5"
+        }
+      ],
+      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
       "type": "library",
       "version": "2.3.5"
     },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.5.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.5.xml.bin
@@ -60,23 +60,6 @@
     </properties>
   </metadata>
   <components>
-    <component type="library" bom-ref="pathlib2@2.3.5#1">
-      <name>pathlib2</name>
-      <version>2.3.5</version>
-      <description>Object-oriented filesystem paths</description>
-      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
-          <comment>from VCS</comment>
-        </reference>
-      </externalReferences>
-      <properties>
-        <property name="cdx:poetry:group">main</property>
-        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
-        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
-      </properties>
-    </component>
     <component type="library" bom-ref="pathlib2@2.3.5">
       <name>pathlib2</name>
       <version>2.3.5</version>
@@ -100,6 +83,23 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pathlib2@2.3.5#1">
+      <name>pathlib2</name>
+      <version>2.3.5</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
       </properties>
     </component>
     <component type="library" bom-ref="pathlib2@2.3.6#2">

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.6.json.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.6.json.bin
@@ -1,35 +1,6 @@
 {
   "components": [
     {
-      "bom-ref": "pathlib2@2.3.5#1",
-      "description": "Object-oriented filesystem paths",
-      "externalReferences": [
-        {
-          "comment": "from VCS",
-          "type": "vcs",
-          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        }
-      ],
-      "name": "pathlib2",
-      "properties": [
-        {
-          "name": "cdx:poetry:group",
-          "value": "main"
-        },
-        {
-          "name": "cdx:python:package:source:vcs:commit_id",
-          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
-        },
-        {
-          "name": "cdx:python:package:source:vcs:requested_revision",
-          "value": "2.3.5"
-        }
-      ],
-      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
-      "type": "library",
-      "version": "2.3.5"
-    },
-    {
       "bom-ref": "pathlib2@2.3.5",
       "description": "Object-oriented filesystem paths",
       "externalReferences": [
@@ -64,6 +35,35 @@
         }
       ],
       "purl": "pkg:pypi/pathlib2@2.3.5",
+      "type": "library",
+      "version": "2.3.5"
+    },
+    {
+      "bom-ref": "pathlib2@2.3.5#1",
+      "description": "Object-oriented filesystem paths",
+      "externalReferences": [
+        {
+          "comment": "from VCS",
+          "type": "vcs",
+          "url": "git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        }
+      ],
+      "name": "pathlib2",
+      "properties": [
+        {
+          "name": "cdx:poetry:group",
+          "value": "main"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:commit_id",
+          "value": "5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6"
+        },
+        {
+          "name": "cdx:python:package:source:vcs:requested_revision",
+          "value": "2.3.5"
+        }
+      ],
+      "purl": "pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6",
       "type": "library",
       "version": "2.3.5"
     },

--- a/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.6.xml.bin
+++ b/tests/_data/snapshots/poetry/plain_multi-constraint-deps_lock21_1.6.xml.bin
@@ -60,23 +60,6 @@
     </properties>
   </metadata>
   <components>
-    <component type="library" bom-ref="pathlib2@2.3.5#1">
-      <name>pathlib2</name>
-      <version>2.3.5</version>
-      <description>Object-oriented filesystem paths</description>
-      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
-      <externalReferences>
-        <reference type="vcs">
-          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
-          <comment>from VCS</comment>
-        </reference>
-      </externalReferences>
-      <properties>
-        <property name="cdx:poetry:group">main</property>
-        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
-        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
-      </properties>
-    </component>
     <component type="library" bom-ref="pathlib2@2.3.5">
       <name>pathlib2</name>
       <version>2.3.5</version>
@@ -100,6 +83,23 @@
       </externalReferences>
       <properties>
         <property name="cdx:poetry:group">main</property>
+      </properties>
+    </component>
+    <component type="library" bom-ref="pathlib2@2.3.5#1">
+      <name>pathlib2</name>
+      <version>2.3.5</version>
+      <description>Object-oriented filesystem paths</description>
+      <purl>pkg:pypi/pathlib2@2.3.5?vcs_url=git%2Bhttps://github.com/jazzband/pathlib2.git%405a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>git+https://github.com/jazzband/pathlib2.git#5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</url>
+          <comment>from VCS</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="cdx:poetry:group">main</property>
+        <property name="cdx:python:package:source:vcs:commit_id">5a6a88db3cc1d08dbc86fbe15edfb69fb5f5a3d6</property>
+        <property name="cdx:python:package:source:vcs:requested_revision">2.3.5</property>
       </properties>
     </component>
     <component type="library" bom-ref="pathlib2@2.3.6#2">


### PR DESCRIPTION
`cyclonedx-python-lib` v9 was released.
the breaking changes do not cause any any friction in the usage here, so let's add support for it.