### PR TITLE
Continue with PEP639 gathering even when encountering encoding errors.

### DIFF
--- a/cyclonedx_py/_internal/utils/pep639.py
+++ b/cyclonedx_py/_internal/utils/pep639.py
@@ -57,9 +57,13 @@ def dist2licenses(
 
             # per spec > license files are stored in the `.dist-info/licenses/` subdirectory of the produced wheel.
             # but in practice, other locations are used, too.
-            content = dist.read_text(join('licenses', mlfile)) \
-                or dist.read_text(join('license_files', mlfile)) \
-                or dist.read_text(mlfile)
+            try:
+                content = dist.read_text(join('licenses', mlfile)) \
+                    or dist.read_text(join('license_files', mlfile)) \
+                    or dist.read_text(mlfile)
+            except UnicodeDecodeError:
+                content = None
+
             if content is None:  # pragma: no cover
                 logger.debug('Error: failed to read license file %r for dist %r',
                              mlfile, metadata['Name'])


### PR DESCRIPTION
When the license text gatherer in the PEP639 module picks the wrong file, that is not UTF-8 encoded, it blows up like this:

```
DEBUG    | CDX > Error: 'utf-8' codec can't decode byte 0xe4 in position 1412: invalid continuation byte
Traceback (most recent call last):
  File "C:\code\repos\cs.platform\sbom\Lib\site-packages\cyclonedx_py\_internal\cli.py", line 295, in run
    Command(**args, logger=logger)(**args)
  File "C:\code\repos\cs.platform\sbom\Lib\site-packages\cyclonedx_py\_internal\cli.py", line 257, in __call__
    bom = self._make_bom(**kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\code\repos\cs.platform\sbom\Lib\site-packages\cyclonedx_py\_internal\cli.py", line 252, in _make_bom
    return self._bbc(**self._clean_kwargs(kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\code\repos\cs.platform\sbom\Lib\site-packages\cyclonedx_py\_internal\environment.py", line 162, in __call__
    self.__add_components(bom, rc, path=path)
  File "C:\code\repos\cs.platform\sbom\Lib\site-packages\cyclonedx_py\_internal\environment.py", line 186, in __add_components
    pep639_licenses = list(dist2licenses_pep639(dist, self._gather_license_texts, self._logger))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\code\repos\cs.platform\sbom\Lib\site-packages\cyclonedx_py\_internal\utils\pep639.py", line 60, in dist2licenses
    content = dist.read_text(join('licenses', mlfile)) \
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\sdk\win32\tools\Python311\Lib\importlib\metadata\__init__.py", line 934, in read_text
    return self._path.joinpath(filename).read_text(encoding='utf-8')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\sdk\win32\tools\Python311\Lib\pathlib.py", line 1059, in read_text
    return f.read()
           ^^^^^^^^
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe4 in position 1412: invalid continuation byte
CRITICAL | CDX > 'utf-8' codec can't decode byte 0xe4 in position 1412: invalid continuation byte
```

Using:
Python 3.11
cyclonedx-bom                          5.3.0

In this case the code tried to read some misdeclared LicenseFile, that got auto detected and placed in the metadata by setuptools.

The wording in PEP639 is pretty strong about those files needing to be valid UTF-8 and tools should raising an error, if this is not valid. But i wonder if this reasoning is valid in the context of an SBOM, as obviously setuptools drops the ball and includes badly encoded files. At least a more explicit error message mentioning the affected file would be nice, if erroring out.