### PR TITLE
feat: apply PyPI heuristics to project-URL classification (#800)

### DIFF
--- a/cyclonedx_py/_internal/utils/cdx.py
+++ b/cyclonedx_py/_internal/utils/cdx.py
@@ -35,6 +35,7 @@ from cyclonedx.model.component import (  # type:ignore[attr-defined]  # Componen
 from cyclonedx.model.license import DisjunctiveLicense, License, LicenseAcknowledgement, LicenseExpression
 
 from ... import __version__ as _THIS_VERSION  # noqa:N812
+from .url_classifiers import _MAP_KNOWN_URL_LABELS, _MAP_URL_LABEL_PREFIXES
 
 
 def make_bom(**kwargs: Any) -> Bom:
@@ -119,32 +120,17 @@ def licenses_fixup(component: 'Component') -> None:
         component.evidence.licenses.update(licenses)
 
 
-_MAP_KNOWN_URL_LABELS: dict[str, ExternalReferenceType] = {
-    # see https://peps.python.org/pep-0345/#project-url-multiple-use
-    # see https://github.com/pypi/warehouse/issues/5947#issuecomment-699660629
-    'bugtracker': ExternalReferenceType.ISSUE_TRACKER,
-    'issuetracker': ExternalReferenceType.ISSUE_TRACKER,
-    'issues': ExternalReferenceType.ISSUE_TRACKER,
-    'bugreports': ExternalReferenceType.ISSUE_TRACKER,
-    'tracker': ExternalReferenceType.ISSUE_TRACKER,
-    'home': ExternalReferenceType.WEBSITE,
-    'homepage': ExternalReferenceType.WEBSITE,
-    'download': ExternalReferenceType.DISTRIBUTION,
-    'documentation': ExternalReferenceType.DOCUMENTATION,
-    'docs': ExternalReferenceType.DOCUMENTATION,
-    'changelog': ExternalReferenceType.RELEASE_NOTES,
-    'changes': ExternalReferenceType.RELEASE_NOTES,
-    # 'source': ExternalReferenceType.SOURCE-DISTRIBUTION,
-    'repository': ExternalReferenceType.VCS,
-    'github': ExternalReferenceType.VCS,
-    'chat': ExternalReferenceType.CHAT,
-}
-
 _NOCHAR_MATCHER = re_compile('[^a-z]')
 
 
-def url_label_to_ert(value: str) -> ExternalReferenceType:
-    return _MAP_KNOWN_URL_LABELS.get(
-        _NOCHAR_MATCHER.sub('', str(value).lower()),
-        ExternalReferenceType.OTHER
-    )
+def url_label_to_ert(label: str, url: Optional[str] = None) -> ExternalReferenceType:
+    norm = _NOCHAR_MATCHER.sub('', str(label).lower())
+    # 1. exact label
+    ert = _MAP_KNOWN_URL_LABELS.get(norm)
+    if ert is not None:
+        return ert
+    # 2. label prefix
+    for prefix, pert in _MAP_URL_LABEL_PREFIXES:
+        if norm.startswith(prefix):
+            return pert
+    return ExternalReferenceType.OTHER

--- a/cyclonedx_py/_internal/utils/url_classifiers.py
+++ b/cyclonedx_py/_internal/utils/url_classifiers.py
@@ -1,0 +1,76 @@
+# This file is part of CycloneDX Python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+
+
+"""
+Pure mapping data for URL -> ExternalReferenceType classification.
+
+This module is DATA ONLY -- no logic. To extend classification, add rows here.
+Four match styles, applied by ``cdx.url_label_to_ert`` in this precedence order:
+
+1. _MAP_KNOWN_URL_LABELS        exact label (normalized: lowercased, non-[a-z] stripped)
+2. _MAP_URL_LABEL_PREFIXES      label prefix (PyPI '*' semantics); first match wins
+3. _MAP_KNOWN_URL_HOST_SUFFIXES host == key OR host endswith '.'+key (domain + subdomains)
+4. _MAP_KNOWN_URL_HOST_PREFIXES host == key OR host startswith key+'.' (e.g. docs.*)
+
+Label keys MUST already be normalized (lowercase, only [a-z]).
+Host keys MUST be lowercase.
+
+see https://docs.pypi.org/project_metadata/#icons
+"""
+
+from cyclonedx.model import ExternalReferenceType
+
+# 1. exact label -> ERT
+_MAP_KNOWN_URL_LABELS: dict[str, ExternalReferenceType] = {
+    # see https://peps.python.org/pep-0345/#project-url-multiple-use
+    # see https://github.com/pypi/warehouse/issues/5947#issuecomment-699660629
+    'bugtracker': ExternalReferenceType.ISSUE_TRACKER,
+    'issuetracker': ExternalReferenceType.ISSUE_TRACKER,
+    'issues': ExternalReferenceType.ISSUE_TRACKER,
+    'bugreports': ExternalReferenceType.ISSUE_TRACKER,
+    'tracker': ExternalReferenceType.ISSUE_TRACKER,
+    'home': ExternalReferenceType.WEBSITE,
+    'homepage': ExternalReferenceType.WEBSITE,
+    'download': ExternalReferenceType.DISTRIBUTION,
+    'documentation': ExternalReferenceType.DOCUMENTATION,
+    'docs': ExternalReferenceType.DOCUMENTATION,
+    'changelog': ExternalReferenceType.RELEASE_NOTES,
+    'changes': ExternalReferenceType.RELEASE_NOTES,
+    'releasenotes': ExternalReferenceType.RELEASE_NOTES,
+    'news': ExternalReferenceType.RELEASE_NOTES,
+    'whatsnew': ExternalReferenceType.RELEASE_NOTES,
+    'history': ExternalReferenceType.RELEASE_NOTES,
+    'repository': ExternalReferenceType.VCS,
+    'source': ExternalReferenceType.VCS,
+    'github': ExternalReferenceType.VCS,
+    'chat': ExternalReferenceType.CHAT,
+}
+
+# 2. label prefix -> ERT (ordered; first match wins). normalized prefixes.
+_MAP_URL_LABEL_PREFIXES: tuple[tuple[str, ExternalReferenceType], ...] = (
+    ('documentation', ExternalReferenceType.DOCUMENTATION),
+    ('docs', ExternalReferenceType.DOCUMENTATION),
+    ('bug', ExternalReferenceType.ISSUE_TRACKER),
+    ('issue', ExternalReferenceType.ISSUE_TRACKER),
+    ('tracker', ExternalReferenceType.ISSUE_TRACKER),
+    ('report', ExternalReferenceType.ISSUE_TRACKER),
+    ('funding', ExternalReferenceType.OTHER),
+    ('sponsor', ExternalReferenceType.OTHER),
+    ('donation', ExternalReferenceType.OTHER),
+    ('donate', ExternalReferenceType.OTHER),
+)

--- a/tests/unit/test_utils_cdx.py
+++ b/tests/unit/test_utils_cdx.py
@@ -23,8 +23,9 @@ from unittest import TestCase
 from cyclonedx.model import ExternalReference, ExternalReferenceType
 from cyclonedx.model.component import Component, ComponentType
 from cyclonedx.model.license import License, LicenseAcknowledgement
+from ddt import data, ddt, unpack
 
-from cyclonedx_py._internal.utils.cdx import make_bom
+from cyclonedx_py._internal.utils.cdx import make_bom, url_label_to_ert
 from tests import EXPECTED_TOOL_NAME, load_pyproject
 
 
@@ -79,3 +80,41 @@ class TestThisComponentInMetadataTools(TestCase, ExtRefsTestMixin):
         c = self.__get_c_by_name(EXPECTED_TOOL_NAME)
         ers: tuple[ExternalReference, ...] = tuple(c.external_references)
         self.assertExtRefs(p, ers)
+
+
+@ddt
+class TestUrlLabelToErt(TestCase):
+
+    @data(
+        # exact labels (existing behaviour preserved)
+        ('Homepage', ExternalReferenceType.WEBSITE),
+        ('Home', ExternalReferenceType.WEBSITE),
+        ('Download', ExternalReferenceType.DISTRIBUTION),
+        ('Changelog', ExternalReferenceType.RELEASE_NOTES),
+        ('Change log', ExternalReferenceType.RELEASE_NOTES),
+        ('Release notes', ExternalReferenceType.RELEASE_NOTES),
+        ("What's new", ExternalReferenceType.RELEASE_NOTES),
+        ('History', ExternalReferenceType.RELEASE_NOTES),
+        ('Repository', ExternalReferenceType.VCS),
+        ('Source', ExternalReferenceType.VCS),
+        ('Chat', ExternalReferenceType.CHAT),
+        # prefix labels (PyPI '*' semantics)
+        ('Documentation', ExternalReferenceType.DOCUMENTATION),
+        ('Documentation for users', ExternalReferenceType.DOCUMENTATION),
+        ('Docs (latest)', ExternalReferenceType.DOCUMENTATION),
+        ('Bug Reports', ExternalReferenceType.ISSUE_TRACKER),
+        ('Issue Tracker', ExternalReferenceType.ISSUE_TRACKER),
+        ('Tracker', ExternalReferenceType.ISSUE_TRACKER),
+        ('Report a bug', ExternalReferenceType.ISSUE_TRACKER),
+        ('Funding', ExternalReferenceType.OTHER),
+        ('Sponsor this project', ExternalReferenceType.OTHER),
+        ('Donate', ExternalReferenceType.OTHER),
+        # unknown -> OTHER
+        ('Some Random Label', ExternalReferenceType.OTHER),
+    )
+    @unpack
+    def test_label_only(self, label: str, expected: ExternalReferenceType) -> None:
+        self.assertIs(expected, url_label_to_ert(label))
+
+    def test_label_only_url_none_backcompat(self) -> None:
+        self.assertIs(ExternalReferenceType.WEBSITE, url_label_to_ert('Homepage', None))


### PR DESCRIPTION
### Description

**This is a draft / work-in-progress** opened early (as requested in the issue) to get feedback on the approach before completing it.

This extends how project URLs are classified into CycloneDX external-reference types, adopting PyPI's documented heuristics (<https://docs.pypi.org/project_metadata/#icons>). Today classification uses **only the URL label** against an exact-match dict in `cyclonedx_py/_internal/utils/cdx.py`. This PR moves toward classifying by both **label** (exact + prefix) and **URL host** (domain/subdomain), so emitted external references follow the de-facto standard.

#### Design (agreed in the issue thread)

- **Precedence (label-first):** exact label → label prefix (PyPI `*` semantics) → host suffix → host subdomain-prefix → `OTHER`. The label is the author's explicit intent; the host fills gaps. E.g. a `Funding` label on a `github.com` URL stays `OTHER`, it does not become `VCS`.
- **Data/logic separation:** all mapping rules live in a new **data-only** module `cyclonedx_py/_internal/utils/url_classifiers.py` (four declarative tables). The matcher in `cdx.py` is pure logic and never changes when rules are added — extending classification is a one-line data edit.
- **Mapping judgment calls** (CycloneDX's enum is narrower than PyPI's icon set):
  - Funding / Sponsor / Donation / Donate → `OTHER` (no CycloneDX funding type; `OTHER` is more honest than forcing `WEBSITE`).
  - Chat vs Social split (refines PyPI's flat "social" bucket): Discord/Slack/Gitter → `CHAT`; Reddit/YouTube/Twitter-X/Mastodon/Bluesky → `SOCIAL`.
  - CI services (AppVeyor/CircleCI/Codecov/Coveralls/Travis) → `BUILD_SYSTEM`.
  - `google.com` left unmapped (too ambiguous) → falls through to `OTHER`.

#### Status / checklist

- [x] **Task 1 — label classification (this commit):** data-only module + exact & prefix label matching; `url_label_to_ert(label, url=None)` gains an optional `url` arg (unused until Task 2, keeps back-compat). New table-driven unit tests; `flake8`/`isort`/`mypy` clean.
- [ ] **Task 2 — host classification:** host-suffix + subdomain-prefix tables, label-first precedence in the matcher, unit tests.
- [ ] **Task 3 — wiring:** pass the URL through the three callers (`poetry.py`, `pep621.py`, `packaging.py`) and reconcile snapshots.

Feedback on the mapping table and the `OTHER`-for-funding choice is especially welcome before I finish Tasks 2–3.

Resolves or fixes issue: #800

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `Claude Code`
  - LLMs and versions: `Claude Opus 4.8`
  - Prompts: `Find a good-first-issue, then design and implement #800: apply PyPI's project-URL classification heuristics (label + host based) to CycloneDX external-reference type detection. Constraints I directed: full port of PyPI heuristics mapped to the nearest CycloneDX type; label-first precedence; keep the mapping expandable and kept in a data module separate from the matching logic. TDD with table-driven unit tests.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX/cyclonedx-python/blob/main/CONTRIBUTING.md) guidelines
