### PR TITLE
feat!: remove deprecated CLI switches `--schema-version` and `--outfile`, use `--spec-version` and `--output-file` instead

### DIFF
--- a/cyclonedx_py/_internal/cli.py
+++ b/cyclonedx_py/_internal/cli.py
@@ -68,13 +68,6 @@ class Command:
                         action='store_true',
                         dest='short_purls',
                         default=False)
-        op.add_argument('--schema-version',  # DEPRECATED
-                        metavar='<version>',
-                        help='DEPRECATED alias for option "--spec-version".',
-                        dest='spec_version',
-                        choices=SchemaVersion,
-                        type=SchemaVersion.from_version,
-                        default=SchemaVersion.V1_6.to_version())
         op.add_argument('--sv', '--spec-version',
                         metavar='<version>',
                         help='Which version of CycloneDX to use.'
@@ -99,12 +92,6 @@ class Command:
                         choices=OutputFormat,
                         type=argparse_type4enum(OutputFormat),
                         default=OutputFormat.JSON.name)
-        op.add_argument('--outfile',  # DEPRECATED
-                        metavar='<file>',
-                        help='DEPRECATED alias for "--output-file".',
-                        type=FileType('wt', encoding='utf8'),
-                        dest='output_file',
-                        default=OPTION_OUTPUT_STDOUT)
         op.add_argument('-o', '--output-file',
                         metavar='<file>',
                         help='Path to the output file.'

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -81,8 +81,6 @@ The full documentation can be issued by running with ``environment --help``:
                             (default: application)
       --short-PURLs         Omit all qualifiers from PackageURLs.
                             This causes information loss in trade-off shorter PURLs, which might improve ingesting these strings.
-      --schema-version <version>
-                            DEPRECATED alias for "--spec-version"
       --sv <version>, --spec-version <version>
                             Which version of CycloneDX to use.
                             {choices: 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0}
@@ -94,7 +92,6 @@ The full documentation can be issued by running with ``environment --help``:
                             Which output format to use.
                             {choices: JSON, XML}
                             (default: JSON)
-      --outfile <file>      DEPRECATED alias for "--output-file".
       -o <file>, --output-file <file>
                             Path to the output file.
                             (set to "-" to output to STDOUT)
@@ -255,8 +252,6 @@ The full documentation can be issued by running with ``pipenv --help``:
                             (default: application)
       --short-PURLs         Omit all qualifiers from PackageURLs.
                             This causes information loss in trade-off shorter PURLs, which might improve ingesting these strings.
-      --schema-version <version>
-                            DEPRECATED alias for "--spec-version"
       --sv <version>, --spec-version <version>
                             Which version of CycloneDX to use.
                             {choices: 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0}
@@ -268,7 +263,6 @@ The full documentation can be issued by running with ``pipenv --help``:
                             Which output format to use.
                             {choices: JSON, XML}
                             (default: JSON)
-      --outfile <file>      DEPRECATED alias for "--output-file".
       -o <file>, --output-file <file>
                             Path to the output file.
                             (set to "-" to output to STDOUT)
@@ -333,8 +327,6 @@ The full documentation can be issued by running with ``poetry --help``:
                             (default: application)
       --short-PURLs         Omit all qualifiers from PackageURLs.
                             This causes information loss in trade-off shorter PURLs, which might improve ingesting these strings.
-      --schema-version <version>
-                            DEPRECATED alias for "--spec-version"
       --sv <version>, --spec-version <version>
                             Which version of CycloneDX to use.
                             {choices: 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0}
@@ -346,7 +338,6 @@ The full documentation can be issued by running with ``poetry --help``:
                             Which output format to use.
                             {choices: JSON, XML}
                             (default: JSON)
-      --outfile <file>      DEPRECATED alias for "--output-file".
       -o <file>, --output-file <file>
                             Path to the output file.
                             (set to "-" to output to STDOUT)
@@ -407,8 +398,6 @@ The full documentation can be issued by running with ``requirements --help``:
                             (default: application)
       --short-PURLs         Omit all qualifiers from PackageURLs.
                             This causes information loss in trade-off shorter PURLs, which might improve ingesting these strings.
-      --schema-version <version>
-                            DEPRECATED alias for "--spec-version"
       --sv <version>, --spec-version <version>
                             Which version of CycloneDX to use.
                             {choices: 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0}
@@ -420,7 +409,6 @@ The full documentation can be issued by running with ``requirements --help``:
                             Which output format to use.
                             {choices: JSON, XML}
                             (default: JSON)
-      --outfile <file>      DEPRECATED alias for "--output-file".
       -o <file>, --output-file <file>
                             Path to the output file.
                             (set to "-" to output to STDOUT)


### PR DESCRIPTION
Closes #873.