### PR TITLE
feat: rootless docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ ARG VERSION
 ARG CDX_PATH=/opt/cyclonedx-py
 ARG CDX_VENV=${CDX_PATH}/venv
 
+RUN addgroup --system --gid 1000 cyclonedx \
+    && adduser --system --shell /bin/bash --uid 1000 --ingroup cyclonedx cyclonedx
+
 RUN mkdir -p "${CDX_PATH}"
 RUN python -m venv --without-pip "${CDX_VENV}"
 ENV VIRTUAL_ENV=${CDX_VENV}
@@ -19,4 +22,5 @@ RUN pip --python "${CDX_VENV}" \
    "cyclonedx-bom==${VERSION}" --find-links "file://${CDX_PATH}/dist"
 RUN rm -rf ${CDX_PATH}/dist
 
+USER cyclonedx
 ENTRYPOINT ["cyclonedx-py"]


### PR DESCRIPTION
As per [OWASP's Docker Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html), it is recommended to set a user instead of running the container as root.

```bash
virgo@lenovo:~$ docker ps -a
CONTAINER ID   IMAGE                 COMMAND       CREATED              STATUS              PORTS     NAMES
ee568549229f   cyclonedx-py:latest   "/bin/bash"   About a minute ago   Up About a minute             nifty_swirles
virgo@lenovo:~$ docker exec -it ee568549229f sh -c "id"
uid=1000(cyclonedx) gid=1000(cyclonedx) groups=1000(cyclonedx)
```

:arrow_up: Now the container is running as a standard user.