### PR TITLE
feat: Add mimetype detection for rich text format (rtf)

### DIFF
--- a/cyclonedx_py/_internal/utils/mimetypes.py
+++ b/cyclonedx_py/_internal/utils/mimetypes.py
@@ -29,12 +29,12 @@ _MAP_EXT_MIME = {
     '.md': 'text/markdown',
     '.txt': 'text/plain',
     '.rst': 'text/prs.fallenstein.rst',
+    '.rtf': 'application/rtf',
     '.xml': 'text/xml',  # not `application/xml` -- our scope is text!
     # license-specific files
     '.license': _MIME_TEXT_PLAIN,
     '.licence': _MIME_TEXT_PLAIN,
     # add more mime types. pull-requests welcome!
-    '.rtf': 'application/rtf',
 }
 
 _LICENSE_FNAME_BASE = ('licence', 'license')

--- a/cyclonedx_py/_internal/utils/mimetypes.py
+++ b/cyclonedx_py/_internal/utils/mimetypes.py
@@ -34,6 +34,7 @@ _MAP_EXT_MIME = {
     '.license': _MIME_TEXT_PLAIN,
     '.licence': _MIME_TEXT_PLAIN,
     # add more mime types. pull-requests welcome!
+    '.rtf': 'application/rtf',  # `text/rtf` could be used, but application fits better
 }
 
 _LICENSE_FNAME_BASE = ('licence', 'license')

--- a/cyclonedx_py/_internal/utils/mimetypes.py
+++ b/cyclonedx_py/_internal/utils/mimetypes.py
@@ -34,7 +34,7 @@ _MAP_EXT_MIME = {
     '.license': _MIME_TEXT_PLAIN,
     '.licence': _MIME_TEXT_PLAIN,
     # add more mime types. pull-requests welcome!
-    '.rtf': 'application/rtf',  # `text/rtf` could be used, but application fits better
+    '.rtf': 'application/rtf',
 }
 
 _LICENSE_FNAME_BASE = ('licence', 'license')


### PR DESCRIPTION
Add a mimetype for the Rich Text Format (RTF).

The format is 7-Bit ASCII safe, so automatically passes basic checks for UTF-8. But with all its custom tags and escape sequences it formally is closer to a binary format. 

So we use the application/rtf mimetype instead of the also possible text/rtf mimetype, as most consumers will consider this to be binary.

This overrides the misdetection by the stdlib, which claims RTF to be associated with application/msword. 