### PR TITLE
fix: improve error message for non-PEP 621 pyproject.toml

### DIFF
--- a/cyclonedx_py/_internal/utils/pyproject.py
+++ b/cyclonedx_py/_internal/utils/pyproject.py
@@ -64,7 +64,7 @@ def pyproject2component(data: dict[str, Any], *,
         licenses_fixup(component)
         # endregion licenses
         return component
-    raise ValueError('Unable to build component from pyproject')
+    raise ValueError('Unable to build component from pyproject: pyproject.toml is not PEP 621-compliant')
 
 
 def pyproject_load(pyproject_file: str) -> dict[str, Any]:


### PR DESCRIPTION


### Description

improved error message when pyproject is malformed or invalid 

Resolves or fixes issue: #1079

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX/cyclonedx-python/blob/main/CONTRIBUTING.md) guidelines
